### PR TITLE
feat(advanced-bodymap): first-party SVG art on workout-plan Advanced …

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -74,3 +74,6 @@ build/
 # Claude Code personal overrides
 .claude/settings.local.json
 .claude/scheduled_tasks.lock
+
+# Body-map scratch / reference output
+static/bodymaps/GPT/

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -2,6 +2,15 @@
 
 All notable changes to Hypertrophy Toolbox v3.
 
+## Unreleased - May 2, 2026
+
+### Muscle Selector — First-Party Advanced Body Map
+
+- Replaced the workout-plan Advanced-mode SVG source with original first-party body maps under `static/bodymaps/hypertrophy-advanced/`. Simple-mode (workout.cool) art is unchanged.
+- Advanced map regions now target sub-muscles directly via `data-canonical-muscles`, so clicking the SVG can select one child such as `upper-chest`, `rhomboids`, or `erector-spinae` without selecting the whole parent group.
+- Updated selector hover matching so parent legend rows highlight all covered child regions in the first-party advanced SVGs.
+- `static/vendor/react-body-highlighter/` is **retained** — `static/js/modules/bodymap-svg.js` still uses it for the `/user_profile` coverage bodymap. Swapping that surface to first-party art is deferred to a future PR.
+
 ## Unreleased - April 24, 2026
 
 ### UI / Redesign

--- a/docs/muscle_selector.md
+++ b/docs/muscle_selector.md
@@ -21,8 +21,8 @@ Interactive SVG body diagram component for selecting target muscle groups in the
 | [static/css/pages-workout-plan.css](../static/css/pages-workout-plan.css) | Bundled styling for the component |
 | [static/vendor/workout-cool/body_anterior.svg](../static/vendor/workout-cool/body_anterior.svg) | Front view, **Simple** mode (workout-cool art) |
 | [static/vendor/workout-cool/body_posterior.svg](../static/vendor/workout-cool/body_posterior.svg) | Back view, **Simple** mode (workout-cool art) |
-| [static/vendor/react-body-highlighter/body_anterior.svg](../static/vendor/react-body-highlighter/body_anterior.svg) | Front view, **Advanced** mode |
-| [static/vendor/react-body-highlighter/body_posterior.svg](../static/vendor/react-body-highlighter/body_posterior.svg) | Back view, **Advanced** mode |
+| [static/bodymaps/hypertrophy-advanced/body_anterior.svg](../static/bodymaps/hypertrophy-advanced/body_anterior.svg) | Front view, **Advanced** mode |
+| [static/bodymaps/hypertrophy-advanced/body_posterior.svg](../static/bodymaps/hypertrophy-advanced/body_posterior.svg) | Back view, **Advanced** mode |
 | [scripts/build_workout_cool_svgs.py](../scripts/build_workout_cool_svgs.py) | Builds the workout-cool SVGs from upstream TSX at the pinned SHA |
 | [templates/workout_plan.html](../templates/workout_plan.html) | Integration in Generate Plan modal |
 | [static/js/app.js](../static/js/app.js) | API integration (generateStarterPlan function) |
@@ -41,10 +41,12 @@ Simple mode and Advanced mode load different SVG art:
   `BACK` region is intentionally multi-key
   (`lats,upper-back,lowerback`) because workout-cool's art does not
   separate those three.
