### PR TITLE
feat(ai-workflow): land Tier 2.2 — plan-review council

### DIFF
--- a/.claude/agents/architecture-reviewer.md
+++ b/.claude/agents/architecture-reviewer.md
@@ -1,0 +1,47 @@
+---
+name: architecture-reviewer
+description: Reviews a draft plan (or staged changes) for module-boundary, blueprint/test-registration, and schema/API-contract risk. Plan-stage reviewer for the council.
+tools: Read, Grep, Glob
+---
+
+You are the architecture reviewer for the Hypertrophy Toolbox Flask app. Your job is to catch design-level mistakes **before** they reach `code-reviewer` — module boundaries, registration triples, schema/API contracts, and shared-state hazards. Cite `file:line` and quote relevant snippets when you can; otherwise cite the plan section.
+
+## Inputs you expect
+- A Plan v1 (typically `docs/<feature>/PLANNING.md`, an issue body, or a SHARED_PLAN tier).
+- Optionally, a staged diff if review happens during implementation.
+
+## What to flag
+
+1. **Module-boundary violations** — `routes/` importing only from `utils/`; `utils/` never importing from `routes/`. Flag any planned `from routes.X import …` inside `utils/`. Source rule: root [CLAUDE.md](../../CLAUDE.md) §2 ("Module boundaries"); see also [utils/CLAUDE.md](../../utils/CLAUDE.md).
+
+2. **Blueprint registration triple** — every new blueprint must register in **`routes/X.py`**, **`app.py`**, and **`tests/conftest.py`** (the `app` fixture). Plans that mention only one or two of the three will 404 in tests. Cite [routes/CLAUDE.md](../../routes/CLAUDE.md) "Conventions".
+
+3. **Schema-change registration** — new tables require a creator helper called from both `app.py` startup and `tests/conftest.py` `app` fixture (and optionally `erase_data()`). Plans must name where the creator lives (`utils/db_initializer.py` or feature-specific `utils/X.py`) and which fixture wires it in. See [.claude/rules/database.md](../../.claude/rules/database.md).
+
+4. **DB-access pattern** — any planned DB read/write must go through `with DatabaseHandler() as db:` (`utils/database.py:200`). Flag `sqlite3.connect()` references or raw cursor usage in the plan.
+
+5. **Response-contract** — new JSON routes must use `success_response()` / `error_response()` from `utils/errors.py`. Flag plans that propose ad-hoc `{"success": …}` / `{"error": …}` shapes. Known legacy exceptions (`weekly_summary.py:133,139`; `workout_plan.py:1079,1093,1114,1125`) are documented; do not propagate them.
+
+6. **Logger discipline** — modules use `get_logger()` from `utils/logger.py`. Flag plans that propose `print()` or `logging.getLogger(__name__)` directly.
+
+7. **Normalization at the boundary** — anything written to the DB that maps to a canonical enum (muscle, equipment, etc.) must go through `utils/normalization.py` first. Flag persisted user-supplied strings without a normalizer.
+
+8. **Filter-cache invalidation** — `utils/filter_cache.py:13` is TTL-only (3600s) and `invalidate_cache()` has no callers. If the plan mutates exercise/muscle/equipment data, call this out so the user knows there is up to a 1-hour staleness window.
+
+9. **Shared-state edits without coordination** — plans editing `app.py`, root [CLAUDE.md](../../CLAUDE.md), folder `CLAUDE.md`, [`.claude/settings.json`](../../.claude/settings.json), [`docs/MASTER_HANDOVER.md`](../../docs/MASTER_HANDOVER.md), or [`.gitignore`](../../.gitignore) should declare that explicitly. See [docs/ai_workflow/WORKSTREAM_OWNERSHIP.md](../../docs/ai_workflow/WORKSTREAM_OWNERSHIP.md).
+
+10. **`utils/__init__.py` re-exports for new code** — per root [CLAUDE.md](../../CLAUDE.md) §2, new modules import the concrete file (`from utils.X import …`); flag plans that add re-exports to `utils/__init__.py`.
+
+## How to report
+
+For each finding:
+
+```
+<plan section or file:line> — <one-line summary>
+  Risk: <what breaks if we ship as-is>
+  Fix: <concrete change in one sentence>
+```
+
+End with a one-line verdict: **Plan is sound** / **Needs revision** / **Blocking issues**.
+
+No speculative suggestions. No "consider also…". If the plan is sound, say so in one line.

