### PR TITLE
docs(ai-workflow): apply CODEX cross-review to Tier 2.2 council

### DIFF
--- a/.claude/agents/architecture-reviewer.md
+++ b/.claude/agents/architecture-reviewer.md
@@ -18,9 +18,9 @@ You are the architecture reviewer for the Hypertrophy Toolbox Flask app. Your jo
 
 3. **Schema-change registration** — new tables require a creator helper called from both `app.py` startup and `tests/conftest.py` `app` fixture (and optionally `erase_data()`). Plans must name where the creator lives (`utils/db_initializer.py` or feature-specific `utils/X.py`) and which fixture wires it in. See [.claude/rules/database.md](../../.claude/rules/database.md).
 
-4. **DB-access pattern** — any planned DB read/write must go through `with DatabaseHandler() as db:` (`utils/database.py:200`). Flag `sqlite3.connect()` references or raw cursor usage in the plan.
+4. **DB-access pattern** — any planned DB read/write must go through `with DatabaseHandler() as db:` (class at `utils/database.py:185`; `__enter__` / `__exit__` at `utils/database.py:414`). Flag `sqlite3.connect()` references or raw cursor usage in the plan.
 
-5. **Response-contract** — new JSON routes must use `success_response()` / `error_response()` from `utils/errors.py`. Flag plans that propose ad-hoc `{"success": …}` / `{"error": …}` shapes. Known legacy exceptions (`weekly_summary.py:133,139`; `workout_plan.py:1079,1093,1114,1125`) are documented; do not propagate them.
+5. **Response-contract** — new JSON routes must use `success_response()` / `error_response()` from `utils/errors.py`. Flag plans that propose ad-hoc `{"success": …}` / `{"error": …}` shapes. Known legacy exceptions (`routes/weekly_summary.py:152,158`; `routes/workout_plan.py:1090,1104,1125,1136`) are documented; do not propagate them.
 
 6. **Logger discipline** — modules use `get_logger()` from `utils/logger.py`. Flag plans that propose `print()` or `logging.getLogger(__name__)` directly.
 

--- a/.claude/agents/test-strategist.md
+++ b/.claude/agents/test-strategist.md
@@ -18,14 +18,15 @@ You are the test strategist for the Hypertrophy Toolbox Flask app. You answer on
 For every changed (or to-be-changed) path:
 
 1. **Existing coverage** — name the pytest file(s) and Playwright spec(s) that already exercise the path. Use the QUALITY_GATE derivation rules:
-   - `routes/X.py` → `tests/test_X_routes.py`, then `tests/test_X.py`, plus `rg "routes\.X|X_bp" tests` hits.
+   - `routes/X.py` → `tests/test_X_routes.py`, then `tests/test_X.py`, plus `rg "routes\.X|X_bp|/route_name" tests` hits.
    - `utils/X.py` → `tests/test_X.py`, plus `rg "from utils.X import" tests` hits.
    - `templates/X.html` / `static/js/**/X*` → normalize `_`→`-` and look up the QUALITY_GATE feature map.
 2. **Coverage gaps** — code paths the plan adds with **no** existing test. Name the test file that should be created (`tests/test_<module>.py`, `e2e/<feature>.spec.ts`) and the case it should cover.
-3. **Gate selection** — which of these is required:
+3. **Gate selection** — which of these is required (see [docs/ai_workflow/QUALITY_GATE.md](../../docs/ai_workflow/QUALITY_GATE.md) for the canonical mapping):
    - **Targeted** (`/run-tests <files>` + `/run-e2e <specs>`) — single-module, no schema/cross-cutting impact.
-   - **Full** (`/verify-suite`) — schema change, `app.py`, `tests/conftest.py`, `.claude/**`, or any cross-cutting refactor.
+   - **Full** (`/verify-suite`) — schema change, `app.py`, `tests/conftest.py`, or any cross-cutting refactor.
    - **CSS** (`/build-css` + `e2e/visual.spec.ts` if visual surface changes) — anything in `scss/**`.
+   - **Manual dry-run / self-review** — `.claude/**`, root `CLAUDE.md`, folder `CLAUDE.md`, `docs/ai_workflow/**`. Run tests only if source behavior changed; otherwise rely on careful self-review.
 4. **Re-baseline / known-red awareness** — if the plan touches a surface with a documented known-red, name it. Current entries (per [docs/ai_workflow/QUALITY_GATE.md](../../docs/ai_workflow/QUALITY_GATE.md) "Known exceptions"):
    - `e2e/nav-dropdown.spec.ts:117` — dark-mode toggle off-viewport at 1440 width.
    - `e2e/program-backup.spec.ts:79` — historical DB-pollution flake.

