### PR TITLE
feat(ai-workflow): land Tier 2.1 — worktree isolation

### DIFF
--- a/.claude/agents/unslop-reviewer.md
+++ b/.claude/agents/unslop-reviewer.md
@@ -1,0 +1,38 @@
+---
+name: unslop-reviewer
+description: Flags AI-generated "slop" in staged changes — verbose docstrings, defensive try/except around impossible cases, premature abstractions, comments restating code, unrelated churn, and stale shims.
+tools: Read, Grep, Glob
+---
+
+You are an "unslop" reviewer for the Hypertrophy Toolbox Flask app. Your job is to flag patterns that AI code generation tends to introduce and that this codebase explicitly does not want. Be terse and concrete — cite `file:line` and quote the offending snippet.
+
+## What to flag
+
+1. **Trivial / restating comments** — comments that just paraphrase the next line. Example: `# increment counter` above `counter += 1`, or a docstring that repeats the signature. Acceptable comments: hidden constraints, subtle invariants, workarounds for a specific bug. If removing the comment would not confuse a future reader, flag it.
+
+2. **Defensive try/except around impossible cases** — wrapping a `DatabaseHandler` call (which already logs and rolls back), wrapping a constant lookup, or catching `Exception` and returning a fallback for a path that has no failure mode. Internal code is trusted; only validate at boundaries (`routes/*` for user input).
+
+3. **Premature abstractions** — single-caller helper functions, base classes with one subclass, configuration knobs no caller sets, "future-proof" parameters with default values that are always used. Three similar lines is fine; an abstraction "for next time" is not.
+
+4. **Verbose docstrings** — multi-paragraph docstrings on small functions, "Args/Returns/Raises" boilerplate that restates the type hints. The repo defaults to **no docstring**; one short line is the cap unless the function has surprising behavior.
+
+5. **Backwards-compat shims & dead code** — re-exports added "for compatibility", `# removed` placeholder comments, unused `_var = None` renames, deprecated wrappers around new functions. Solo single-user repo: there is no external API to preserve. Delete, don't shim.
+
+6. **Unrelated churn** — formatting-only edits, rename-only refactors, or import reorders mixed into a feature/bug-fix diff. Flag any diff hunks that don't belong to the stated task.
+
+7. **`utils/__init__.py` re-exports for new code** — per root [CLAUDE.md](../../CLAUDE.md) §2, `utils/__init__.py` is no longer the authoritative facade. New modules should be imported directly (`from utils.X import ...`).
+
+8. **Logger / response-contract drift** — `print()` or `logging.getLogger(...)` instead of `get_logger()`; ad-hoc `{"success": ...}` returns instead of `success_response()`. (These also show up in `code-reviewer`; flag them only if `code-reviewer` missed them or the user is running `unslop-reviewer` standalone.)
+
+9. **PR-description prose in code** — comments that reference the current task ("added for issue #X", "used by Y flow"). That belongs in the commit message, not the source.
+
+## How to report
+
+For each finding, output:
+```
+<file>:<line> — <one-line summary>
+  > <quoted offending code, ≤2 lines>
+  Fix: <what to remove or rewrite, in one sentence>
+```
+
+No speculative suggestions. No "consider also…". If the diff is clean, say so in one line.

--- a/.claude/commands/handover.md
+++ b/.claude/commands/handover.md
@@ -1,0 +1,23 @@
+---
+description: Update local handover scratch with current session state; optionally edit committed handover.
+---
+
+Update the handover layers per `.claude/SHARED_PLAN.md` Appendix A1.1.
+
+## Steps
+1. Capture current state:
+   - Run `git status --short --branch` and `git log -1 --oneline`.
+   - Note the current TodoWrite list (if any) and the file/line you are mid-edit on.
+2. **Prepend** a new dated block to `MASTER_HANDOVER.local.md` (do not overwrite or delete prior blocks). Block template:
+
+   ```markdown
+   ## YYYY-MM-DDTHH:MM
+   - git status: <one-line summary>
+   - last commit: <sha> — <subject>
+   - in-progress edit: <file:line>
+   - open todos: <list>
+   - next step: <action>
+   ```
+3. Ask the user: "Update committed `docs/MASTER_HANDOVER.md` too? (y/N)" — default no.
+4. If yes, open `docs/MASTER_HANDOVER.md` for manual edit; never auto-write to it. The committed handover is curated, not appended.
+5. No Stop hook is wired — `/handover` stays manual until it proves low-noise.

--- a/.claude/commands/unslop.md
+++ b/.claude/commands/unslop.md
@@ -1,0 +1,31 @@
+---
+description: Quality gate — diff → targeted tests → code-reviewer → unslop-reviewer → handover update.
+---
+
+Run the post-implementation polish gate per `.claude/SHARED_PLAN.md` Appendix A1.2.
+
+## Steps
+1. **Capture changed files**. Include staged, unstaged, and untracked files:
+   - `git diff --name-only HEAD`
+   - `git diff --name-only --cached`
+   - `git ls-files --others --exclude-standard`
+   - If a feature branch has an upstream/base, also include `git diff --name-only <merge-base>...HEAD`.
+   - De-duplicate the list. If it is empty, stop.
+2. **Targeted tests** — derive from the diff using `docs/ai_workflow/QUALITY_GATE.md`:
+   - `routes/X.py` → try `tests/test_X_routes.py`, then `tests/test_X.py`; also `rg` tests for imports/blueprint names.
+   - `utils/X.py` → try `tests/test_X.py`; also `rg` tests for imports.
+   - `templates/X.html` or `static/js/**/X*` → normalize `_` to `-` and use the feature-to-spec map in `QUALITY_GATE.md`.
+   - Run via `/run-tests <files>` and `/run-e2e <specs>`. If the union is empty or the diff is cross-cutting, fall back to `/verify-suite`.
+3. **`code-reviewer` agent**: invoke on the staged diff. Address every finding or document why deferred.
+4. **`unslop-reviewer` agent**: invoke on the staged diff. Address every finding before commit; AI smells are not "preferences".
+5. **`/handover`**: prepend a session block to `MASTER_HANDOVER.local.md` capturing what shipped + new test counts.
+
+## When to use
+- Before declaring a non-trivial change complete.
+- Before opening a PR.
+- Not for product-docs-only or comment-only changes — those go straight to `/handover`.
+- For `.claude/**`, `CLAUDE.md`, folder `CLAUDE.md`, and `docs/ai_workflow/**`, do the manual dry-run/self-review from `QUALITY_GATE.md`; these files change agent behavior even though they are Markdown.
+
+## When NOT to chain
+- If targeted tests fail in step 2, stop and fix; do not let `code-reviewer`/`unslop-reviewer` review broken code.
+- If the diff is purely product docs, skip steps 2–4; jump to step 5.