-- **Advanced mode** stays on react-body-highlighter, whose regions
-  carry vendor `data-muscle="<slug>"` attributes that
-  `mapVendorSlugsToCanonical()` translates at SVG-load time into
-  `data-canonical-muscle` (singular).
+- **Advanced mode** uses first-party schematic art under
+  `static/bodymaps/hypertrophy-advanced/`. These files are already keyed
+  to advanced sub-muscles (`upper-chest`, `rhomboids`,
+  `erector-spinae`, etc.) with `data-canonical-muscles`, so clicking the
+  map can select individual children instead of only broad parent
+  regions.
 
 `SVG_PATHS[mode][side]` and `getSvgPathForMode(mode, side)` resolve the
 right URL; `switchViewMode()` triggers a full SVG reload (not just a

--- a/docs/muscle_selector_vendor.md
+++ b/docs/muscle_selector_vendor.md
@@ -1,10 +1,12 @@
 # Muscle Selector Vendor Integration
 
-The MuscleSelector component sources SVG art from **two** vendor projects.
-Simple mode uses workout-cool; Advanced mode keeps react-body-highlighter.
+The MuscleSelector component sources Simple-mode SVG art from workout-cool.
+Advanced mode uses first-party Hypertrophy Toolbox SVGs under
+`static/bodymaps/hypertrophy-advanced/`. The legacy react-body-highlighter
+assets remain vendored for the Profile coverage body map.
 See [muscle_selector.md](muscle_selector.md) for the runtime split.
 
-## Source Attribution — Advanced mode (react-body-highlighter)
+## Source Attribution — Profile coverage map (react-body-highlighter)
 
 - **Package**: `react-body-highlighter` v2.0.5 (npm)
 - **Repository**: https://github.com/giavinh79/react-body-highlighter
@@ -64,8 +66,7 @@ ships `data-canonical-muscles="<key>[,<key2>,...]"` directly, with our
 canonical keys baked in at build time per the
 `ENUM_SIDE_TO_CANONICAL` table in the build script (mirrors PLANNING.md
 §3.3). So the runtime `VENDOR_SLUG_TO_CANONICAL` table is **not used**
-for this variant — it stays in place only for the legacy
-react-body-highlighter SVGs that Advanced mode loads.
+for this variant.
 
 The only multi-key region today is the posterior `BACK`
 (`data-canonical-muscles="lats,upper-back,lowerback"`), because
@@ -203,9 +204,10 @@ Highlights entire muscle groups. The SVG shows the full region.
 
 ### Advanced Mode
 
-Allows selection of the same muscle groups (vendor SVGs don't have sub-regions), but prepares the system for future detailed SVGs. The legend shows more specific options when available.
-
-**Note:** The vendor SVGs don't include sub-muscle regions. In Advanced mode, clicking a muscle still selects the entire group, but the UI indicates advanced mode is active.
+Uses first-party SVGs with direct sub-muscle regions. The legend and the map
+both operate on the same advanced keys, so clicking a path such as
+`upper-chest`, `rhomboids`, or `erector-spinae` selects that child without
+forcing the entire parent group.
 
 ## Bilateral Synchronization
 

--- a/e2e/workout-plan.spec.ts
+++ b/e2e/workout-plan.spec.ts
@@ -612,8 +612,8 @@ test.describe('Plan Generator v1.5.0 Features', () => {
 // Muscle selector — workout-cool body map (PLANNING.md §3)
 //
 // Simple mode loads workout-cool's anatomy art (multi-key BACK region);
-// Advanced mode keeps react-body-highlighter. Switching modes must reload
-// the SVG variant and preserve `selectedMuscles` across the swap.
+// Advanced mode loads first-party sub-muscle SVGs. Switching modes must
+// reload the SVG variant and preserve `selectedMuscles` across the swap.
 // ============================================================================
 
 test.describe('Muscle selector body-map variants', () => {
@@ -634,7 +634,7 @@ test.describe('Muscle selector body-map variants', () => {
     consoleErrors.assertNoErrors();
   });
 
-  test('Simple mode loads workout-cool art; Advanced reloads react-body-highlighter; selection survives swap', async ({ page }) => {
+  test('Simple mode loads workout-cool art; Advanced reloads first-party sub-muscle art; selection survives swap', async ({ page }) => {
     const svg = page.locator('#muscle-selector-container #svg-container svg');
 
     // Default mode is simple. Workout-cool art ships with id="body-anterior-workoutcool".
@@ -649,7 +649,7 @@ test.describe('Muscle selector body-map variants', () => {
 
     // Switch to advanced — must trigger an SVG variant reload, not just a legend re-render.
     await page.locator('#muscle-selector-container [data-view="advanced"]').click();
-    await expect(svg).toHaveAttribute('id', /body-anterior(?!-workoutcool)/);
+    await expect(svg).toHaveAttribute('id', /body-anterior-hypertrophy-advanced/);
 
     // Selection state preserved (advanced legend renders one row per child of chest).
     for (const child of ['upper-chest', 'mid-chest', 'lower-chest']) {
@@ -725,5 +725,30 @@ test.describe('Muscle selector body-map variants', () => {
       .first();
     await expect(backRegion).toHaveClass(/partial/);
     await expect(backRegion).not.toHaveClass(/selected(?!\.partial)/);
+  });
+
+  test('Advanced map region selects a single sub-muscle without selecting siblings', async ({ page }) => {
+    await page.locator('#muscle-selector-container [data-view="advanced"]').click();
+    await expect(
+      page.locator('#muscle-selector-container #svg-container svg')
+    ).toHaveAttribute('id', /body-anterior-hypertrophy-advanced/);
+
+    await page
+      .locator('#muscle-selector-container svg [data-canonical-muscles="upper-chest"]')
+      .first()
+      .click();
+
+    await expect(
+      page.locator('#muscle-selector-container .legend-item[data-muscle="upper-chest"] .legend-checkbox.checked')
+    ).toBeVisible();
+    await expect(
+      page.locator('#muscle-selector-container .legend-item[data-muscle="mid-chest"] .legend-checkbox.checked')
+    ).toHaveCount(0);
+    await expect(
+      page.locator('#muscle-selector-container .legend-item[data-muscle="lower-chest"] .legend-checkbox.checked')
+    ).toHaveCount(0);
+    await expect(
+      page.locator('#muscle-selector-container .legend-group-header[data-parent="chest"] .legend-checkbox.partial')
+    ).toBeVisible();
   });
 });

--- a/static/bodymaps/hypertrophy-advanced/README.md
+++ b/static/bodymaps/hypertrophy-advanced/README.md
@@ -1,0 +1,10 @@
+# Hypertrophy Toolbox Advanced Body Map
+
+These SVGs are first-party schematic assets for the workout-plan muscle selector.
+They are not derived from MuscleWiki artwork, screenshots, API media, or traced
+images. The shapes are deliberately simplified and use the application's
+canonical muscle keys in `data-canonical-muscles` attributes so advanced mode can
+select individual sub-muscles directly from the map.
+
+Simple mode continues to use the separately licensed workout-cool assets under
+`static/vendor/workout-cool/`.

--- a/static/bodymaps/hypertrophy-advanced/body_anterior.svg
+++ b/static/bodymaps/hypertrophy-advanced/body_anterior.svg
@@ -1,0 +1,98 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  Hypertrophy Toolbox Advanced Body Map - Anterior
+  Original schematic SVG, created for this project. Not derived from MuscleWiki.
+-->
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 140 320" id="body-anterior-hypertrophy-advanced" role="img" aria-label="Advanced anterior muscle map">
+  <defs>
+    <style>
+      .body-shell {
+        fill: #f6f7f9;
+        stroke: #444861;
+        stroke-width: 1.35;
+        stroke-linejoin: round;
+        pointer-events: none;
+      }
+      .body-line {
+        fill: none;
+        stroke: #444861;
+        stroke-width: 1;
+        stroke-linecap: round;
+        pointer-events: none;
+      }
+      .muscle-region {
+        fill: rgba(52, 152, 219, 0.18);
+        stroke: rgba(52, 152, 219, 0.45);
+        stroke-width: 0.55;
+        cursor: pointer;
+        transition: fill 0.15s ease, stroke 0.15s ease;
+      }
+    </style>
+  </defs>
+
+  <g class="body-outline" aria-hidden="true">
+    <path class="body-shell" d="M70 6 C82 7 91 16 91 29 C91 40 84 48 77 51 L77 60 C86 65 98 68 107 76 C116 85 119 100 121 113 C126 121 132 139 137 154 C139 163 136 172 130 176 C127 181 126 191 124 205 C122 220 120 239 116 257 C116 270 118 286 119 319 L94 319 C92 292 89 273 86 260 C84 249 81 237 78 225 C75 232 72 237 70 239 C68 237 65 232 62 225 C59 237 56 249 54 260 C51 273 48 292 46 319 L21 319 C22 286 24 270 24 257 C20 239 18 220 16 205 C14 191 13 181 10 176 C4 172 1 163 3 154 C8 139 14 121 19 113 C21 100 24 85 33 76 C42 68 54 65 63 60 L63 51 C56 48 49 40 49 29 C49 16 58 7 70 6 Z"/>
+    <path class="body-line" d="M58 39 C62 45 66 48 70 49 C74 48 78 45 82 39"/>
+    <path class="body-line" d="M63 60 C66 64 74 64 77 60"/>
+    <path class="body-line" d="M50 72 C59 68 81 68 90 72"/>
+    <path class="body-line" d="M70 102 L70 184"/>
+    <path class="body-line" d="M56 184 C60 194 64 205 70 213 C76 205 80 194 84 184"/>
+  </g>
+
+  <g id="anterior-regions">
+    <path class="muscle-region" data-canonical-muscles="neck" d="M61 45 C65 50 75 50 79 45 L78 62 C74 66 66 66 62 62 Z"/>
+
+    <path class="muscle-region" data-canonical-muscles="anterior-deltoid" d="M49 69 C41 71 34 77 30 87 C35 89 43 88 50 81 C53 77 55 72 55 68 Z"/>
+    <path class="muscle-region" data-canonical-muscles="anterior-deltoid" d="M91 69 C99 71 106 77 110 87 C105 89 97 88 90 81 C87 77 85 72 85 68 Z"/>
+    <path class="muscle-region" data-canonical-muscles="lateral-deltoid" d="M30 87 C27 94 26 103 28 110 C35 111 42 105 45 96 C47 90 47 84 45 80 C39 86 34 88 30 87 Z"/>
+    <path class="muscle-region" data-canonical-muscles="lateral-deltoid" d="M110 87 C113 94 114 103 112 110 C105 111 98 105 95 96 C93 90 93 84 95 80 C101 86 106 88 110 87 Z"/>
+
+    <path class="muscle-region" data-canonical-muscles="upper-chest" d="M55 70 C62 68 67 69 69 73 L69 92 C62 92 56 89 52 84 C49 80 49 74 55 70 Z"/>
+    <path class="muscle-region" data-canonical-muscles="upper-chest" d="M85 70 C78 68 73 69 71 73 L71 92 C78 92 84 89 88 84 C91 80 91 74 85 70 Z"/>
+    <path class="muscle-region" data-canonical-muscles="mid-chest" d="M51 84 C56 92 62 96 69 96 L69 111 C61 112 53 108 49 101 C47 95 47 89 51 84 Z"/>
+    <path class="muscle-region" data-canonical-muscles="mid-chest" d="M89 84 C84 92 78 96 71 96 L71 111 C79 112 87 108 91 101 C93 95 93 89 89 84 Z"/>
+    <path class="muscle-region" data-canonical-muscles="lower-chest" d="M49 101 C54 111 61 116 69 116 L69 126 C61 124 55 121 50 116 C47 112 46 106 49 101 Z"/>
+    <path class="muscle-region" data-canonical-muscles="lower-chest" d="M91 101 C86 111 79 116 71 116 L71 126 C79 124 85 121 90 116 C93 112 94 106 91 101 Z"/>
+
+    <path class="muscle-region" data-canonical-muscles="long-head-bicep" d="M28 111 C25 119 23 130 23 142 C27 144 32 140 35 132 C37 124 37 116 34 111 Z"/>
+    <path class="muscle-region" data-canonical-muscles="short-head-bicep" d="M35 111 C38 117 38 125 36 133 C40 130 43 123 44 116 C42 112 38 110 35 111 Z"/>
+    <path class="muscle-region" data-canonical-muscles="long-head-bicep" d="M112 111 C115 119 117 130 117 142 C113 144 108 140 105 132 C103 124 103 116 106 111 Z"/>
+    <path class="muscle-region" data-canonical-muscles="short-head-bicep" d="M105 111 C102 117 102 125 104 133 C100 130 97 123 96 116 C98 112 102 110 105 111 Z"/>
+    <path class="muscle-region" data-canonical-muscles="lateral-head-triceps" d="M22 114 C18 122 14 134 11 146 C14 148 18 145 22 139 C22 130 24 120 27 112 Z"/>
+    <path class="muscle-region" data-canonical-muscles="lateral-head-triceps" d="M118 114 C122 122 126 134 129 146 C126 148 122 145 118 139 C118 130 116 120 113 112 Z"/>
+    <path class="muscle-region" data-canonical-muscles="long-head-triceps" d="M27 143 C31 145 35 143 38 138 C39 148 37 156 33 162 C28 160 25 153 27 143 Z"/>
+    <path class="muscle-region" data-canonical-muscles="long-head-triceps" d="M113 143 C109 145 105 143 102 138 C101 148 103 156 107 162 C112 160 115 153 113 143 Z"/>
+    <path class="muscle-region" data-canonical-muscles="medial-head-triceps" d="M23 142 C25 148 26 156 25 164 C21 163 18 157 18 150 C19 146 20 144 23 142 Z"/>
+    <path class="muscle-region" data-canonical-muscles="medial-head-triceps" d="M117 142 C115 148 114 156 115 164 C119 163 122 157 122 150 C121 146 120 144 117 142 Z"/>
+
+    <path class="muscle-region" data-canonical-muscles="brachioradialis" d="M17 151 C22 153 26 160 28 170 C26 177 21 181 16 178 C14 169 14 158 17 151 Z"/>
+    <path class="muscle-region" data-canonical-muscles="wrist-flexors" d="M28 165 C31 174 31 185 28 196 C24 194 22 186 23 177 C24 171 26 167 28 165 Z"/>
+    <path class="muscle-region" data-canonical-muscles="wrist-extensors" d="M15 178 C20 181 23 189 22 199 C18 201 14 197 12 189 C12 184 13 181 15 178 Z"/>
+    <path class="muscle-region" data-canonical-muscles="brachioradialis" d="M123 151 C118 153 114 160 112 170 C114 177 119 181 124 178 C126 169 126 158 123 151 Z"/>
+    <path class="muscle-region" data-canonical-muscles="wrist-flexors" d="M112 165 C109 174 109 185 112 196 C116 194 118 186 117 177 C116 171 114 167 112 165 Z"/>
+    <path class="muscle-region" data-canonical-muscles="wrist-extensors" d="M125 178 C120 181 117 189 118 199 C122 201 126 197 128 189 C128 184 127 181 125 178 Z"/>
+
+    <path class="muscle-region" data-canonical-muscles="upper-abs" d="M61 121 C65 123 75 123 79 121 C81 130 80 139 76 145 L64 145 C60 139 59 130 61 121 Z"/>
+    <path class="muscle-region" data-canonical-muscles="lower-abs" d="M64 145 L76 145 C80 156 79 169 70 182 C61 169 60 156 64 145 Z"/>
+    <path class="muscle-region" data-canonical-muscles="obliques" d="M50 119 C55 128 58 142 59 158 C56 168 52 174 47 177 C44 160 44 137 50 119 Z"/>
+    <path class="muscle-region" data-canonical-muscles="obliques" d="M90 119 C85 128 82 142 81 158 C84 168 88 174 93 177 C96 160 96 137 90 119 Z"/>
+
+    <path class="muscle-region" data-canonical-muscles="adductors" d="M57 185 C62 190 66 201 67 215 C65 228 61 241 57 250 C53 235 52 209 57 185 Z"/>
+    <path class="muscle-region" data-canonical-muscles="adductors" d="M83 185 C78 190 74 201 73 215 C75 228 79 241 83 250 C87 235 88 209 83 185 Z"/>
+    <path class="muscle-region" data-canonical-muscles="rectus-femoris" d="M42 184 C49 190 53 206 54 226 C52 241 48 251 43 256 C38 241 37 202 42 184 Z"/>
+    <path class="muscle-region" data-canonical-muscles="rectus-femoris" d="M98 184 C91 190 87 206 86 226 C88 241 92 251 97 256 C102 241 103 202 98 184 Z"/>
+    <path class="muscle-region" data-canonical-muscles="vastus-lateralis" d="M31 184 C39 190 41 212 40 235 C38 246 35 254 31 257 C26 238 26 202 31 184 Z"/>
+    <path class="muscle-region" data-canonical-muscles="vastus-lateralis" d="M109 184 C101 190 99 212 100 235 C102 246 105 254 109 257 C114 238 114 202 109 184 Z"/>
+    <path class="muscle-region" data-canonical-muscles="vastus-medialis" d="M54 222 C58 230 59 244 55 257 C50 255 47 250 45 242 C47 233 50 227 54 222 Z"/>
+    <path class="muscle-region" data-canonical-muscles="vastus-medialis" d="M86 222 C82 230 81 244 85 257 C90 255 93 250 95 242 C93 233 90 227 86 222 Z"/>
+    <path class="muscle-region" data-canonical-muscles="vastus-intermedius" d="M44 192 C49 200 51 214 50 229 C47 224 44 218 42 210 C42 202 42 196 44 192 Z"/>
+    <path class="muscle-region" data-canonical-muscles="vastus-intermedius" d="M96 192 C91 200 89 214 90 229 C93 224 96 218 98 210 C98 202 98 196 96 192 Z"/>
+
+    <path class="muscle-region" data-canonical-muscles="tibialis-anterior" d="M31 257 C36 262 38 280 37 303 L29 319 C26 294 27 271 31 257 Z"/>
+    <path class="muscle-region" data-canonical-muscles="gastrocnemius" d="M43 257 C48 266 50 286 47 302 C43 308 38 307 36 300 C37 281 38 265 43 257 Z"/>
+    <path class="muscle-region" data-canonical-muscles="soleus" d="M37 300 C41 307 45 308 48 302 C48 309 47 315 46 319 L35 319 C35 311 36 305 37 300 Z"/>
+    <path class="muscle-region" data-canonical-muscles="tibialis-anterior" d="M109 257 C104 262 102 280 103 303 L111 319 C114 294 113 271 109 257 Z"/>
+    <path class="muscle-region" data-canonical-muscles="gastrocnemius" d="M97 257 C92 266 90 286 93 302 C97 308 102 307 104 300 C103 281 102 265 97 257 Z"/>
+    <path class="muscle-region" data-canonical-muscles="soleus" d="M103 300 C99 307 95 308 92 302 C92 309 93 315 94 319 L105 319 C105 311 104 305 103 300 Z"/>
+  </g>
+</svg>

--- a/static/bodymaps/hypertrophy-advanced/body_posterior.svg
+++ b/static/bodymaps/hypertrophy-advanced/body_posterior.svg
@@ -1,0 +1,103 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  Hypertrophy Toolbox Advanced Body Map - Posterior
+  Original schematic SVG, created for this project. Not derived from MuscleWiki.
+-->
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 140 320" id="body-posterior-hypertrophy-advanced" role="img" aria-label="Advanced posterior muscle map">
+  <defs>
+    <style>
+      .body-shell {
+        fill: #f6f7f9;
+        stroke: #444861;
+        stroke-width: 1.35;
+        stroke-linejoin: round;
+        pointer-events: none;
+      }
+      .body-line {
+        fill: none;
+        stroke: #444861;
+        stroke-width: 1;
+        stroke-linecap: round;
+        pointer-events: none;
+      }
+      .muscle-region {
+        fill: rgba(52, 152, 219, 0.18);
+        stroke: rgba(52, 152, 219, 0.45);
+        stroke-width: 0.55;
+        cursor: pointer;
+        transition: fill 0.15s ease, stroke 0.15s ease;
+      }
+    </style>
+  </defs>
+
+  <g class="body-outline" aria-hidden="true">
+    <path class="body-shell" d="M70 6 C83 7 92 17 92 31 C92 42 84 49 77 52 L78 61 C88 65 100 69 109 78 C117 87 120 101 121 114 C126 122 132 139 137 154 C139 164 136 173 130 177 C126 185 125 198 123 216 C121 232 119 245 116 257 C117 273 118 290 119 319 L94 319 C92 296 89 277 86 262 C84 249 80 237 76 224 C74 231 72 236 70 239 C68 236 66 231 64 224 C60 237 56 249 54 262 C51 277 48 296 46 319 L21 319 C22 290 23 273 24 257 C21 245 19 232 17 216 C15 198 14 185 10 177 C4 173 1 164 3 154 C8 139 14 122 19 114 C20 101 23 87 31 78 C40 69 52 65 62 61 L63 52 C56 49 48 42 48 31 C48 17 57 7 70 6 Z"/>
+    <path class="body-line" d="M58 42 C62 48 66 51 70 52 C74 51 78 48 82 42"/>
+    <path class="body-line" d="M58 69 C64 73 76 73 82 69"/>
+    <path class="body-line" d="M70 73 L70 178"/>
+    <path class="body-line" d="M56 177 C60 189 65 203 70 214 C75 203 80 189 84 177"/>
+  </g>
+
+  <g id="posterior-regions">
+    <path class="muscle-region" data-canonical-muscles="neck" d="M61 45 C65 50 75 50 79 45 L79 62 C75 66 65 66 61 62 Z"/>
+
+    <path class="muscle-region" data-canonical-muscles="upper-traps" d="M54 63 C61 59 79 59 86 63 C82 72 76 80 70 88 C64 80 58 72 54 63 Z"/>
+    <path class="muscle-region" data-canonical-muscles="mid-traps" d="M55 82 C63 88 77 88 85 82 L78 114 C73 119 67 119 62 114 Z"/>
+    <path class="muscle-region" data-canonical-muscles="lower-traps" d="M62 114 C67 119 73 119 78 114 L72 151 C71 155 69 155 68 151 Z"/>
+
+    <path class="muscle-region" data-canonical-muscles="posterior-deltoid" d="M48 68 C39 70 33 77 30 87 C35 90 43 88 50 81 C53 76 54 71 53 68 Z"/>
+    <path class="muscle-region" data-canonical-muscles="posterior-deltoid" d="M92 68 C101 70 107 77 110 87 C105 90 97 88 90 81 C87 76 86 71 87 68 Z"/>
+    <path class="muscle-region" data-canonical-muscles="lateral-deltoid" d="M30 87 C27 96 26 105 29 112 C36 112 43 106 46 96 C47 90 47 84 45 80 C39 86 34 88 30 87 Z"/>
+    <path class="muscle-region" data-canonical-muscles="lateral-deltoid" d="M110 87 C113 96 114 105 111 112 C104 112 97 106 94 96 C93 90 93 84 95 80 C101 86 106 88 110 87 Z"/>
+
+    <path class="muscle-region" data-canonical-muscles="rhomboids" d="M54 78 C58 90 60 101 62 114 C56 111 50 102 47 91 C48 85 50 81 54 78 Z"/>
+    <path class="muscle-region" data-canonical-muscles="rhomboids" d="M86 78 C82 90 80 101 78 114 C84 111 90 102 93 91 C92 85 90 81 86 78 Z"/>
+    <path class="muscle-region" data-canonical-muscles="teres-minor" d="M44 88 C50 88 54 92 56 98 C52 102 47 103 42 101 C41 96 42 92 44 88 Z"/>
+    <path class="muscle-region" data-canonical-muscles="teres-minor" d="M96 88 C90 88 86 92 84 98 C88 102 93 103 98 101 C99 96 98 92 96 88 Z"/>
+    <path class="muscle-region" data-canonical-muscles="teres-major" d="M42 101 C49 103 55 107 59 116 C55 123 48 127 42 126 C39 116 39 108 42 101 Z"/>
+    <path class="muscle-region" data-canonical-muscles="teres-major" d="M98 101 C91 103 85 107 81 116 C85 123 92 127 98 126 C101 116 101 108 98 101 Z"/>
+    <path class="muscle-region" data-canonical-muscles="lats" d="M40 108 C50 121 56 139 57 161 C52 171 45 176 38 178 C34 154 34 126 40 108 Z"/>
+    <path class="muscle-region" data-canonical-muscles="lats" d="M100 108 C90 121 84 139 83 161 C88 171 95 176 102 178 C106 154 106 126 100 108 Z"/>
+    <path class="muscle-region" data-canonical-muscles="erector-spinae" d="M60 116 C65 126 66 148 64 174 C61 181 58 181 55 175 C56 151 57 131 60 116 Z"/>
+    <path class="muscle-region" data-canonical-muscles="erector-spinae" d="M80 116 C75 126 74 148 76 174 C79 181 82 181 85 175 C84 151 83 131 80 116 Z"/>
+
+    <path class="muscle-region" data-canonical-muscles="long-head-triceps" d="M28 113 C24 123 22 137 24 151 C29 153 34 148 36 139 C36 128 33 119 28 113 Z"/>
+    <path class="muscle-region" data-canonical-muscles="lateral-head-triceps" d="M36 115 C42 124 43 139 38 151 C34 147 32 136 33 126 C34 121 35 118 36 115 Z"/>
+    <path class="muscle-region" data-canonical-muscles="medial-head-triceps" d="M24 151 C29 154 34 153 38 149 C38 159 35 166 30 170 C25 166 23 159 24 151 Z"/>
+    <path class="muscle-region" data-canonical-muscles="long-head-triceps" d="M112 113 C116 123 118 137 116 151 C111 153 106 148 104 139 C104 128 107 119 112 113 Z"/>
+    <path class="muscle-region" data-canonical-muscles="lateral-head-triceps" d="M104 115 C98 124 97 139 102 151 C106 147 108 136 107 126 C106 121 105 118 104 115 Z"/>
+    <path class="muscle-region" data-canonical-muscles="medial-head-triceps" d="M116 151 C111 154 106 153 102 149 C102 159 105 166 110 170 C115 166 117 159 116 151 Z"/>
+
+    <path class="muscle-region" data-canonical-muscles="brachioradialis" d="M18 153 C23 156 27 164 28 174 C25 181 20 184 15 180 C13 169 14 159 18 153 Z"/>
+    <path class="muscle-region" data-canonical-muscles="wrist-extensors" d="M15 180 C20 184 23 191 22 200 C18 203 14 199 12 190 C12 186 13 182 15 180 Z"/>
+    <path class="muscle-region" data-canonical-muscles="wrist-flexors" d="M28 168 C31 177 31 188 28 198 C24 195 22 187 23 179 C24 174 26 170 28 168 Z"/>
+    <path class="muscle-region" data-canonical-muscles="brachioradialis" d="M122 153 C117 156 113 164 112 174 C115 181 120 184 125 180 C127 169 126 159 122 153 Z"/>
+    <path class="muscle-region" data-canonical-muscles="wrist-extensors" d="M125 180 C120 184 117 191 118 200 C122 203 126 199 128 190 C128 186 127 182 125 180 Z"/>
+    <path class="muscle-region" data-canonical-muscles="wrist-flexors" d="M112 168 C109 177 109 188 112 198 C116 195 118 187 117 179 C116 174 114 170 112 168 Z"/>
+
+    <path class="muscle-region" data-canonical-muscles="gluteus-medius" d="M46 175 C54 174 62 179 66 188 C61 196 53 199 45 196 C42 189 42 181 46 175 Z"/>
+    <path class="muscle-region" data-canonical-muscles="gluteus-medius" d="M94 175 C86 174 78 179 74 188 C79 196 87 199 95 196 C98 189 98 181 94 175 Z"/>
+    <path class="muscle-region" data-canonical-muscles="gluteus-maximus" d="M45 196 C53 199 62 196 67 188 C69 202 67 215 62 223 C53 224 45 220 42 212 C41 205 42 200 45 196 Z"/>
+    <path class="muscle-region" data-canonical-muscles="gluteus-maximus" d="M95 196 C87 199 78 196 73 188 C71 202 73 215 78 223 C87 224 95 220 98 212 C99 205 98 200 95 196 Z"/>
+    <path class="muscle-region" data-canonical-muscles="gluteus-minimus" d="M42 184 C45 189 45 196 42 203 C38 200 36 195 36 188 C38 185 40 184 42 184 Z"/>
+    <path class="muscle-region" data-canonical-muscles="gluteus-minimus" d="M98 184 C95 189 95 196 98 203 C102 200 104 195 104 188 C102 185 100 184 98 184 Z"/>
+    <path class="muscle-region" data-canonical-muscles="tensor-fasciae-latae" d="M34 185 C38 190 39 202 37 216 C33 212 30 201 30 191 C31 188 32 186 34 185 Z"/>
+    <path class="muscle-region" data-canonical-muscles="tensor-fasciae-latae" d="M106 185 C102 190 101 202 103 216 C107 212 110 201 110 191 C109 188 108 186 106 185 Z"/>
+
+    <path class="muscle-region" data-canonical-muscles="biceps-femoris" d="M31 216 C39 223 42 240 41 258 C38 268 34 273 30 272 C25 254 25 228 31 216 Z"/>
+    <path class="muscle-region" data-canonical-muscles="semitendinosus" d="M42 220 C48 230 50 248 47 265 C43 269 39 266 39 258 C41 242 40 228 42 220 Z"/>
+    <path class="muscle-region" data-canonical-muscles="semimembranosus" d="M55 220 C58 235 57 254 51 270 C47 267 47 260 49 249 C50 238 51 228 55 220 Z"/>
+    <path class="muscle-region" data-canonical-muscles="biceps-femoris" d="M109 216 C101 223 98 240 99 258 C102 268 106 273 110 272 C115 254 115 228 109 216 Z"/>
+    <path class="muscle-region" data-canonical-muscles="semitendinosus" d="M98 220 C92 230 90 248 93 265 C97 269 101 266 101 258 C99 242 100 228 98 220 Z"/>
+    <path class="muscle-region" data-canonical-muscles="semimembranosus" d="M85 220 C82 235 83 254 89 270 C93 267 93 260 91 249 C90 238 89 228 85 220 Z"/>
+
+    <path class="muscle-region" data-canonical-muscles="gastrocnemius" d="M30 270 C35 272 38 286 37 303 C34 310 29 310 26 303 C25 290 26 278 30 270 Z"/>
+    <path class="muscle-region" data-canonical-muscles="gastrocnemius" d="M48 270 C53 278 54 292 50 305 C46 310 41 307 40 299 C41 286 43 276 48 270 Z"/>
+    <path class="muscle-region" data-canonical-muscles="soleus" d="M37 301 C41 307 46 309 50 304 C50 311 49 316 48 319 L36 319 C36 312 36 306 37 301 Z"/>
+    <path class="muscle-region" data-canonical-muscles="tibialis-anterior" d="M25 302 C29 310 33 310 36 304 C35 311 34 316 33 319 L22 319 C22 312 23 307 25 302 Z"/>
+    <path class="muscle-region" data-canonical-muscles="gastrocnemius" d="M110 270 C105 272 102 286 103 303 C106 310 111 310 114 303 C115 290 114 278 110 270 Z"/>
+    <path class="muscle-region" data-canonical-muscles="gastrocnemius" d="M92 270 C87 278 86 292 90 305 C94 310 99 307 100 299 C99 286 97 276 92 270 Z"/>
+    <path class="muscle-region" data-canonical-muscles="soleus" d="M103 301 C99 307 94 309 90 304 C90 311 91 316 92 319 L104 319 C104 312 104 306 103 301 Z"/>
+    <path class="muscle-region" data-canonical-muscles="tibialis-anterior" d="M115 302 C111 310 107 310 104 304 C105 311 106 316 107 319 L118 319 C118 312 117 307 115 302 Z"/>
+  </g>
+</svg>

--- a/static/js/modules/muscle-selector.js
+++ b/static/js/modules/muscle-selector.js
@@ -2,11 +2,11 @@
  * Muscle Group Selector Module v3.0
  * SVG-based anatomically accurate body diagram for muscle group selection
  * 
- * Uses vendor SVGs from react-body-highlighter (MIT License)
- * See static/vendor/react-body-highlighter/ATTRIBUTION.md
+ * Simple mode uses workout-cool SVGs (MIT License).
+ * Advanced mode uses first-party Hypertrophy Toolbox SVGs.
  * 
  * Features:
- * - Anatomically accurate SVG polygons from react-body-highlighter
+ * - SVG muscle regions with canonical keys baked into data attributes
  * - Simple/Advanced view modes with proper parent-child mapping
  * - Front/Back tab navigation  
  * - Bilateral synchronization (both sides highlight/select together)
@@ -253,10 +253,9 @@ const MUSCLE_TO_BACKEND = {
  *
  * Simple mode swaps in workout-cool's anatomy art (vendored under
  * static/vendor/workout-cool/, ships pre-canonicalized data-canonical-muscles
- * — see static/vendor/workout-cool/NOTICE.md). Advanced mode stays on
- * react-body-highlighter so every scientific sub-muscle key remains
- * clickable; that variant continues to use vendor `data-muscle` slugs that
- * mapVendorSlugsToCanonical() translates at load time.
+ * - see static/vendor/workout-cool/NOTICE.md). Advanced mode uses
+ * first-party schematic SVGs whose regions are already keyed to the
+ * scientific sub-muscles in SIMPLE_TO_ADVANCED_MAP.
  */
 const SVG_PATHS = {
     simple: {
@@ -264,8 +263,8 @@ const SVG_PATHS = {
         back: '/static/vendor/workout-cool/body_posterior.svg'
     },
     advanced: {
-        front: '/static/vendor/react-body-highlighter/body_anterior.svg',
-        back: '/static/vendor/react-body-highlighter/body_posterior.svg'
+        front: '/static/bodymaps/hypertrophy-advanced/body_anterior.svg',
+        back: '/static/bodymaps/hypertrophy-advanced/body_posterior.svg'
     }
 };
 
@@ -432,8 +431,9 @@ class MuscleSelector {
      * Map vendor SVG slugs to canonical muscle keys.
      * Updates data attributes on SVG elements.
      *
-     * Two SVG flavors are supported:
-     *   - Pre-canonicalized (workout-cool simple variant): each region
+     * Three SVG flavors are supported:
+     *   - Pre-canonicalized (workout-cool simple variant and first-party
+     *     advanced variant): each region
      *     already carries `data-canonical-muscles="<key1>[,<key2>,...]"`.
      *     No translation needed — left as-is.
      *   - Vendor-slug (react-body-highlighter advanced variant): each region
@@ -647,14 +647,26 @@ class MuscleSelector {
     }
 
     /**
-     * Handle hover state - highlight all paths for the same canonical key
+     * Return true when a region should respond to hover for `muscleKey`.
+     * This supports both direct advanced child keys and parent/simple keys
+     * used by legend group headers.
+     */
+    regionMatchesMuscleKey(region, muscleKey) {
+        const regionKeys = this.getCanonicalKeys(region);
+        if (regionKeys.includes(muscleKey)) return true;
+
+        const targetAdvanced = this.flattenToAdvancedChildren([muscleKey]);
+        const regionAdvanced = this.flattenToAdvancedChildren(regionKeys);
+        return regionAdvanced.some(key => targetAdvanced.includes(key));
+    }
+
+    /**
+     * Handle hover state - highlight all paths covered by a canonical key.
      */
     handleMuscleHover(canonicalKey, isHovering) {
-        // Find all regions with this canonical key (handles bilateral sides)
         const regions = this.container.querySelectorAll('.muscle-region');
         regions.forEach(region => {
-            const regionKey = this.getCanonicalKey(region);
-            if (regionKey === canonicalKey) {
+            if (this.regionMatchesMuscleKey(region, canonicalKey)) {
                 region.classList.toggle('hover', isHovering);
             }
         });

--- a/tests/test_muscle_selector_mapping.py
+++ b/tests/test_muscle_selector_mapping.py
@@ -206,9 +206,10 @@ class TestMuscleSelectorJSStructure:
         """VENDOR_SLUG_TO_CANONICAL should be defined."""
         assert "VENDOR_SLUG_TO_CANONICAL" in js_content
     
-    def test_svg_paths_use_vendor_directory(self, js_content):
-        """SVG_PATHS should reference vendor directory."""
-        assert "/static/vendor/react-body-highlighter/" in js_content
+    def test_svg_paths_reference_simple_and_advanced_assets(self, js_content):
+        """SVG_PATHS should reference workout-cool simple art and first-party advanced art."""
+        assert "/static/vendor/workout-cool/" in js_content
+        assert "/static/bodymaps/hypertrophy-advanced/" in js_content
 
 
 # ============================================================================
@@ -226,6 +227,20 @@ WC_ANTERIOR_SVG = (
 )
 WC_POSTERIOR_SVG = (
     Path(__file__).parent.parent / "static" / "vendor" / "workout-cool" / "body_posterior.svg"
+)
+ADVANCED_ANTERIOR_SVG = (
+    Path(__file__).parent.parent
+    / "static"
+    / "bodymaps"
+    / "hypertrophy-advanced"
+    / "body_anterior.svg"
+)
+ADVANCED_POSTERIOR_SVG = (
+    Path(__file__).parent.parent
+    / "static"
+    / "bodymaps"
+    / "hypertrophy-advanced"
+    / "body_posterior.svg"
 )
 
 
@@ -377,6 +392,92 @@ class TestWorkoutCoolSvgCoverage:
         assert not missing_posterior, (
             f"Posterior simple keys neither drawn nor allowlisted: {missing_posterior}"
         )
+
+
+class TestFirstPartyAdvancedSvgCoverage:
+    """First-party advanced SVGs expose direct clickable sub-muscle regions."""
+
+    @pytest.fixture
+    def anterior_groups(self):
+        return extract_canonical_muscle_lists(ADVANCED_ANTERIOR_SVG)
+
+    @pytest.fixture
+    def posterior_groups(self):
+        return extract_canonical_muscle_lists(ADVANCED_POSTERIOR_SVG)
+
+    def test_advanced_svgs_exist(self):
+        assert ADVANCED_ANTERIOR_SVG.exists(), f"Missing {ADVANCED_ANTERIOR_SVG}"
+        assert ADVANCED_POSTERIOR_SVG.exists(), f"Missing {ADVANCED_POSTERIOR_SVG}"
+
+    def test_anterior_advanced_keys_are_drawn(self, anterior_groups):
+        flat = {k for grp in anterior_groups for k in grp}
+        for key in [
+            "neck",
+            "anterior-deltoid",
+            "lateral-deltoid",
+            "upper-chest",
+            "mid-chest",
+            "lower-chest",
+            "long-head-bicep",
+            "short-head-bicep",
+            "lateral-head-triceps",
+            "long-head-triceps",
+            "medial-head-triceps",
+            "wrist-flexors",
+            "wrist-extensors",
+            "brachioradialis",
+            "upper-abs",
+            "lower-abs",
+            "obliques",
+            "adductors",
+            "rectus-femoris",
+            "vastus-lateralis",
+            "vastus-medialis",
+            "vastus-intermedius",
+            "gastrocnemius",
+            "soleus",
+            "tibialis-anterior",
+        ]:
+            assert key in flat, f"Anterior advanced SVG missing '{key}'"
+
+    def test_posterior_advanced_keys_are_drawn(self, posterior_groups):
+        flat = {k for grp in posterior_groups for k in grp}
+        for key in [
+            "neck",
+            "posterior-deltoid",
+            "lateral-deltoid",
+            "upper-traps",
+            "mid-traps",
+            "lower-traps",
+            "rhomboids",
+            "teres-major",
+            "teres-minor",
+            "lats",
+            "erector-spinae",
+            "lateral-head-triceps",
+            "long-head-triceps",
+            "medial-head-triceps",
+            "wrist-flexors",
+            "wrist-extensors",
+            "brachioradialis",
+            "gluteus-maximus",
+            "gluteus-medius",
+            "gluteus-minimus",
+            "tensor-fasciae-latae",
+            "biceps-femoris",
+            "semitendinosus",
+            "semimembranosus",
+            "gastrocnemius",
+            "soleus",
+            "tibialis-anterior",
+        ]:
+            assert key in flat, f"Posterior advanced SVG missing '{key}'"
+
+    def test_advanced_svg_uses_submuscle_keys_not_parent_back_region(self, posterior_groups):
+        groups = {tuple(grp) for grp in posterior_groups}
+        assert ("lats", "upper-back", "lowerback") not in groups
+        for key in ("lats", "rhomboids", "erector-spinae"):
+            assert (key,) in groups
 
 
 class TestRegionVisualState:


### PR DESCRIPTION
…view

Replaces react-body-highlighter as the source for the workout-plan Advanced muscle selector with original SVGs at
static/bodymaps/hypertrophy-advanced/. Regions carry data-canonical-muscles targeting sub-muscles directly, so a click can select one child (upper-chest, rhomboids, erector-spinae, ...) without selecting siblings.

react-body-highlighter retained: static/js/modules/bodymap-svg.js still uses it for the /user_profile coverage map. Profile-map swap is out of scope.

Adds 17 pytest in tests/test_muscle_selector_mapping.py and 1 new E2E covering the single-sub-muscle click. Gitignores static/bodymaps/GPT/ scratch dir.