### PR TITLE
test(workout-cool §4.6): visual-baseline thumbnail spec + seed

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -52,6 +52,7 @@ test-results/
 playwright-report/
 debug/
 /artifacts/
+e2e/artifacts/
 /baseline*.txt
 /phase*.txt
 /cleanup*.txt

--- a/e2e/visual-baseline-thumbnails.spec.ts
+++ b/e2e/visual-baseline-thumbnails.spec.ts
@@ -1,0 +1,143 @@
+/**
+ * §4 visual-baseline sweep for free-exercise-db thumbnails.
+ *
+ * Validates rendering across the PLANNING §4.6 matrix:
+ *   - /workout_plan and /workout_log
+ *   - viewports: desktop (1440x900), tablet (768x1024), mobile (375x667)
+ *   - themes: light, dark
+ *   - view modes: simple, advanced (workout_plan only)
+ *
+ * Screenshots saved under e2e/artifacts/visual-baseline/ for inspection;
+ * NOT committed as `toHaveScreenshot()` baselines yet -- first-run
+ * baseline commit is owner-eyes-on.
+ *
+ * Requires the worktree DB to be seeded by
+ *   scripts/seed_visual_baseline.py
+ * and the apply step (`scripts/apply_free_exercise_db_mapping.py`) to
+ * have populated media_path values.
+ */
+import { test, expect, Page } from '@playwright/test';
+import { ROUTES } from './fixtures';
+import { promises as fs } from 'fs';
+import * as path from 'path';
+
+const ARTIFACT_DIR = path.join(__dirname, 'artifacts', 'visual-baseline');
+
+const VIEWPORTS = [
+  { name: 'desktop', width: 1440, height: 900 },
+  { name: 'tablet', width: 768, height: 1024 },
+  { name: 'mobile', width: 375, height: 667 },
+] as const;
+
+const THEMES = ['light', 'dark'] as const;
+const PLAN_VIEW_MODES = ['simple', 'advanced'] as const;
+
+async function applyTheme(page: Page, theme: 'light' | 'dark'): Promise<void> {
+  await page.addInitScript((t) => {
+    localStorage.setItem('darkMode', t === 'dark' ? 'true' : 'false');
+  }, theme);
+}
+
+async function applyPlanViewMode(page: Page, mode: 'simple' | 'advanced'): Promise<void> {
+  await page.addInitScript((m) => {
+    localStorage.setItem('hypertrophy_filter_view_mode', m);
+  }, mode);
+}
+
+async function ensureArtifactDir(): Promise<void> {
+  await fs.mkdir(ARTIFACT_DIR, { recursive: true });
+}
+
+test.describe.configure({ mode: 'serial' });
+
+test.describe('§4 visual baseline — workout_plan thumbnails', () => {
+  test.beforeAll(async () => {
+    await ensureArtifactDir();
+  });
+
+  for (const viewport of VIEWPORTS) {
+    for (const theme of THEMES) {
+      for (const mode of PLAN_VIEW_MODES) {
+        const label = `plan-${viewport.name}-${theme}-${mode}`;
+        test(label, async ({ browser }) => {
+          const context = await browser.newContext({
+            viewport: { width: viewport.width, height: viewport.height },
+          });
+          const page = await context.newPage();
+          await applyTheme(page, theme);
+          await applyPlanViewMode(page, mode);
+
+          await page.goto(ROUTES.WORKOUT_PLAN);
+          await page.waitForSelector('#workout_plan_table_body tr', { timeout: 15_000 });
+
+          // Behavioural assertions (deterministic across browsers).
+          const rowCount = await page.locator('#workout_plan_table_body tr').count();
+          expect(rowCount).toBeGreaterThanOrEqual(4);
+
+          const thumbCount = await page.locator('#workout_plan_table_body img.exercise-thumbnail').count();
+          expect(thumbCount).toBeGreaterThanOrEqual(1);
+
+          for (const src of await page.locator('#workout_plan_table_body img.exercise-thumbnail').evaluateAll(
+            (els) => els.map((el) => (el as HTMLImageElement).getAttribute('src') ?? ''),
+          )) {
+            expect(src).toMatch(/^\/static\/vendor\/free-exercise-db\/exercises\//);
+            expect(src).not.toContain('..');
+          }
+
+          const htmlTheme = await page.locator('html').getAttribute('data-theme');
+          expect(htmlTheme).toBe(theme);
+
+          // Save screenshot artifact (full table only — keeps diff size sane).
+          const target = page.locator('.workout-plan-table, #workout_plan_table_body').first();
+          await target.screenshot({ path: path.join(ARTIFACT_DIR, `${label}.png`) });
+
+          await context.close();
+        });
+      }
+    }
+  }
+});
+
+test.describe('§4 visual baseline — workout_log thumbnails', () => {
+  test.beforeAll(async () => {
+    await ensureArtifactDir();
+  });
+
+  for (const viewport of VIEWPORTS) {
+    for (const theme of THEMES) {
+      const label = `log-${viewport.name}-${theme}`;
+      test(label, async ({ browser }) => {
+        const context = await browser.newContext({
+          viewport: { width: viewport.width, height: viewport.height },
+        });
+        const page = await context.newPage();
+        await applyTheme(page, theme);
+
+        await page.goto(ROUTES.WORKOUT_LOG);
+        await page.waitForLoadState('domcontentloaded');
+        await page.waitForSelector('#workout-log-table tbody tr', { timeout: 15_000 });
+
+        const rowCount = await page.locator('#workout-log-table tbody tr').count();
+        expect(rowCount).toBeGreaterThanOrEqual(4);
+
+        const thumbCount = await page.locator('#workout-log-table img.exercise-thumbnail').count();
+        expect(thumbCount).toBeGreaterThanOrEqual(1);
+
+        for (const src of await page.locator('#workout-log-table img.exercise-thumbnail').evaluateAll(
+          (els) => els.map((el) => (el as HTMLImageElement).getAttribute('src') ?? ''),
+        )) {
+          expect(src).toMatch(/^\/static\/vendor\/free-exercise-db\/exercises\//);
+          expect(src).not.toContain('..');
+        }
+
+        const htmlTheme = await page.locator('html').getAttribute('data-theme');
+        expect(htmlTheme).toBe(theme);
+
+        const target = page.locator('.workout-log-table, #workout-log-table').first();
+        await target.screenshot({ path: path.join(ARTIFACT_DIR, `${label}.png`) });
+
+        await context.close();
+      });
+    }
+  }
+});

--- a/scripts/seed_visual_baseline.py
+++ b/scripts/seed_visual_baseline.py
@@ -1,0 +1,86 @@
+"""Seed the worktree DB with fixtures that exercise §4 thumbnail variants.
+
+Idempotent: clears `user_selection` + `workout_log` before inserting.
+Run only in a worktree -- the DB has skip-worktree applied so the
+modified file stays out of the index.
+"""
+from __future__ import annotations
+
+import sys
+
+from utils.database import DatabaseHandler
+
+
+# (exercise_name, routine, sets, min_reps, max_reps, rir, weight)
+PLAN_FIXTURES = [
+    ("Band Good Morning", "GYM - Full Body - Workout A", 3, 8, 12, 2, 30.0),
+    ("Ankle Circle", "GYM - Full Body - Workout A", 2, 10, 15, 3, 0.0),
+    ("Band Lateral Raise", "GYM - Full Body - Workout A", 3, 12, 15, 2, 7.5),
+    ("Band Bench Press", "GYM - Full Body - Workout A", 3, 8, 12, 2, 20.0),
+    ("Squat", "GYM - Full Body - Workout A", 4, 5, 8, 2, 100.0),
+    ("Bench Press", "GYM - Full Body - Workout A", 4, 6, 10, 2, 80.0),
+]
+
+
+def main() -> int:
+    with DatabaseHandler() as db:
+        catalogue_rows = db.fetch_all(
+            "SELECT exercise_name FROM exercises WHERE exercise_name IN ({})".format(
+                ",".join("?" * len(PLAN_FIXTURES))
+            ),
+            tuple(name for name, *_ in PLAN_FIXTURES),
+        )
+        catalogue = {row["exercise_name"] for row in catalogue_rows}
+        missing = [name for name, *_ in PLAN_FIXTURES if name not in catalogue]
+        if missing:
+            print(f"ERROR: catalogue missing exercises: {missing}", file=sys.stderr)
+            return 1
+
+        db.execute_query("DELETE FROM workout_log")
+        db.execute_query("DELETE FROM user_selection")
+
+        for name, routine, sets, min_reps, max_reps, rir, weight in PLAN_FIXTURES:
+            db.execute_query(
+                """
+                INSERT INTO user_selection (routine, exercise, sets, min_rep_range, max_rep_range, rir, weight)
+                VALUES (?, ?, ?, ?, ?, ?, ?)
+                """,
+                (routine, name, sets, min_reps, max_reps, rir, weight),
+            )
+
+        plan_rows = db.fetch_all(
+            "SELECT id, routine, exercise, sets, min_rep_range, max_rep_range, rir, weight FROM user_selection"
+        )
+        for row in plan_rows:
+            db.execute_query(
+                """
+                INSERT INTO workout_log (
+                    workout_plan_id, routine, exercise,
+                    planned_sets, planned_min_reps, planned_max_reps,
+                    planned_rir, planned_weight,
+                    scored_min_reps, scored_max_reps, scored_rir, scored_weight
+                )
+                VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+                """,
+                (
+                    row["id"], row["routine"], row["exercise"],
+                    row["sets"], row["min_rep_range"], row["max_rep_range"],
+                    row["rir"], row["weight"],
+                    row["min_rep_range"], row["max_rep_range"], max(0, row["rir"] - 1), row["weight"],
+                ),
+            )
+
+        plan_count = db.fetch_one("SELECT COUNT(*) AS c FROM user_selection")["c"]
+        log_count = db.fetch_one("SELECT COUNT(*) AS c FROM workout_log")["c"]
+        thumb_count = db.fetch_one(
+            "SELECT COUNT(*) AS c FROM user_selection us "
+            "JOIN exercises e ON us.exercise = e.exercise_name "
+            "WHERE e.media_path IS NOT NULL"
+        )["c"]
+        print(f"Seeded {plan_count} plan rows, {log_count} log rows, "
+              f"{thumb_count} of which have media_path populated.")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Summary

Adds the deferred §4.6 visual-baseline regression coverage for free-exercise-db thumbnails (PLANNING.md §4.6, deferred from PR #20 squash).

- `e2e/visual-baseline-thumbnails.spec.ts` — 18 tests covering the full matrix:
  - `/workout_plan`: desktop / tablet / mobile × light / dark × simple / advanced (12)
  - `/workout_log`: desktop / tablet / mobile × light / dark (6)
  - Behavioural assertions only (count ≥ 1, src prefix, no `..`, theme attr). Screenshots saved to `e2e/artifacts/visual-baseline/` for inspection but NOT committed as `toHaveScreenshot()` baselines — first-run baseline commit remains owner eyes-on.
- `scripts/seed_visual_baseline.py` — idempotent fixture loader (six exercises hitting all four media-path variants + two without thumbnails). Clears `user_selection` + `workout_log` then re-inserts. Verifies catalogue presence before mutating.
- `.gitignore` — adds `e2e/artifacts/` so the screenshot output never lands in git.

## Test plan

- [x] Worktree run (Chromium): **18 passed in 21.3s** at `8b348a5` with the worktree DB seeded via `scripts/seed_visual_baseline.py` and `exercises.media_path` populated (108 confirmed/manual rows from PR #20).
- [ ] CI `e2e-smoke` is scoped to `smoke-navigation.spec.ts` only; this spec is not in the smoke job and runs only on local/manual invocation. Reviewer can run with `npx playwright test e2e/visual-baseline-thumbnails.spec.ts --project=chromium`.
- [ ] CI `frontend-build`, `test`, `security-audit`, `lint`, `dependency-check` jobs pass (this PR adds no new deps).

## How to reproduce locally

```
PYTHONPATH=. .venv/Scripts/python.exe scripts/seed_visual_baseline.py
npx playwright test e2e/visual-baseline-thumbnails.spec.ts --project=chromium --reporter=line
```

Screenshots will be under `e2e/artifacts/visual-baseline/`.

## Notes

This PR is independent of #21 (handoff docs + nav e2e + dependency pins). Either can land first.

🤖 Generated with [Claude Code](https://claude.com/claude-code)