--- a/.claude/commands/verify-and-polish.md
+++ b/.claude/commands/verify-and-polish.md
@@ -1,0 +1,20 @@
+---
+description: Documented sequence — full /verify-suite, then code-reviewer, then unslop-reviewer, then handover. Use before declaring a feature complete.
+---
+
+This is a **sequence guide**, not a chained skill. Run each step, address findings, re-run if needed.
+
+## Steps
+1. **`/verify-suite`** — full pytest + Chromium E2E gate. Must pass (modulo the known current red / historical flake in `e2e/CLAUDE.md` Gotchas) before continuing.
+2. **`code-reviewer` agent** — invoke on the staged diff. Cites SQL-injection, response-contract, DB-access, logging, blueprint-registration risks. Address every finding or document why deferred.
+3. **`unslop-reviewer` agent** — invoke on the staged diff. Flags AI smells (verbose docstrings, defensive try/except, premature abstractions, restating comments, unrelated churn). Address every finding before commit.
+4. **`/handover`** — prepend a session block to `MASTER_HANDOVER.local.md`. If a milestone shipped, edit `docs/MASTER_HANDOVER.md` manually with new test counts and workstream status.
+
+## Failure handling
+- Step 1 fail → fix the test, re-run from step 1.
+- Step 2 fail → fix the violation, re-run from step 1 if logic changed, else continue from step 3.
+- Step 3 fail → fix the smell, re-run from step 3.
+- Do not skip to commit on partial success.
+
+## Difference vs `/unslop`
+`/unslop` is the **lighter** post-implementation gate — uses targeted tests instead of the full suite. Use `/unslop` for routine work, `/verify-and-polish` for refactors, schema changes, or anything that touches multiple modules.

--- a/.claude/commands/worktree.md
+++ b/.claude/commands/worktree.md
@@ -1,0 +1,53 @@
+---
+description: Create a new git worktree with isolated SQLite DB for parallel agent work.
+---
+
+Use this to fork a workstream onto its own checkout so parallel Claude instances don't corrupt each other's `data/database.db`. SQLite WAL is not safe across concurrent writers from independent processes pointing at the same file — this is why [CLAUDE.md](../../CLAUDE.md) §3 keeps `FLASK_USE_RELOADER=0` by default.
+
+## Quick start
+
+```powershell
+.\scripts\new-worktree.ps1 -Task <slug> [-Seed visual|empty|copy-current] [-OpenTerminal]
+```
+
+Creates `..\Hypertrophy-Toolbox-v3-<slug>` from HEAD on branch `wt/<slug>`, ensures `data/` and `data/auto_backup/` exist, seeds `data/database.db` per the mode, and (with `-OpenTerminal`) opens a new Windows Terminal tab in the new worktree.
+
+## When to fork
+
+- Two or more agents will edit the working tree at once.
+- A long experiment will pollute `data/database.db` and you want the main checkout clean.
+- You need to compare two implementations side-by-side.
+
+If only one agent is active, stay in the main checkout — worktrees are overhead.
+
+## Seed modes
+
+| Mode | What it does | Use when |
+|---|---|---|
+| `visual` (default) | Copies `e2e/fixtures/database.visual.seed.db` into `data/database.db`. If the fixture is missing, warns and leaves the DB absent so `app.py` initializes fresh on launch. | E2E or template work that expects the fixture dataset. |
+| `empty` | Leaves `data/database.db` absent. `app.py` will run `initialize_database()` on first launch. | Fresh dev / unit-test work. |
+| `copy-current` | Copies the main checkout's `data/database.db` if it exists. Warns about WAL/SHM sidecars; stop the source app first. | Reproducing a bug against your live local data. |
+
+The script always checks the source exists before copying — missing source warns and skips rather than failing the worktree creation.
+
+## Per-worktree, never shared
+
+- `data/database.db` (and `-wal` / `-shm` sidecars)
+- `data/auto_backup/`
+- `.venv/` — recreate with `python -m venv .venv` or symlink the main checkout's venv with `New-Item -ItemType SymbolicLink`
+- `MASTER_HANDOVER.local.md`
+- Live workstream claims — see [docs/ai_workflow/WORKSTREAM_OWNERSHIP.md](../../docs/ai_workflow/WORKSTREAM_OWNERSHIP.md); put the active row in `MASTER_HANDOVER.local.md` or a local `WORKSTREAM_OWNERSHIP.local.md`, not the committed table.
+
+## Tearing down
+
+```powershell
+git worktree remove ..\Hypertrophy-Toolbox-v3-<slug>
+git branch -d wt/<slug>   # or -D if abandoned
+```
+
+`git worktree remove` refuses if the worktree has uncommitted changes. Investigate before forcing.
+
+## See also
+
+- [docs/ai_workflow/PARALLEL_WORKFLOW.md](../../docs/ai_workflow/PARALLEL_WORKFLOW.md) — when to fork, DB isolation rule, conflict avoidance.
+- [docs/ai_workflow/WORKSTREAM_OWNERSHIP.md](../../docs/ai_workflow/WORKSTREAM_OWNERSHIP.md) — path-claim rules.

--- a/.gitignore
+++ b/.gitignore
@@ -78,5 +78,6 @@ build/
 # Body-map scratch / reference output
 static/bodymaps/GPT/
 
-# AI workflow scratch (see .claude/SHARED_PLAN.md Appendix A1.1)
+# AI workflow scratch (see .claude/SHARED_PLAN.md Appendix A1.1, A2.1)
 MASTER_HANDOVER.local.md
+WORKSTREAM_OWNERSHIP.local.md

--- a/.gitignore
+++ b/.gitignore
@@ -77,3 +77,6 @@ build/
 
 # Body-map scratch / reference output
 static/bodymaps/GPT/
+
+# AI workflow scratch (see .claude/SHARED_PLAN.md Appendix A1.1)
+MASTER_HANDOVER.local.md

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,6 +1,6 @@
 # CLAUDE.md
 
-Operational guidance for Claude Code. Keep this file under 200 lines. Subsystem-specific detail lives in `.claude/rules/*.md` and loads only when the matching files enter context.
+Operational guidance for Claude Code. Keep this file under 200 lines. Subsystem-specific detail lives in `.claude/rules/*.md` and loads only when the matching files enter context. **For long-running work, read [`docs/MASTER_HANDOVER.md`](docs/MASTER_HANDOVER.md) first** (canonical current state); folder orientation lives in `<dir>/CLAUDE.md` files.
 
 ---
 

--- a/docs/MASTER_HANDOVER.md
+++ b/docs/MASTER_HANDOVER.md
@@ -1,0 +1,27 @@
+# Master Handover
+
+*Committed canonical state. Curated manually after each milestone. New Claude instances read this first.*
+
+## Current State
+- **Branch**: `main`
+- **Last commit**: `4d2febe` — docs(fatigue): record synthetic calibration stress test
+- **Last verified pytest**: 1160 passed in 159.70s on 2026-05-10
+- **Last verified E2E (Chromium)**: 414 passed / 1 failed on 2026-05-10. Failure is pre-existing & out-of-scope: `nav-dropdown.spec.ts:117` dark-mode toggle off-viewport at 1440 width. The previous `program-backup.spec.ts:79` DB-state-pollution flake passed in this full run.
+
+## Active Workstreams
+| Workstream | Status | Next safe step | Docs |
+|---|---|---|---|
+| Avi Lewis AI workflow Tier 1 | shipped 2026-05-10 | Awaiting user review before starting Tier 2 | [docs/ai_workflow/INDEX.md](ai_workflow/INDEX.md) |
+| Fatigue meter | parked (Phase 1 + Stage 4 entry shipped) | Hold; no Phase 2 / `utils/fatigue.py` edits without real data or explicit go-ahead | [docs/fatigue_meter/PLANNING.md](fatigue_meter/PLANNING.md) |
+| workout.cool integration | §3 + §5 shipped (2026-04-29 / 2026-04-30) | §4 free-exercise-db media | [docs/workout_cool_integration/PLANNING.md](workout_cool_integration/PLANNING.md) |
+| Redesign post-P8 triage | #6 done; 5 issues remaining | #7 + #8 | local-only `debug/redesign_post_p8_issues_SESSION_STATE.md` |
+| phase5_3i_plan | paused mid-draft | Resume from session-state file | local-only `debug/phase5_3i_plan_SESSION_STATE.md` |
+
+## Open Decisions
+- Tier 2 of the Avi Lewis workflow (worktree isolation + plan-review council) is approved in concept but not approved to start until Tier 1 ships and is reviewed.
+
+## Blockers
+- None.
+
+## Next Safe Step
+Tier 1 is complete and uncommitted. Review the new artifacts (handover spine, six folder maps, quality/unslop gate) and commit when satisfied. Do not start Tier 2 (worktree isolation + plan-review council) until that review and an explicit go-ahead.