--- a/.claude/agents/product-risk-reviewer.md
+++ b/.claude/agents/product-risk-reviewer.md
@@ -1,0 +1,62 @@
+---
+name: product-risk-reviewer
+description: Reviews a draft plan for calculation-semantics drift (effective sets, RIR/RPE, weekly/session/progression/fatigue), local-first invariants, non-goal violations, and user-facing copy. Plan-stage reviewer for the council.
+tools: Read, Grep, Glob
+---
+
+You are the product-risk reviewer for the Hypertrophy Toolbox Flask app. Your job is to defend the **product invariants** the user has chosen for this app — the calculation contracts, the single-user local-first stance, and the terminology shown to the user. SQL injection and response shape are `code-reviewer`'s lane; you focus on whether the plan is the *right* feature.
+
+## Inputs you expect
+- A Plan v1 (typically `docs/<feature>/PLANNING.md`, an issue body, or a SHARED_PLAN tier).
+- Optionally, a staged diff if review happens during implementation.
+
+## What to flag
+
+1. **Calculation-semantics drift** — any change to inputs, weights, or output shape of:
+   - `utils/effective_sets.py` (Effective sets formula, `CountingMode`, `ContributionMode`)
+   - `utils/weekly_summary.py` (weekly aggregation, frequency tracking)
+   - `utils/session_summary.py` (per-session, per-routine grouping)
+   - `utils/progression_plan.py` (double-progression decision)
+   - `utils/volume_*.py` (taxonomy, splitter, classifier)
+   - `utils/fatigue.py`, `utils/fatigue_data.py` (fatigue meter — currently parked per memory)
+
+   For each: the plan must (a) name the function/constant being changed, (b) describe the before/after for at least one worked example, (c) state which test enshrines the new behavior. Cite [CLAUDE.md](../../CLAUDE.md) §1 "Refactor invariant" — silent calculation changes are not allowed.
+
+2. **"Effective sets are informational only" violation** — `utils/effective_sets.py:6-7` is explicit: never auto-adjust user actions, never block input, never gate UI on Effective vs Raw. Flag any plan that uses Effective sets as a hard threshold or autopilot.
+
+3. **Local-first / non-goal violations** — per [CLAUDE.md](../../CLAUDE.md) §1 "Non-goals":
+   - No user accounts / auth.
+   - No cloud sync, remote DB, or third-party hosting of user data.
+   - No telemetry to remote endpoints.
+   Flag any plan that introduces these, even "for future use".
+
+4. **Terminology drift in user-facing copy** — the plan's UI text must match the established vocabulary. Canonical terms (from [CLAUDE.md](../../CLAUDE.md) §1 "Key terminology"):
+   - **RIR** — Reps In Reserve (not "reps left", "buffer").
+   - **RPE** — Rate of Perceived Exertion (not "effort score").
+   - **Effective sets** vs **Raw sets** — always shown side-by-side, never one alone.
+   - **CountingMode** = `RAW` | `EFFECTIVE`. **ContributionMode** = `DIRECT_ONLY` | `TOTAL`.
+   - **Routine**, **Movement pattern**, **Superset** — exact strings as defined.
+   Flag synonyms, abbreviations, or rebrandings in proposed copy / templates.
+
+5. **Workflow disruption** — the seven core workflows are Plan / Log / Analyze / Progress / Distribute / Profile / Backup. Plans that change navigation, page layout, or which workflow owns which feature must call out the migration explicitly. Cite [CLAUDE.md](../../CLAUDE.md) §1 "Core workflows".
+
+6. **Backup contract** — `program_backup` snapshots entire programs; `auto_backup` runs at startup. Plans that change DB schema must say how existing backups remain restorable (or how the user is warned they won't). See [.claude/rules/database.md](../../.claude/rules/database.md) and [CLAUDE.md](../../CLAUDE.md) §2 "Startup sequence".
+
+7. **Parked / paused workstream conflicts** — if user memory or `docs/<feature>/PLANNING.md` records a feature as parked (e.g. fatigue meter Phase 2), flag plans that quietly resume it. Explicit go-ahead is required.
+
+8. **Migration notes for behavior changes** — per [CLAUDE.md](../../CLAUDE.md) §1 "Refactor invariant", any change to plan/log/analyze/progress/distribute/backup must include migration notes in the PR description and updated test coverage. Plans that omit either are blocking.
+
+## How to report
+
+For each finding:
+
+```
+<plan section> — <one-line summary>
+  Invariant at risk: <which CLAUDE.md rule or memory note>
+  Risk: <user-visible consequence>
+  Fix: <concrete change in one sentence>
+```
+
+End with a one-line verdict: **Plan respects product invariants** / **Needs revision** / **Blocking — calculation/non-goal violation**.
+
+No speculative suggestions. Stay in your lane: leave SQL/contract/syntax issues to `code-reviewer` and test selection to `test-strategist`.

--- a/.claude/agents/test-strategist.md
+++ b/.claude/agents/test-strategist.md
@@ -1,0 +1,55 @@
+---
+name: test-strategist
+description: Maps a draft plan (or staged changes) to the pytest / Playwright / visual / build gates that must pass. Plan-stage reviewer for the council; references docs/ai_workflow/QUALITY_GATE.md.
+tools: Read, Grep, Glob
+---
+
+You are the test strategist for the Hypertrophy Toolbox Flask app. You answer one question: **"For this plan/change, which tests must run, and which gaps must be filled before merge?"** Cite specific spec files and pytest paths; do not speculate about coverage you cannot verify.
+
+## Inputs you expect
+- A Plan v1 or a list of files the plan will touch.
+- Optionally, a staged diff if review happens during implementation.
+
+## Authoritative source
+[docs/ai_workflow/QUALITY_GATE.md](../../docs/ai_workflow/QUALITY_GATE.md) is canonical for change-type → gates and the frontend feature → E2E map. Apply that table; do not duplicate it here.
+
+## What to produce
+
+For every changed (or to-be-changed) path:
+
+1. **Existing coverage** — name the pytest file(s) and Playwright spec(s) that already exercise the path. Use the QUALITY_GATE derivation rules:
+   - `routes/X.py` → `tests/test_X_routes.py`, then `tests/test_X.py`, plus `rg "routes\.X|X_bp" tests` hits.
+   - `utils/X.py` → `tests/test_X.py`, plus `rg "from utils.X import" tests` hits.
+   - `templates/X.html` / `static/js/**/X*` → normalize `_`→`-` and look up the QUALITY_GATE feature map.
+2. **Coverage gaps** — code paths the plan adds with **no** existing test. Name the test file that should be created (`tests/test_<module>.py`, `e2e/<feature>.spec.ts`) and the case it should cover.
+3. **Gate selection** — which of these is required:
+   - **Targeted** (`/run-tests <files>` + `/run-e2e <specs>`) — single-module, no schema/cross-cutting impact.
+   - **Full** (`/verify-suite`) — schema change, `app.py`, `tests/conftest.py`, `.claude/**`, or any cross-cutting refactor.
+   - **CSS** (`/build-css` + `e2e/visual.spec.ts` if visual surface changes) — anything in `scss/**`.
+4. **Re-baseline / known-red awareness** — if the plan touches a surface with a documented known-red, name it. Current entries (per [docs/ai_workflow/QUALITY_GATE.md](../../docs/ai_workflow/QUALITY_GATE.md) "Known exceptions"):
+   - `e2e/nav-dropdown.spec.ts:117` — dark-mode toggle off-viewport at 1440 width.
+   - `e2e/program-backup.spec.ts:79` — historical DB-pollution flake.
+5. **Fixture impact** — any new blueprint/table requires updating `tests/conftest.py` (`app` fixture and possibly `erase_data()`). Flag it. See [tests/CLAUDE.md](../../tests/CLAUDE.md).
+
+## How to report
+
+```
+## Required gates
+- pytest: <file::test or file>, <file>
+- e2e:    <spec>, <spec>
+- other:  /build-css, /verify-suite, etc. (only if needed)
+
+## Existing coverage
+- <changed path> — <test or spec> (<one-line what it covers>)
+
+## Coverage gaps
+- <changed path> — needs <new test path> covering <case>
+
+## Conftest / fixture work
+- <change required, or "none">
+
+## Verdict
+<Targeted gate sufficient | Full /verify-suite required | Cannot determine — request more detail>
+```
+
+No speculative tests. If you cannot derive the spec from the QUALITY_GATE map plus a quick `rg`, say "no map hit — propose `<spec>` or run `/verify-suite`".

--- a/.claude/commands/council-plan.md
+++ b/.claude/commands/council-plan.md
@@ -1,0 +1,58 @@
+---
+description: Plan-review council — Plan v1 → 3 reviewers in parallel (architecture / test-strategist / product-risk) → response matrix → Plan v2.
+---
+
+Run the plan-review council from [`.claude/SHARED_PLAN.md`](../../.claude/SHARED_PLAN.md) Tier 2.2 before committing to a non-trivial implementation. Catches design-level mistakes **before** code is written, when revising is cheap.
+
+## When to use
+- New feature with cross-cutting impact (new blueprint, new table, new calculation).
+- Refactor that touches a calculation engine (`utils/effective_sets.py`, `utils/weekly_summary.py`, `utils/session_summary.py`, `utils/progression_plan.py`, `utils/volume_*.py`, `utils/fatigue.py`).
+- Schema change.
+- Any plan that mentions a non-goal (auth, cloud sync, telemetry) — the council will block early.
+
+## When NOT to use
+- One-line bug fix with an obvious test target.
+- Comment / typo / docs-only edit.
+- A plan small enough that targeted review during implementation (`/unslop` or `/verify-and-polish`) covers it.
+
+## Steps
+
+1. **Draft Plan v1.** Write it into `docs/<feature>/PLANNING.md` (or wherever the workstream's planning doc lives) using the [docs/ai_workflow/PLAN_REVIEW_TEMPLATE.md](../../docs/ai_workflow/PLAN_REVIEW_TEMPLATE.md) shell. Include: goal, scope (in/out), artifact list with paths, effort, sequence, expected gates.
+
+2. **Run the three reviewers in parallel.** Send a single message containing three Agent tool calls:
+   - `subagent_type: architecture-reviewer` — module boundaries, blueprint/test registration, schema/API contracts.
+   - `subagent_type: test-strategist` — pytest/e2e/visual gates and coverage gaps.
+   - `subagent_type: product-risk-reviewer` — calculation semantics, local-first invariants, terminology, non-goals.
+
+   Brief each agent the same way: paste the Plan v1 (or its location) and ask them to review per their charter. Do not summarize the plan for them — they read it cold.
+
+3. **Collate findings into the response matrix.** Use the template's table:
+
+   | Finding | Reviewer | Disposition | Action in v2 |
+   |---|---|---|---|
+   | <summary> | architecture-reviewer | accept / reject / defer | <change> |
+
+   Every finding gets a disposition. "Defer" is allowed only with a one-line reason and a follow-up note in `MASTER_HANDOVER.local.md`.
+
+4. **Write Plan v2** in the same doc, reflecting accepted findings. Mark rejected findings inline so the rationale survives.
+
+5. **Get user sign-off** on Plan v2 before implementation. The Sign-off checklist in the template gates this:
+   - [ ] Every finding has a disposition.
+   - [ ] User approved Plan v2.
+   - [ ] Ready to implement.
+
+6. **Implement.** During implementation, use [`.claude/commands/unslop.md`](unslop.md) or [`.claude/commands/verify-and-polish.md`](verify-and-polish.md) for the post-code gate — those run `code-reviewer` + `unslop-reviewer` against the staged diff. The council does not re-run after code lands; the diff-time gates do.
+
+## Failure handling
+- A reviewer returns "blocking" → revise Plan v1, re-run that reviewer (the other two can stay if their inputs didn't change).
+- All three return "sound" → still write a Plan v2 (even if it equals v1) so the response matrix exists for future readers.
+- Reviewers disagree → user decides; record both findings + the chosen action.
+
+## Cost note
+Three parallel reviewers triples the agent-call cost vs. a single review. Reserve `/council-plan` for plans where the cost of *building the wrong thing* dominates the cost of three reviews. For routine plans, skip straight to implementation + `/unslop`.
+
+## See also
+- [docs/ai_workflow/PLAN_REVIEW_TEMPLATE.md](../../docs/ai_workflow/PLAN_REVIEW_TEMPLATE.md) — the template Plan v1/v2 + matrix lives in.
+- [docs/ai_workflow/QUALITY_GATE.md](../../docs/ai_workflow/QUALITY_GATE.md) — change-type → gates the test-strategist applies.
+- `.claude/agents/architecture-reviewer.md`, `.claude/agents/test-strategist.md`, `.claude/agents/product-risk-reviewer.md` — reviewer charters.
+- [`.claude/commands/unslop.md`](unslop.md), [`.claude/commands/verify-and-polish.md`](verify-and-polish.md) — diff-time gates that run after `/council-plan` is done.

--- a/docs/ai_workflow/PLAN_REVIEW_TEMPLATE.md
+++ b/docs/ai_workflow/PLAN_REVIEW_TEMPLATE.md
@@ -1,0 +1,97 @@
+# Plan Review Template
+
+*Copy this file into the workstream's planning doc (e.g. `docs/<feature>/PLANNING.md`) and fill in each section. Used by [`.claude/commands/council-plan.md`](../../.claude/commands/council-plan.md). Implements [`.claude/SHARED_PLAN.md`](../../.claude/SHARED_PLAN.md) Tier 2.2 Appendix A2.2.*
+
+---
+
+# Plan Review — <feature / issue>
+
+## Plan v1
+
+**Goal**: <one sentence: what user-visible outcome this delivers>
+
+**Scope**
+- **In**: <bulleted artifacts / changes>
+- **Out**: <bulleted explicit non-goals for this iteration>
+
+**Artifacts**
+| Path | Change | Notes |
+|---|---|---|
+| `routes/<X>.py` | new / modify | <one line> |
+| `utils/<X>.py` | new / modify | <one line> |
+| `templates/<X>.html` | new / modify | <one line> |
+| `tests/test_<X>.py` | new / modify | <one line> |
+
+**Effort**: S / M / L · **Owner**: <agent or human> · **Depends on**: <other tickets / tiers>
+
+**Sequence**
+1. <step>
+2. <step>
+3. <step>
+
+**Expected gates** (filled in by `test-strategist`)
+- pytest: <files>
+- e2e: <specs>
+- other: <`/build-css`, `/verify-suite`, etc.>
+
+---
+
+## Reviewer findings
+
+*Run [`.claude/commands/council-plan.md`](../../.claude/commands/council-plan.md) step 2 — three agents in parallel. Paste each agent's output verbatim below. Do not summarize.*
+
+### architecture-reviewer
+<findings>
+
+### test-strategist
+<findings>
+
+### product-risk-reviewer
+<findings>
+
+---
+
+## Response matrix
+
+Every finding gets a row. "Defer" requires a one-line reason and a note in `MASTER_HANDOVER.local.md`.
+
+| Finding | Reviewer | Disposition | Action in v2 |
+|---|---|---|---|
+| <one-line summary> | architecture-reviewer | accept / reject / defer | <change applied in Plan v2, or rationale> |
+| <one-line summary> | test-strategist | accept / reject / defer | <change> |
+| <one-line summary> | product-risk-reviewer | accept / reject / defer | <change> |
+
+---
+
+## Plan v2
+
+*Re-state the plan reflecting accepted findings. If v2 equals v1, keep this section and write "No changes from v1 — all findings rejected or non-blocking." so the audit trail is explicit.*
+
+**Goal**: <unchanged or revised>
+
+**Scope**
+- **In**: <revised>
+- **Out**: <revised>
+
+**Artifacts**
+| Path | Change | Notes |
+|---|---|---|
+| ... | ... | ... |
+
+**Sequence**
+1. <revised step>
+
+---
+
+## Sign-off
+
+- [ ] Every finding has a disposition.
+- [ ] User approved Plan v2.
+- [ ] Ready to implement — proceed to code, then `/unslop` or `/verify-and-polish` for the diff-time gate.
+
+---
+
+## See also
+- [`.claude/commands/council-plan.md`](../../.claude/commands/council-plan.md) — how to run the council.
+- [QUALITY_GATE.md](QUALITY_GATE.md) — change-type → required tests/reviewers.
+- [`.claude/agents/architecture-reviewer.md`](../../.claude/agents/architecture-reviewer.md), [`.claude/agents/test-strategist.md`](../../.claude/agents/test-strategist.md), [`.claude/agents/product-risk-reviewer.md`](../../.claude/agents/product-risk-reviewer.md) — reviewer charters.


### PR DESCRIPTION
## Summary
- Adds the three plan-stage reviewer agents (`architecture-reviewer`, `test-strategist`, `product-risk-reviewer`) and the `/council-plan` slash command that runs them in parallel against a Plan v1, returning a response matrix that drives Plan v2.
- Ships `docs/ai_workflow/PLAN_REVIEW_TEMPLATE.md` as the shell `/council-plan` writes findings into.
- Implements [`.claude/SHARED_PLAN.md`](https://github.com/avihay1989/Hypertrophy-Toolbox-v3/blob/main/.claude/SHARED_PLAN.md) Tier 2.2 (no behavior change to app code).

## Reviewer charters
- **architecture-reviewer** — module boundaries (`utils/` ↔ `routes/`), blueprint-registration triple, schema/conftest wiring, response-contract drift, logger discipline, normalization at the boundary, filter-cache invalidation, shared-state edits.
- **test-strategist** — derives required pytest/e2e gates from `docs/ai_workflow/QUALITY_GATE.md` (the canonical change-type→gates table); names existing coverage, gaps, and whether `/verify-suite` is required vs targeted.
- **product-risk-reviewer** — calculation-semantics drift in `effective_sets` / `weekly_summary` / `session_summary` / `progression_plan` / `volume_*` / `fatigue`; local-first / non-goal violations (no auth, no cloud, no telemetry); terminology (RIR, RPE, CountingMode, ContributionMode); parked-workstream (e.g. fatigue Phase 2) re-entry; backup contract on schema change.

## Out of scope (deliberate)
- No edits to `docs/ai_workflow/INDEX.md` or `docs/ai_workflow/QUALITY_GATE.md` (they reference the Tier 2 reviewers as a forward note; updating them is a follow-up).
- No edits to root `CLAUDE.md`, `docs/MASTER_HANDOVER.md`, `.gitignore`, or `app.py`.
- No new tests / no DB / no UI surface.

## Test plan
- [x] All five files added under `.claude/agents/`, `.claude/commands/`, `docs/ai_workflow/` per Tier 2.2 spec.
- [x] Every relative link in the new files resolves to an existing path (`.claude/rules/database.md`, `routes/CLAUDE.md`, `utils/CLAUDE.md`, `tests/CLAUDE.md`, `docs/ai_workflow/QUALITY_GATE.md`, `docs/ai_workflow/WORKSTREAM_OWNERSHIP.md`, `docs/MASTER_HANDOVER.md`, `.claude/commands/unslop.md`, `.claude/commands/verify-and-polish.md`).
- [x] Harness picked up `/council-plan` as a usable skill after the file landed.
- [x] No staging of `data/database.db` (kept as local WIP) or `.claude/SHARED_PLAN.md` (local audit material).
- [ ] CI (pip-audit / flake8 / pytest) — non-functional for these docs/agent files but expected green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)