--- a/.claude/commands/council-plan.md
+++ b/.claude/commands/council-plan.md
@@ -12,7 +12,7 @@ Run the plan-review council from [`.claude/SHARED_PLAN.md`](../../.claude/SHARED
 
 ## When NOT to use
 - One-line bug fix with an obvious test target.
-- Comment / typo / docs-only edit.
+- Comment / typo / product-docs-only edit (i.e. `docs/**` excluding `docs/ai_workflow/**`). Edits to `.claude/**`, root `CLAUDE.md`, folder `CLAUDE.md`, or `docs/ai_workflow/**` are agent config — they change agent behavior and may still warrant the council.
 - A plan small enough that targeted review during implementation (`/unslop` or `/verify-and-polish`) covers it.
 
 ## Steps

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -64,7 +64,7 @@ app.py                 ← startup + middleware only; no business logic
 
 - Routes import from utils; utils never import from routes.
 - Prefer concrete module imports such as `utils.db_initializer`; `utils/__init__.py` is no longer the authoritative facade for new code.
-- All DB access via `DatabaseHandler` context manager (`utils/database.py:200`).
+- All DB access via `DatabaseHandler` context manager (class at `utils/database.py:185`; `__enter__` / `__exit__` at `utils/database.py:414`).
 - All JSON responses via `success_response()` / `error_response()` (`utils/errors.py:22,67`).
 - All logging via `get_logger()` (`utils/logger.py:121`).
 
@@ -181,9 +181,9 @@ npx playwright test --project=chromium --reporter=line
 
 Re-verify after significant changes and update counts above.
 
-### Known response-contract exceptions (2026-04-18)
-- `routes/weekly_summary.py:133,139` — pattern coverage still returns legacy `success`/`error` JSON.
-- `routes/workout_plan.py:1079,1093,1114,1125` — replace-exercise fallback paths return legacy ad-hoc JSON with 200 error payloads.
+### Known response-contract exceptions (2026-05-11)
+- `routes/weekly_summary.py:152,158` — pattern coverage still returns legacy `success`/`error` JSON.
+- `routes/workout_plan.py:1090,1104,1125,1136` — replace-exercise fallback paths return legacy ad-hoc JSON with 200 error payloads.
 
 ### Filter cache: TTL-only invalidation
 `utils/filter_cache.py:13` — TTL 3600s. `invalidate_cache()` exists but is never called from any route. Stale filter options may persist up to 1 hour after exercise data changes.

--- a/docs/ai_workflow/INDEX.md
+++ b/docs/ai_workflow/INDEX.md
@@ -30,8 +30,10 @@
   - [e2e/CLAUDE.md](../../e2e/CLAUDE.md)
   - [templates/CLAUDE.md](../../templates/CLAUDE.md)
   - [static/js/CLAUDE.md](../../static/js/CLAUDE.md)
-- Slash commands: `/handover`, `/unslop`, `/verify-and-polish` (in `.claude/commands/`)
-- Agents: `code-reviewer`, `unslop-reviewer` (in `.claude/agents/`)
+- [Plan Review Template](PLAN_REVIEW_TEMPLATE.md) — Plan v1 → council findings → response matrix → Plan v2 (used by `/council-plan`)
+- Slash commands: `/handover`, `/unslop`, `/verify-and-polish`, `/council-plan` (in `.claude/commands/`)
+- Agents (diff-time): `code-reviewer`, `unslop-reviewer` (in `.claude/agents/`)
+- Agents (plan-time, council): `architecture-reviewer`, `test-strategist`, `product-risk-reviewer` (in `.claude/agents/`)
 
 ## Baselines (gitignored, generated locally)
 - `baseline_pytest.txt`, `baseline_e2e.txt` — last full-suite outputs; not in git

--- a/docs/ai_workflow/PLAN_REVIEW_TEMPLATE.md
+++ b/docs/ai_workflow/PLAN_REVIEW_TEMPLATE.md
@@ -20,7 +20,8 @@
 | `routes/<X>.py` | new / modify | <one line> |
 | `utils/<X>.py` | new / modify | <one line> |
 | `templates/<X>.html` | new / modify | <one line> |
-| `tests/test_<X>.py` | new / modify | <one line> |
+| `tests/test_<X>_routes.py` | new / modify | <route HTTP tests> |
+| `tests/test_<X>.py` | new / modify | <util unit tests> |
 
 **Effort**: S / M / L · **Owner**: <agent or human> · **Depends on**: <other tickets / tiers>
 

--- a/docs/ai_workflow/QUALITY_GATE.md
+++ b/docs/ai_workflow/QUALITY_GATE.md
@@ -6,9 +6,9 @@
 
 | Change type | Path globs | Required gates | Required reviewers |
 |---|---|---|---|
-| Route / API | `routes/**`, `app.py` | route pytest target (`tests/test_<route>_routes.py` or `tests/test_<route>.py`) + blueprint-registration coverage in `tests/conftest.py` | `code-reviewer`; + `product-risk-reviewer` if response shape changes (Tier 2) |
-| DB / schema | `utils/db_initializer.py`, `utils/database.py`, `utils/program_backup.py`, `utils/auto_backup.py` | full `pytest` + manual backup/restore smoke | `code-reviewer` + `architecture-reviewer` (Tier 2) |
-| Business logic | `utils/**.py` (non-DB) | `pytest tests/test_<module>.py` | `code-reviewer`; + `product-risk-reviewer` (Tier 2) if `effective_sets` / `weekly_summary` / `session_summary` / `progression` / `fatigue` touched |
+| Route / API | `routes/**`, `app.py` | route pytest target (`tests/test_<route>_routes.py` or `tests/test_<route>.py`) + blueprint-registration coverage in `tests/conftest.py` | `code-reviewer`; + `product-risk-reviewer` if response shape changes |
+| DB / schema | `utils/db_initializer.py`, `utils/database.py`, `utils/program_backup.py`, `utils/auto_backup.py` | full `pytest` + manual backup/restore smoke | `code-reviewer` + `architecture-reviewer` |
+| Business logic | `utils/**.py` (non-DB) | `pytest tests/test_<module>.py` | `code-reviewer`; + `product-risk-reviewer` if `effective_sets` / `weekly_summary` / `session_summary` / `progression` / `fatigue` touched |
 | Frontend (template) | `templates/**` | matching Chromium specs from the feature map below | none required |
 | Frontend (JS) | `static/js/**` | matching Chromium specs from the feature map below + manual smoke if interactive | none required |
 | CSS | `scss/**` | `/build-css` + `e2e/visual.spec.ts` if visual surface changes | none required |
@@ -16,7 +16,7 @@
 | AI workflow / agent config | `.claude/**`, `CLAUDE.md`, `*/CLAUDE.md`, `docs/ai_workflow/**` | manual dry-run/self-review; run tests only if source behavior changed | `code-reviewer` or careful self-review |
 | Product docs only | `docs/**`, `*.md` excluding AI workflow files above | none unless examples/scripts changed | none |
 
-> **Tier 2 reviewers** (`architecture-reviewer`, `test-strategist`, `product-risk-reviewer`) ship in the next phase of `.claude/SHARED_PLAN.md`. Until they exist, fall back to `code-reviewer` plus a careful self-read.
+> All three Tier 2 reviewers — `architecture-reviewer`, `test-strategist`, `product-risk-reviewer` — are live. Run them at the plan stage via [`/council-plan`](../../.claude/commands/council-plan.md); the table above also names them as code-time reviewers when the relevant change types are touched.
 
 ## Diff collection (used by `/unslop`)
 

--- a/docs/ai_workflow/QUALITY_GATE.md
+++ b/docs/ai_workflow/QUALITY_GATE.md
@@ -16,7 +16,7 @@
 | AI workflow / agent config | `.claude/**`, `CLAUDE.md`, `*/CLAUDE.md`, `docs/ai_workflow/**` | manual dry-run/self-review; run tests only if source behavior changed | `code-reviewer` or careful self-review |
 | Product docs only | `docs/**`, `*.md` excluding AI workflow files above | none unless examples/scripts changed | none |
 
-> All three Tier 2 reviewers — `architecture-reviewer`, `test-strategist`, `product-risk-reviewer` — are live. Run them at the plan stage via [`/council-plan`](../../.claude/commands/council-plan.md); the table above also names them as code-time reviewers when the relevant change types are touched.
+> All three Tier 2 reviewers — `architecture-reviewer`, `test-strategist`, `product-risk-reviewer` — are live. Run them at the plan stage via [`/council-plan`](../../.claude/commands/council-plan.md). The table above also names `architecture-reviewer` and `product-risk-reviewer` as code-time reviewers when the relevant change types are touched; `test-strategist` runs at the plan stage only.
 
 ## Diff collection (used by `/unslop`)
 
@@ -37,7 +37,8 @@ For each changed file:
 - `routes/X.py` → try `tests/test_X_routes.py`, then `tests/test_X.py`, plus any tests found by `rg "routes\.X|X_bp|/route_name" tests`
 - `utils/X.py` → try `tests/test_X.py`, plus any tests found by `rg "utils\.X|from utils.X import" tests`
 - `templates/X.html` or `static/js/**/X*` → normalize underscores to hyphens and use the feature map below
-- `app.py`, `tests/conftest.py`, `.claude/**`, root configs → fall back to `/verify-suite` (cross-cutting)
+- `app.py`, `tests/conftest.py`, root configs → fall back to `/verify-suite` (cross-cutting)
+- `.claude/**`, `CLAUDE.md`, `*/CLAUDE.md`, `docs/ai_workflow/**` → manual dry-run / self-review per the AI workflow / agent config row above; run tests only if source behavior changed
 
 Run the union. If the union is empty, run `/verify-suite`.
 


### PR DESCRIPTION
## Summary
Triage of the 8 findings CODEX raised against PR #17 (Tier 2.2 plan-review council). All accepted; no behavior change to app code.

## Findings → fixes

| # | Finding | Fix file |
|---|---|---|
| 1 | `/council-plan` "When NOT to use" treats `.claude/**` and `docs/ai_workflow/**` as ordinary docs, but they're agent config | `.claude/commands/council-plan.md` |
| 2 | `test-strategist` gate selection sends `.claude/**` to `/verify-suite`, contradicting QUALITY_GATE's manual-dry-run rule | `.claude/agents/test-strategist.md` |
| 3 | QUALITY_GATE forward-references the Tier 2 reviewers as not-yet-shipped even though PR #17 shipped them | `docs/ai_workflow/QUALITY_GATE.md` |
| 4 | INDEX.md lists only the diff-time agents; missing `/council-plan`, the template, and the three plan-time reviewers | `docs/ai_workflow/INDEX.md` |
| 5 | `architecture-reviewer` cites `utils/database.py:200`, which is `execute_query()`, not the context manager (real: class `:185`, `__enter__` `:414`) | `.claude/agents/architecture-reviewer.md` + root `CLAUDE.md` §2 (same stale ref) |
| 6 | `architecture-reviewer` cites stale legacy-response-contract exception lines (real: `routes/weekly_summary.py:152,158` and `routes/workout_plan.py:1090,1104,1125,1136`) | `.claude/agents/architecture-reviewer.md` + root `CLAUDE.md` §5 (same stale list; date stamp also refreshed to 2026-05-11) |
| 7 | `test-strategist` route-coverage derivation dropped QUALITY_GATE's `\|/route_name` URL grep fallback | `.claude/agents/test-strategist.md` |
| 8 | `PLAN_REVIEW_TEMPLATE` artifact example reintroduces narrow `tests/test_<X>.py` pattern; should split route vs util | `docs/ai_workflow/PLAN_REVIEW_TEMPLATE.md` |

7 files changed, 21 insertions, 17 deletions.

## Why root CLAUDE.md is in this PR
Findings #5 and #6 trace back to root `CLAUDE.md` §2 line 67 and §5 lines 185–186 — that file is the canonical source the agent docs were copied from. Fixing only the agent files would leave the root operational guide knowingly stale; CODEX recommended Option A (single follow-up PR), user approved.

## Verification
- All cited line numbers re-grepped against `main@77b29ed` before editing.
- `data/database.db` and `.claude/SHARED_PLAN.md` intentionally not staged.

## Test plan
- [x] All eight CODEX findings have a matching diff hunk.
- [x] `architecture-reviewer.md` and `CLAUDE.md` cite the verified line numbers (`utils/database.py:185`/`:414`; `routes/weekly_summary.py:152,158`; `routes/workout_plan.py:1090,1104,1125,1136`).
- [x] `QUALITY_GATE.md` forward-reference removed; "(Tier 2)" qualifiers dropped.
- [x] `INDEX.md` lists `/council-plan`, `PLAN_REVIEW_TEMPLATE.md`, and the three plan-time reviewers.
- [ ] CI (pip-audit / flake8 / pytest) — non-functional change; expected green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)