--- a/docs/ai_workflow/INDEX.md
+++ b/docs/ai_workflow/INDEX.md
@@ -1,0 +1,37 @@
+# AI Workflow Index
+
+*Navigation map for AI agents and humans working on this repo. The Master Handover is the entry point; everything else here is reference.*
+
+## Spine (read first)
+- [Master Handover](../MASTER_HANDOVER.md) — canonical current state
+- root [CLAUDE.md](../../CLAUDE.md) — operational guidance
+- [`.claude/rules/`](../../.claude/rules/) — subsystem rules (auto-loaded by Claude Code on matching paths)
+- `.claude/SHARED_PLAN.md` — optional local planning/audit trail if present; Tier 1 artifacts here should stand on their own
+
+## Active feature plans
+- [Fatigue meter](../fatigue_meter/PLANNING.md) — parked; Phase 1 + Stage 4 entry shipped
+- [workout.cool integration](../workout_cool_integration/PLANNING.md) — §3 + §5 done; §4 next
+- [User profile](../user_profile/PLANNING.md) — questionnaire + bodymap shipped
+
+## History & decisions
+- [CHANGELOG](../CHANGELOG.md)
+- [DECISIONS](../DECISIONS.md)
+- [CLAUDE.md audit](../CLAUDE_MD_AUDIT.md)
+- [E2E testing notes](../E2E_TESTING.md)
+- [CSS ownership map](../CSS_OWNERSHIP_MAP.md)
+- [Volume taxonomy audit](../VOLUME_TAXONOMY_AUDIT.md)
+
+## Workflow artifacts
+- [Quality Gate](QUALITY_GATE.md) — change-type → required tests/reviewers map
+- Folder orientation maps (Claude Code auto-loads on path entry):
+  - [routes/CLAUDE.md](../../routes/CLAUDE.md)
+  - [utils/CLAUDE.md](../../utils/CLAUDE.md)
+  - [tests/CLAUDE.md](../../tests/CLAUDE.md)
+  - [e2e/CLAUDE.md](../../e2e/CLAUDE.md)
+  - [templates/CLAUDE.md](../../templates/CLAUDE.md)
+  - [static/js/CLAUDE.md](../../static/js/CLAUDE.md)
+- Slash commands: `/handover`, `/unslop`, `/verify-and-polish` (in `.claude/commands/`)
+- Agents: `code-reviewer`, `unslop-reviewer` (in `.claude/agents/`)
+
+## Baselines (gitignored, generated locally)
+- `baseline_pytest.txt`, `baseline_e2e.txt` — last full-suite outputs; not in git

--- a/docs/ai_workflow/PARALLEL_WORKFLOW.md
+++ b/docs/ai_workflow/PARALLEL_WORKFLOW.md
@@ -1,0 +1,102 @@
+# Parallel Workflow
+
+*How to run more than one Claude (or any concurrent dev) on this repo without corrupting state. Implements [`.claude/SHARED_PLAN.md`](../../.claude/SHARED_PLAN.md) Tier 2.1.*
+
+## Why this exists
+
+The app uses SQLite. `app.py` enables WAL mode in non-debug runs ([utils/database.py:90](../../utils/database.py#L90)) and the auto-backup task snapshots `data/database.db` at startup ([utils/auto_backup.py](../../utils/auto_backup.py)). Two parallel checkouts pointing at the same DB file will:
+
+- Race on WAL/SHM sidecars and risk corruption.
+- Stomp each other's `data/auto_backup/` snapshots.
+- Produce non-deterministic test runs when one agent's seed pollutes another's.
+
+The fix is **one DB per checkout**, achieved via `git worktree`.
+
+## When to fork
+
+Fork when any of these is true:
+- Two agents will edit the working tree at the same time.
+- One agent will run the dev server or pytest while another agent edits unrelated code.
+- An experiment will leave `data/database.db` in a state you don't want to keep.
+
+Don't fork for:
+- Single-agent sequential work — the main checkout is fine.
+- Docs-only edits that don't touch `data/`.
+
+## Forking — the short version
+
+```powershell
+.\scripts\new-worktree.ps1 -Task <slug> [-Seed visual|empty|copy-current] [-OpenTerminal]
+```
+
+The script:
+1. `git worktree add -b wt/<slug> ..\Hypertrophy-Toolbox-v3-<slug> HEAD`.
+2. Creates `data/` and `data/auto_backup/` in the new worktree.
+3. Seeds `data/database.db` per `-Seed`. Defensive — warns and skips if the source is missing rather than aborting.
+4. Optionally opens a Windows Terminal tab in the worktree (`-OpenTerminal`).
+
+See [`.claude/commands/worktree.md`](../../.claude/commands/worktree.md) for the seed-mode table and the per-worktree-never-shared list.
+
+## Python environment
+
+`.venv/` is gitignored, so a new worktree starts without one. Two options:
+
+- Fresh venv (slowest, fully isolated):
+  ```powershell
+  python -m venv .venv
+  .\.venv\Scripts\pip.exe install -r requirements.txt
+  ```
+- Symlink to the main checkout's venv (fast; works because the venv is read-only at runtime):
+  ```powershell
+  New-Item -ItemType SymbolicLink -Path .venv -Target ..\Hypertrophy-Toolbox-v3-main\.venv
+  ```
+  Requires admin or Developer Mode on Windows.
+
+## DB isolation rule
+
+**Each worktree owns its own `data/database.db`.** Do not symlink it; do not point a second worktree at the same file via `DB_FILE`. Even read-only access from a second process can disrupt WAL recovery.
+
+Auto-backups land in the worktree's own `data/auto_backup/`. They never need to be merged across worktrees — they are throw-away local snapshots.
+
+### Why the script applies `--skip-worktree`
+
+`data/database.db` is currently tracked in this repo, so `git worktree add` checks HEAD's copy out into the new worktree before the seed step runs. The script then calls `git update-index --skip-worktree data/database.db` *inside the new worktree only*. That hides subsequent seed writes from `git status` and lets `git worktree remove` succeed cleanly when you tear down.
+
+If you ever genuinely need to commit a `data/database.db` change from a worktree, undo the flag first:
+
+```powershell
+git update-index --no-skip-worktree data/database.db
+```
+
+The root cause is that `data/database.db` should arguably not be tracked at all. Untracking it (`git rm --cached data/database.db`) is a separate, larger change with cross-cutting consequences for fresh clones — out of scope for the worktree script.
+
+## Conflict avoidance
+
+- Read [WORKSTREAM_OWNERSHIP.md](WORKSTREAM_OWNERSHIP.md) before claiming files.
+- Put your live claim in `MASTER_HANDOVER.local.md` (gitignored) or in a local `WORKSTREAM_OWNERSHIP.local.md` (also gitignored). The committed `WORKSTREAM_OWNERSHIP.md` is rules + template only — keeping live rows out of git avoids merge churn on every claim/release.
+- Coordinate explicitly on the **never-claimed shared paths**: `app.py`, root [`CLAUDE.md`](../../CLAUDE.md) and folder-level `CLAUDE.md` files, [`.claude/settings.json`](../../.claude/settings.json), [`docs/MASTER_HANDOVER.md`](../MASTER_HANDOVER.md), [`.gitignore`](../../.gitignore).
+- If two worktrees both need to edit a claimed glob, finish one branch and rebase the other.
+
+## Merging back
+
+Standard PR flow. Push the `wt/<slug>` branch, open a PR, let CI run, merge into `main`. Then:
+
+```powershell
+git worktree remove ..\Hypertrophy-Toolbox-v3-<slug>
+git branch -d wt/<slug>
+```
+
+`git worktree remove` refuses if the worktree has uncommitted changes — that's intentional. Investigate before forcing.
+
+## Failure modes to expect
+
+- **Stale `wt/` branches** — `git worktree list` shows all active checkouts. `git worktree prune` clears orphaned admin entries after a manual directory delete.
+- **DB schema drift** — if you fork from an older HEAD and the main DB has new tables, `app.py` startup runs the table-creation helpers idempotently; the worktree's DB will catch up on first launch.
+- **Auto-backup spam** — every worktree creates its own startup snapshot. Periodically clear `data/auto_backup/` per worktree.
+- **Visual fixture missing** — `.gitignore` whitelists `e2e/fixtures/database.visual.seed.db`, so it should be in tree. If it isn't, the seed step warns and skips; either regenerate the fixture or pass `-Seed empty`.
+
+## See also
+
+- [`.claude/commands/worktree.md`](../../.claude/commands/worktree.md) — slash command.
+- [WORKSTREAM_OWNERSHIP.md](WORKSTREAM_OWNERSHIP.md) — path-claim rules.
+- [`CLAUDE.md`](../../CLAUDE.md) §3 — `FLASK_USE_RELOADER=0` rationale (same WAL hazard).

--- a/docs/ai_workflow/QUALITY_GATE.md
+++ b/docs/ai_workflow/QUALITY_GATE.md
@@ -1,0 +1,73 @@
+# Quality Gate
+
+*Required gates per change type. Used by `/unslop` and `/verify-and-polish` to decide which tests and reviewers to run. This file is the canonical implemented version of the Tier 1 quality gate.*
+
+## Change-type → gates table
+
+| Change type | Path globs | Required gates | Required reviewers |
+|---|---|---|---|
+| Route / API | `routes/**`, `app.py` | route pytest target (`tests/test_<route>_routes.py` or `tests/test_<route>.py`) + blueprint-registration coverage in `tests/conftest.py` | `code-reviewer`; + `product-risk-reviewer` if response shape changes (Tier 2) |
+| DB / schema | `utils/db_initializer.py`, `utils/database.py`, `utils/program_backup.py`, `utils/auto_backup.py` | full `pytest` + manual backup/restore smoke | `code-reviewer` + `architecture-reviewer` (Tier 2) |
+| Business logic | `utils/**.py` (non-DB) | `pytest tests/test_<module>.py` | `code-reviewer`; + `product-risk-reviewer` (Tier 2) if `effective_sets` / `weekly_summary` / `session_summary` / `progression` / `fatigue` touched |
+| Frontend (template) | `templates/**` | matching Chromium specs from the feature map below | none required |
+| Frontend (JS) | `static/js/**` | matching Chromium specs from the feature map below + manual smoke if interactive | none required |
+| CSS | `scss/**` | `/build-css` + `e2e/visual.spec.ts` if visual surface changes | none required |
+| E2E spec | `e2e/**` | run the spec; intentionally re-baseline if visual | none required |
+| AI workflow / agent config | `.claude/**`, `CLAUDE.md`, `*/CLAUDE.md`, `docs/ai_workflow/**` | manual dry-run/self-review; run tests only if source behavior changed | `code-reviewer` or careful self-review |
+| Product docs only | `docs/**`, `*.md` excluding AI workflow files above | none unless examples/scripts changed | none |
+
+> **Tier 2 reviewers** (`architecture-reviewer`, `test-strategist`, `product-risk-reviewer`) ship in the next phase of `.claude/SHARED_PLAN.md`. Until they exist, fall back to `code-reviewer` plus a careful self-read.
+
+## Diff collection (used by `/unslop`)
+
+Collect all changed files before deriving tests:
+
+```powershell
+git diff --name-only HEAD
+git diff --name-only --cached
+git ls-files --others --exclude-standard
+```
+
+If a feature branch has an upstream or known base, also include `git diff --name-only <merge-base>...HEAD`. De-duplicate the final list. Do not rely on plain `git diff --name-only`; it misses untracked Tier 1-style artifacts.
+
+## Targeted-test derivation
+
+For each changed file:
+
+- `routes/X.py` → try `tests/test_X_routes.py`, then `tests/test_X.py`, plus any tests found by `rg "routes\.X|X_bp|/route_name" tests`
+- `utils/X.py` → try `tests/test_X.py`, plus any tests found by `rg "utils\.X|from utils.X import" tests`
+- `templates/X.html` or `static/js/**/X*` → normalize underscores to hyphens and use the feature map below
+- `app.py`, `tests/conftest.py`, `.claude/**`, root configs → fall back to `/verify-suite` (cross-cutting)
+
+Run the union. If the union is empty, run `/verify-suite`.
+
+## Frontend feature → E2E map
+
+| Template / JS hint | Primary E2E specs |
+|---|---|
+| `welcome`, `base`, `navbar`, `darkMode` | `smoke-navigation.spec.ts`, `nav-dropdown.spec.ts`, `dark-mode.spec.ts` |
+| `workout_plan`, `workout-plan`, `filters`, `exercises`, `routine-cascade` | `workout-plan.spec.ts`, `exercise-interactions.spec.ts`, `superset-edge-cases.spec.ts` |
+| `workout_log`, `workout-log` | `workout-log.spec.ts` |
+| `weekly_summary`, `session_summary`, `summary`, `charts` | `summary-pages.spec.ts` |
+| `progression_plan`, `progression-plan` | `progression.spec.ts` |
+| `volume_splitter`, `volume-splitter`, `plan_volume_panel` | `volume-splitter.spec.ts`, `volume-progress.spec.ts` |
+| `user_profile`, `user-profile`, `bodymap`, `muscle-selector` | `user-profile.spec.ts` |
+| `backup`, `program-backup`, `backup-center` | `program-backup.spec.ts` |
+| validation, error, empty state, accessibility changes | `validation-boundary.spec.ts`, `error-handling.spec.ts`, `empty-states.spec.ts`, `accessibility.spec.ts` |
+| API wrapper / endpoint-shape changes | `api-integration.spec.ts` |
+| broad layout or CSS visual changes | `visual.spec.ts` |
+
+## Two gates, two purposes
+
+- **`/unslop`** — routine post-implementation polish. Targeted tests + `code-reviewer` + `unslop-reviewer`.
+- **`/verify-and-polish`** — full gate before milestones / refactors / schema changes. `/verify-suite` (full pytest + Chromium E2E) + `code-reviewer` + `unslop-reviewer`.
+
+Both end with `/handover` to record what shipped.
+
+## Known exceptions to treat as pre-existing
+
+Current full-suite baseline (2026-05-10):
+- `e2e/nav-dropdown.spec.ts:117` — dark-mode toggle off-viewport at 1440 width; current known red.
+- `e2e/program-backup.spec.ts:79` — historical DB-state-pollution flake; passed in the 2026-05-10 full run and passes in isolation.
+
+If the nav-dropdown failure is the only red, do not block unrelated work on it; note it in the handover entry. Treat any reappearance of the program-backup flake as known but record whether it passes in isolation.

--- a/docs/ai_workflow/WORKSTREAM_OWNERSHIP.md
+++ b/docs/ai_workflow/WORKSTREAM_OWNERSHIP.md
@@ -1,0 +1,51 @@
+# Workstream Ownership
+
+*Advisory path-claim rules for parallel Claude instances. Solo dev — claims are coordination hints, not enforced. Implements [`.claude/SHARED_PLAN.md`](../../.claude/SHARED_PLAN.md) Appendix A2.1.*
+
+## Where live claims go
+
+**Do not put live claims in this file.** This committed doc is rules + template only; live ownership rows would create merge churn on every claim/release.
+
+Put live claims in one of:
+- `MASTER_HANDOVER.local.md` — append a claim block under the current session entry (gitignored).
+- `WORKSTREAM_OWNERSHIP.local.md` — gitignored sibling of this file, dedicated to claims (see [`.gitignore`](../../.gitignore)).
+
+## Active claims (template)
+
+Copy this block into your local file, fill in the rows, delete rows when done.
+
+```markdown
+## Active claims
+| Path glob | Workstream | Owner instance | Worktree | Started |
+|---|---|---|---|---|
+| `routes/workout_plan.py`, `templates/workout_plan.html` | fatigue badge slot | claude-A | Hypertrophy-Toolbox-v3-fatigue-badge | 2026-05-11 14:00 |
+```
+
+## Rules
+
+1. Before editing files matching a claimed glob, check the local claim file in the worktree(s) you know about.
+2. If you must edit a claimed path, note it in `MASTER_HANDOVER.local.md` and coordinate — rebase, pair, or wait.
+3. Release a claim by deleting the row from the local file (nothing to commit).
+4. **Never-claimed shared paths** (coordinate per-edit, not via claims):
+   - `app.py`
+   - root [`CLAUDE.md`](../../CLAUDE.md) and any folder-level `CLAUDE.md`
+   - [`.claude/settings.json`](../../.claude/settings.json), [`.claude/SHARED_PLAN.md`](../../.claude/SHARED_PLAN.md)
+   - [`docs/MASTER_HANDOVER.md`](../MASTER_HANDOVER.md)
+   - [`.gitignore`](../../.gitignore)
+5. **Per-worktree, never shared** (do not claim — they are isolated by construction):
+   - `data/database.db` and its `-wal` / `-shm` sidecars
+   - `data/auto_backup/`
+   - `MASTER_HANDOVER.local.md`
+   - `.venv/`
+
+## Claim granularity
+
+- Prefer file globs over folder-level claims. `routes/workout_plan.py` is a claim; `routes/**` is a foot-gun.
+- A single workstream can hold multiple claims — list them as separate rows.
+- Reviewer-only edits (proofreading, comments) don't need a claim; coordinate verbally.
+
+## See also
+
+- [PARALLEL_WORKFLOW.md](PARALLEL_WORKFLOW.md) — when to fork, DB isolation rule.
+- [`.claude/commands/worktree.md`](../../.claude/commands/worktree.md) — how to fork.
+- `MASTER_HANDOVER.local.md` — preferred home for live claims.

--- a/e2e/CLAUDE.md
+++ b/e2e/CLAUDE.md
@@ -1,0 +1,38 @@
+# e2e/ — Orientation
+
+## Purpose
+Playwright Chromium specs covering UI flows end-to-end. `playwright.config.ts` auto-starts Flask via `.venv/Scripts/python.exe app.py` on port 5000; serial execution (`fullyParallel: false`).
+
+## Key files
+| File | Coverage |
+|---|---|
+| `fixtures.ts` | Shared `test` fixture (console-error collector), `ROUTES`, `API_ENDPOINTS`, `SELECTORS`, `waitForPageReady()`, `expectToast()` |
+| `fixtures/database.visual.seed.db` | Seed DB used by visual specs (committed; whitelisted in `.gitignore`) |
+| `smoke-navigation.spec.ts` | Page loads + nav cycle (no fixtures) |
+| `dark-mode.spec.ts`, `nav-dropdown.spec.ts` | Theme + navbar |
+| `workout-plan.spec.ts`, `workout-log.spec.ts` | Plan/log CRUD |
+| `summary-pages.spec.ts`, `progression.spec.ts`, `volume-splitter.spec.ts` | Analyze + progress + distribute |
+| `program-backup.spec.ts`, `user-profile.spec.ts` | Backup modal, profile questionnaire |
+| `exercise-interactions.spec.ts`, `superset-edge-cases.spec.ts`, `replace-exercise-errors.spec.ts` | Per-row actions |
+| `validation-boundary.spec.ts`, `error-handling.spec.ts`, `empty-states.spec.ts`, `accessibility.spec.ts` | Edge & a11y |
+| `api-integration.spec.ts` | All API endpoints |
+| `visual.spec.ts`, `volume-progress.spec.ts`, `fatigue-stage4-smokes.spec.ts` | Visual snapshots + recent feature smokes |
+
+Full per-spec test count map: `.claude/rules/testing.md`.
+
+## Conventions
+- Reuse the `test` fixture from `fixtures.ts` — it fails specs that emit console errors.
+- Reference routes via `ROUTES.X`, selectors via `SELECTORS.X` — keeps locators centralized.
+- `npx playwright test --project=chromium --reporter=line` — Chromium only; Firefox/WebKit are not configured.
+- `PW_REUSE_SERVER=1` reuses an already-running Flask process.
+
+## Gotchas
+- **Known current red (out-of-scope)**: `nav-dropdown.spec.ts:117` — dark-mode toggle off-viewport at 1440 width. Do not "fix" this without an explicit task.
+- **Known historical flake**: `program-backup.spec.ts:79` — sequential DB-pollution flake observed in earlier full runs; it passed in the 2026-05-10 full run and passes in isolation.
+- Visual snapshot regressions need an intentional re-baseline. Don't blanket-`--update-snapshots`.
+- Chromium is the only configured project (`playwright.config.ts`).
+
+## See also
+- `.claude/rules/testing.md` — spec inventory + baselines
+- `/run-e2e` skill (full or single spec) and `/verify-suite` skill (full gate)
+- [docs/E2E_TESTING.md](../docs/E2E_TESTING.md)

--- a/routes/CLAUDE.md
+++ b/routes/CLAUDE.md
@@ -1,0 +1,36 @@
+# routes/ — Orientation
+
+## Purpose
+HTTP layer. Each file is one Flask blueprint that validates input, calls `utils/`, and returns a response. No business logic, no direct DB access — those live in `utils/`.
+
+## Key files
+| File | Blueprint / route |
+|---|---|
+| `main.py` | `main_bp` — `GET /` (welcome) |
+| `workout_plan.py` | `workout_plan_bp` — plan CRUD, starter generator, replace-exercise |
+| `workout_log.py` | `workout_log_bp` — log table + updates |
+| `weekly_summary.py` | `weekly_summary_bp` — `/weekly_summary`, `/api/pattern_coverage` |
+| `session_summary.py` | `session_summary_bp` — `/session_summary` |
+| `progression_plan.py` | `progression_plan_bp` — double-progression page + goals |
+| `volume_splitter.py` | `volume_splitter_bp` — split-allocator UI + API |
+| `user_profile.py` | `user_profile_bp` — reference lifts + estimate API |
+| `program_backup.py` | `program_backup_bp` — `/api/backups` snapshot/restore |
+| `filters.py` | `filters_bp` — `/api/exercises`, `/api/available_filters` (column whitelist lives here) |
+| `exports.py` | `exports_bp` — CSV export |
+
+`POST /erase-data` is a direct route in `app.py:130`, not a blueprint.
+
+## Conventions
+- All JSON returns via `success_response()` / `error_response()` from `utils/errors.py`.
+- New blueprints register in **three** places: `routes/X.py`, `app.py`, `tests/conftest.py` (fixture). Missing the third = 404 in tests.
+- Logger: `from utils.logger import get_logger` then `logger = get_logger()`. Never `print()`.
+- Dynamic column names must pass `validate_column_name()` in `filters.py:147` before SQL interpolation.
+
+## Gotchas
+- **Latent SQLi risk**: `utils/filter_cache.py:85` interpolates column/table names. Only `warm_cache()` calls it today; any new caller must pre-validate.
+- **Known response-contract exceptions** (legacy, do not propagate): `weekly_summary.py:133,139` and `workout_plan.py:1079,1093,1114,1125`.
+- No auth — single-user local. Do not expose to untrusted networks.
+
+## See also
+- `.claude/rules/routes.md` — endpoint template, response contract, filter/SQL detail
+- root [CLAUDE.md](../CLAUDE.md) §2 (architecture) and §5 (current risks)

--- a/scripts/new-worktree.ps1
+++ b/scripts/new-worktree.ps1
@@ -1,0 +1,163 @@
+<#
+.SYNOPSIS
+    Create a git worktree with isolated SQLite state for parallel agent work.
+
+.DESCRIPTION
+    Each worktree gets its own data/database.db so concurrent SQLite WAL writes
+    cannot corrupt the main checkout. See docs/ai_workflow/PARALLEL_WORKFLOW.md
+    for the full rationale and `.claude/commands/worktree.md` for invocation tips.
+
+.PARAMETER Task
+    Short task slug. Becomes the worktree dir suffix and the branch suffix.
+    Example: "fatigue-fix" -> ..\Hypertrophy-Toolbox-v3-fatigue-fix
+             on branch wt/fatigue-fix.
+
+.PARAMETER Seed
+    DB seed mode:
+      visual       (default) copy e2e/fixtures/database.visual.seed.db
+      empty        leave data/database.db absent; app.py will initialize on launch
+      copy-current copy the current checkout's data/database.db if it exists
+
+.PARAMETER BranchPrefix
+    Branch name prefix. Default 'wt/'. Pass '' to disable.
+
+.PARAMETER OpenTerminal
+    If set, opens a new Windows Terminal tab in the new worktree via wt.exe.
+
+.EXAMPLE
+    .\scripts\new-worktree.ps1 -Task fatigue-fix
+    .\scripts\new-worktree.ps1 -Task experiment -Seed empty -OpenTerminal
+#>
+param(
+    [Parameter(Mandatory = $true)]
+    [string] $Task,
+
+    [ValidateSet("visual", "empty", "copy-current")]
+    [string] $Seed = "visual",
+
+    [string] $BranchPrefix = "wt/",
+
+    [switch] $OpenTerminal
+)
+
+$ErrorActionPreference = "Stop"
+[Console]::OutputEncoding = [System.Text.Encoding]::UTF8
+
+$RepoRoot = Resolve-Path (Join-Path $PSScriptRoot "..")
+$RepoName = Split-Path -Leaf $RepoRoot
+
+$Slug = ($Task -replace '[^A-Za-z0-9._-]+', '-').Trim('-')
+if (-not $Slug) {
+    throw "Task slug is empty after sanitization. Pass -Task <something>."
+}
+if ($Slug -match '\.\.' -or $Slug.StartsWith('.')) {
+    throw "Task slug '$Slug' must not contain '..' or start with '.' (path-traversal and invalid-ref safety)."
+}
+
+$WorktreePath = Join-Path (Split-Path -Parent $RepoRoot) ("$RepoName-$Slug")
+$BranchName   = "$BranchPrefix$Slug"
+
+if (Test-Path $WorktreePath) {
+    throw "Worktree path already exists: $WorktreePath"
+}
+
+$null = git -C $RepoRoot rev-parse --verify --quiet HEAD 2>$null
+if ($LASTEXITCODE -ne 0) {
+    throw "Cannot resolve HEAD in $RepoRoot."
+}
+
+$null = git -C $RepoRoot check-ref-format --branch $BranchName 2>$null
+if ($LASTEXITCODE -ne 0) {
+    throw "Invalid branch name '$BranchName' (rejected by git check-ref-format). Pick a different -Task."
+}
+
+$null = git -C $RepoRoot rev-parse --verify --quiet "refs/heads/$BranchName" 2>$null
+if ($LASTEXITCODE -eq 0) {
+    throw "Branch '$BranchName' already exists. Pass a different -Task or delete it first."
+}
+
+Write-Host "Source HEAD:"
+git -C $RepoRoot log -1 --oneline
+Write-Host ""
+Write-Host "Creating worktree at $WorktreePath on new branch $BranchName ..."
+
+git -C $RepoRoot worktree add -b $BranchName $WorktreePath HEAD
+if ($LASTEXITCODE -ne 0) {
+    throw "git worktree add failed (exit $LASTEXITCODE)."
+}
+
+$DataDir   = Join-Path $WorktreePath "data"
+$BackupDir = Join-Path $DataDir "auto_backup"
+New-Item -ItemType Directory -Force -Path $DataDir, $BackupDir | Out-Null
+
+$TargetDb = Join-Path $DataDir "database.db"
+
+# If data/database.db is tracked in this repo, `git worktree add` already wrote
+# HEAD's copy at $TargetDb. Without --skip-worktree, seeding overwrites it and
+# leaves the new worktree dirty, which blocks `git worktree remove` and makes
+# the binary DB commit-bait. Mark it skip-worktree in the new worktree only.
+$DbIsTracked = $false
+$null = git -C $WorktreePath ls-files --error-unmatch "data/database.db" 2>$null
+if ($LASTEXITCODE -eq 0) {
+    $DbIsTracked = $true
+    git -C $WorktreePath update-index --skip-worktree "data/database.db" | Out-Null
+    Write-Host "data/database.db is tracked in this repo; applied --skip-worktree in the new worktree so seeding stays out of the index."
+}
+
+switch ($Seed) {
+    "visual" {
+        $Fixture = Join-Path $RepoRoot "e2e\fixtures\database.visual.seed.db"
+        if (Test-Path $Fixture) {
+            Copy-Item -LiteralPath $Fixture -Destination $TargetDb -Force
+            Write-Host "Seeded $TargetDb from visual fixture."
+        }
+        else {
+            $Fallback = if ($DbIsTracked) { "leaving the tracked HEAD copy in place" } else { "no DB present; app.py will initialize on first run" }
+            Write-Warning "Visual fixture not found at $Fixture. $Fallback."
+        }
+    }
+    "empty" {
+        if (Test-Path $TargetDb) {
+            Remove-Item -LiteralPath $TargetDb -Force
+            Write-Host "Empty seed mode: removed checked-out $TargetDb. app.py will initialize on first run."
+        }
+        else {
+            Write-Host "Empty seed mode: $TargetDb absent. app.py will initialize on first run."
+        }
+    }
+    "copy-current" {
+        $Source = Join-Path $RepoRoot "data\database.db"
+        if (Test-Path $Source) {
+            Copy-Item -LiteralPath $Source -Destination $TargetDb -Force
+            Write-Host "Seeded $TargetDb by copying current checkout's data/database.db."
+            Write-Warning "WAL/SHM sidecars were NOT copied. Stop the source app before relying on this seed."
+        }
+        else {
+            $Fallback = if ($DbIsTracked) { "leaving the tracked HEAD copy in place" } else { "no DB present; app.py will initialize on first run" }
+            Write-Warning "Source data/database.db not found at $Source. $Fallback."
+        }
+    }
+}
+
+Write-Host ""
+Write-Host "Worktree ready: $WorktreePath"
+Write-Host "  branch: $BranchName"
+Write-Host "  seed:   $Seed"
+Write-Host ""
+Write-Host "Next steps:"
+Write-Host "  1. cd '$WorktreePath'"
+Write-Host "  2. Provision a Python env. Either:"
+Write-Host "       python -m venv .venv  (then pip install -r requirements.txt)"
+Write-Host "     or symlink: New-Item -ItemType SymbolicLink -Path .venv -Target '$RepoRoot\.venv'"
+Write-Host "  3. Read docs/ai_workflow/PARALLEL_WORKFLOW.md before parallel work."
+
+if ($OpenTerminal) {
+    $Wt = Get-Command wt.exe -ErrorAction SilentlyContinue
+    if ($Wt) {
+        Start-Process wt.exe -ArgumentList @("-w", "0", "nt", "-d", $WorktreePath) | Out-Null
+        Write-Host "Opened new Windows Terminal tab in $WorktreePath."
+    }
+    else {
+        Write-Warning "wt.exe not found on PATH; cannot open new terminal tab."
+    }
+}

--- a/static/js/CLAUDE.md
+++ b/static/js/CLAUDE.md
@@ -1,0 +1,38 @@
+# static/js/ — Orientation
+
+## Purpose
+Vanilla ES6 modules, no framework. `modules/` holds feature-scoped modules; the flat files are page-level entry points or shared utilities.
+
+## Key files
+| File | Role |
+|---|---|
+| `app.js` | Top-level entry hooked from `base.html` |
+| `darkMode.js` | Theme toggle + `localStorage` persistence |
+| `accessibility.js` | Skip-links, keyboard helpers |
+| `populateRoutines.js` | Routine cascade entry |
+| `table-responsiveness.js` | Mobile table re-layout |
+| `modules/fetch-wrapper.js` | **API client.** Exports `apiFetch` (low-level) and `api` (convenience) |
+| `modules/toast.js` | `showToast()` notifications |
+| `modules/navbar.js`, `modules/navbar-enhancements.js` | Nav UI |
+| `modules/workout-plan.js`, `modules/workout-plan-events.js`, `modules/workout-dropdowns.js`, `modules/exercises.js`, `modules/filters.js`, `modules/filter-view-mode.js`, `modules/routine-cascade.js` | Plan-builder pieces |
+| `modules/workout-log.js` | Log page |
+| `modules/summary.js`, `modules/charts.js` | Weekly/session analyzers |
+| `modules/progression-plan.js` | Progression page |
+| `modules/volume-splitter.js`, `modules/plan_volume_panel.js` | Distribute |
+| `modules/user-profile.js`, `modules/bodymap-svg.js`, `modules/muscle-selector.js` | Profile + body map |
+| `modules/program-backup.js`, `modules/backup-center.js` | Backups |
+| `modules/exports.js`, `modules/validation.js`, `modules/ui-handlers.js`, `modules/workout-controls-animation.js` | Cross-cutting |
+
+## Conventions
+- All JSON calls go through `apiFetch` / `api` from `fetch-wrapper.js` — they normalize the `{ok, status, data, error}` shape and unify error handling. Do **not** call raw `fetch()` for app endpoints.
+- User-facing notifications via `showToast()` from `toast.js`.
+- Modules are loaded with `<script type="module">` from templates; export named symbols, not defaults.
+- Dark-mode behavior is centralized — search `dark-mode` references before adding new theme code.
+
+## Gotchas
+- New CSS belongs in an existing global or route bundle (`.claude/rules/frontend.md`), not a new `styles_*.css`.
+- The `static/bodymaps/GPT/` directory is gitignored scratch — don't commit reference output there.
+
+## See also
+- `.claude/rules/frontend.md` — bundle ownership, SCSS build
+- `templates/CLAUDE.md` — which template loads which module

--- a/templates/CLAUDE.md
+++ b/templates/CLAUDE.md
@@ -1,0 +1,35 @@
+# templates/ — Orientation
+
+## Purpose
+Server-rendered Jinja templates. Every user-facing page extends `base.html`; partials are prefixed with `_`.
+
+## Key files
+| File | Role |
+|---|---|
+| `base.html` | Master layout: navbar, 8 global CSS bundles, dark-mode toggle, body block |
+| `welcome.html` | `/` landing |
+| `workout_plan.html` | Plan builder + filter sidebar |
+| `workout_log.html` | Log table + import-from-plan |
+| `weekly_summary.html`, `session_summary.html` | Volume analyzers (Effective vs Raw) |
+| `progression_plan.html` | Double-progression page + goals |
+| `volume_splitter.html` | Slider-based weekly allocator |
+| `user_profile.html` | Reference-lifts questionnaire + bodymap |
+| `backup.html` | `/api/backups` UI |
+| `error.html` | Generic error page |
+| `_fatigue_badge.html` | Reusable fatigue partial included from summary pages |
+
+## Conventions
+- All pages start with `{% extends "base.html" %}`. Add nav links in `base.html` navbar block.
+- **8 global CSS bundles** are loaded by `base.html`; **8 route bundles** are loaded by individual templates. Do **not** add new runtime `styles_*.css` files or per-feature `<link>` tags — extend the matching bundle.
+- Use `{{ url_for('static', filename='...') }}` for asset URLs and `{{ url_for('blueprint.endpoint') }}` for route URLs.
+- Load JS as ES6 modules: `<script type="module" src="{{ url_for('static', filename='js/modules/X.js') }}"></script>`.
+
+## Gotchas
+- Nav flow is canonical: Plan → Log → Analyze → Progress → Distribute. New pages slot into this order in `base.html`.
+- Dark-mode classes are toggled by the shared dark-mode JS module + `theme-dark.css`. Do not add inline theme styling.
+- API responses are normalized via `static/js/modules/fetch-wrapper.js` — don't roll your own JSON-shape handling in inline scripts.
+
+## See also
+- `.claude/rules/frontend.md` — bundle inventory, JS module pattern, SCSS build
+- [docs/CSS_OWNERSHIP_MAP.md](../docs/CSS_OWNERSHIP_MAP.md) — which bundle owns which selectors
+- `static/js/CLAUDE.md` — JS module orientation

--- a/tests/CLAUDE.md
+++ b/tests/CLAUDE.md
@@ -1,0 +1,40 @@
+# tests/ — Orientation
+
+## Purpose
+Pytest suite covering routes, utils, and integration paths. Each test gets a unique tmp SQLite DB via the `app` / `client` fixtures — never hits the live `data/database.db`.
+
+## Key files
+| File | Role |
+|---|---|
+| `conftest.py` | Fixture hierarchy (see below) and blueprint registration for the test app |
+| `test_<route>.py` | Per-route HTTP tests (e.g. `test_workout_plan_routes.py`) |
+| `test_<util>.py` | Per-module unit tests (e.g. `test_effective_sets.py`, `test_fatigue.py`) |
+| `test_priority0_*.py` | Cross-cutting contract / FK / filter tests |
+| `test_harness_isolation.py` | Verifies the test fixtures themselves isolate DB state |
+
+## Fixture hierarchy (`conftest.py`)
+```
+test_db_path (function)         — unique tmp_path SQLite per test
+  app (function)                — Flask app + fresh schema, all blueprints
+    client (function)           — test client bound to the same DB
+    db_handler (function)       — DatabaseHandler at the same DB
+      clean_db (function)       — DELETEs rows, preserves tables
+        exercise_factory        — INSERTs into exercises
+        workout_plan_factory    — needs exercise
+        workout_log_factory     — needs plan
+```
+
+## Conventions
+- Patch DB path by **assignment**, not import: `import utils.config; utils.config.DB_FILE = test_db_path`. `DatabaseHandler.__init__` reads `utils.config.DB_FILE` at call time (`database.py:209`).
+- Use the shared `app` / `client` / `db_handler` fixtures unless you need a specialized setup.
+- New blueprint? Register in **both** `app.py` and `conftest.py`'s `app` fixture.
+- New table? Call its creator in `conftest.py`'s `app` fixture and `erase_data()` inner function (see `.claude/rules/database.md`).
+
+## Gotchas
+- `pytest` not found → use `.venv/Scripts/python.exe -m pytest` (system Python lacks deps).
+- `no such table` → bypassed conftest init; use the shared fixtures.
+- `FK constraint failed` → call `exercise_factory` before `workout_plan_factory` before `workout_log_factory`.
+
+## See also
+- `.claude/rules/testing.md` — full E2E map, baselines, fixture detail
+- `/run-tests` skill (full or scoped) and `/verify-suite` skill (full gate)

--- a/utils/CLAUDE.md
+++ b/utils/CLAUDE.md
@@ -1,0 +1,29 @@
+# utils/ — Orientation
+
+## Purpose
+All business logic and DB access. Routes call into here; nothing in here imports from `routes/`. Each module owns one concern.
+
+## Key files (by concern)
+| Concern | Files |
+|---|---|
+| **DB / persistence** | `database.py` (DatabaseHandler), `db_initializer.py` (schema), `config.py` (env), `auto_backup.py`, `program_backup.py` |
+| **Calculation engines** | `effective_sets.py`, `weekly_summary.py`, `session_summary.py`, `progression_plan.py`, `volume_classifier.py`, `volume_taxonomy.py`, `volume_progress.py`, `volume_export.py`, `volume_ai.py`, `fatigue.py`, `fatigue_data.py` |
+| **Filters & catalogs** | `filter_predicates.py`, `filter_cache.py`, `normalization.py`, `constants.py`, `movement_patterns.py` |
+| **Domain helpers** | `workout_log.py`, `user_selection.py`, `exercise_manager.py`, `plan_generator.py`, `profile_estimator.py` |
+| **Infra** | `logger.py`, `errors.py`, `request_id.py`, `maintenance.py`, `export_utils.py` |
+
+## Conventions
+- DB access via `with DatabaseHandler() as db:` only (`database.py:200`). No `sqlite3.connect()` calls.
+- Logger via `get_logger()` (`logger.py:121`). Never `print()` or a custom logger.
+- Normalize before persisting: `normalize_muscle()`, `normalize_equipment()`, etc. from `normalization.py`.
+- `utils/__init__.py` is **not** an authoritative facade for new code — import the concrete module (`from utils.db_initializer import ...`).
+
+## Gotchas
+- **Effective sets are informational only** (`effective_sets.py:6-7`). Never auto-adjust or block user actions on them.
+- **FLASK_DEBUG default mismatch**: `app.py:259` defaults `'0'`, `database.py:90` defaults `'1'`. Result: `python app.py` runs Flask non-debug but DB uses DELETE-journal/FULL-sync (safe).
+- `session_summary.py` imports `STATUS_MAP` from `weekly_summary.py` — not duplicates; per-session vs cross-routine weekly aggregation.
+
+## See also
+- `.claude/rules/database.md` — schema table, DatabaseHandler pattern, adding a table
+- `.claude/rules/debugging.md` — logging / request-id / typical failures
+- root [CLAUDE.md](../CLAUDE.md) §2–§3 (architecture, conventions) and §5 (risks)


### PR DESCRIPTION
## Summary
- Adds `scripts/new-worktree.ps1` to fork a workstream onto its own git worktree with an isolated `data/database.db`, avoiding SQLite WAL collisions under parallel Claude/agent sessions.
- Auto-applies `git update-index --skip-worktree` on the tracked `data/database.db` inside the new worktree so seeded checkouts stay clean and `git worktree remove` succeeds without `--force`.
- Ships the `/worktree` slash command, `PARALLEL_WORKFLOW.md`, and a rules-only `WORKSTREAM_OWNERSHIP.md` (live claims go to gitignored `MASTER_HANDOVER.local.md` or `WORKSTREAM_OWNERSHIP.local.md`).

Implements `.claude/SHARED_PLAN.md` Tier 2.1; reviewed by OPUS + CODEX with all three CODEX-found blockers resolved.

## Test plan
- [x] PowerShell AST parse: clean.
- [x] `-Task "..."`, `-Task ".hidden"`, `-Task "foo..bar"`: all rejected at preflight before `git worktree add`.
- [x] `-Seed visual`: worktree DB byte-identical to `e2e/fixtures/database.visual.seed.db` (SHA-256 `0E1D86D0...30305FB33`).
- [x] Post-create `git status --short --branch` in worktree: clean (only branch line).
- [x] `git ls-files -v -- data/database.db` in worktree: `S` prefix confirms `--skip-worktree`.
- [x] `git worktree remove` succeeds **without** `--force`.
- [x] `-Seed empty`: removes the checked-out tracked DB; teardown clean.
- [x] `-Seed copy-current`: warns about uncopied WAL/SHM sidecars; teardown clean.
- [x] No leftover throwaway `wt/*` branches or worktrees.
- [ ] CI (pip-audit / flake8 / pytest) — non-functional for these files but expected green.