### PR TITLE
docs(workout-cool §5): document YouTube curation follow-up status

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -13,6 +13,7 @@ All notable changes to Hypertrophy Toolbox v3.
 
 - Added nullable `youtube_video_id TEXT` support for `exercises`, route contracts for `/get_workout_plan` and `/get_workout_logs`, and a strict header-only curated CSV/apply script path for future manual video IDs.
 - Added a shared Bootstrap reference-video modal and per-row play buttons on `/workout_plan` and `/workout_log`. NULL or malformed IDs open a YouTube search fallback; valid IDs use official `https://www.youtube.com/embed/<id>` embeds and clear the iframe on close.
+- Content note: curated video IDs are not populated by this ship. Until `data/youtube_curated_top_n.csv` is filled and `scripts/apply_youtube_curated.py` is run, every exercise uses the search fallback. See `docs/workout_cool_integration/YOUTUBE_REFERENCE_VIDEOS.md`.
 - Verification: `tests/test_youtube_video_id.py` 40/40 passed; Chromium Playwright `e2e/workout-plan.spec.ts` + `e2e/workout-log.spec.ts` 52/52 passed.
 
 ## Unreleased - May 2, 2026

--- a/docs/ai_workflow/INDEX.md
+++ b/docs/ai_workflow/INDEX.md
@@ -10,7 +10,8 @@
 
 ## Active feature plans
 - [Fatigue meter](../fatigue_meter/PLANNING.md) — parked; Phase 1 + Stage 4 entry shipped
-- [workout.cool integration](../workout_cool_integration/PLANNING.md) — §3 + §5 done; §4 next
+- [workout.cool integration](../workout_cool_integration/PLANNING.md) - §3 + §4 + §5 infrastructure shipped; §5 curated YouTube video IDs are a content follow-up
+- [YouTube reference videos](../workout_cool_integration/YOUTUBE_REFERENCE_VIDEOS.md) - current fallback behavior and curation checklist
 - [User profile](../user_profile/PLANNING.md) — questionnaire + bodymap shipped
 
 ## History & decisions

--- a/docs/workout_cool_integration/EXECUTION_LOG.md
+++ b/docs/workout_cool_integration/EXECUTION_LOG.md
@@ -520,6 +520,17 @@ Run on 2026-05-11 against this slice (post-polish):
 and `/workout_plan` and `/workout_log` wiring). This was adapted from historical
 off-main §5 commits and landed on current `main` after the AI workflow refit.
 Curated CSV ships header-only, so every uncurated row uses the search fallback.
+For the explicit curation checklist and user-facing status, see
+[YOUTUBE_REFERENCE_VIDEOS.md](YOUTUBE_REFERENCE_VIDEOS.md).
+
+### Content status
+
+The shipped §5 work is complete as infrastructure: schema, route contracts,
+shared modal, page wiring, importer, and tests are present. The curated-video
+content is not populated yet. Until `data/youtube_curated_top_n.csv` contains
+valid `exercise_name,youtube_video_id` rows and
+`scripts/apply_youtube_curated.py` is run, all exercises will show the search
+fallback variant.
 
 ### Commits on `main`
 
@@ -553,6 +564,10 @@ Run on 2026-05-11 against current `main`:
 
 ### Outstanding / next sessions
 
+- Optional §5 content curation: populate `data/youtube_curated_top_n.csv` for a
+  starter batch of common exercises, run `scripts/apply_youtube_curated.py`, and
+  verify with `tests/test_youtube_video_id.py`. See
+  [YOUTUBE_REFERENCE_VIDEOS.md](YOUTUBE_REFERENCE_VIDEOS.md).
 - §4 (free-exercise-db media + path validation + thumbnail rendering) is next.
 - §3.6 (Profile coverage body map) remains deferred.
 

--- a/docs/workout_cool_integration/PLANNING.md
+++ b/docs/workout_cool_integration/PLANNING.md
@@ -431,6 +431,14 @@ free-exercise-db does not include YouTube IDs. Three options:
 
 **Decision: option 3 (hybrid)** — solves coverage without committing to populating all ~1,897 rows.
 
+**Current shipped content state:** §5 shipped with the modal, schema, route
+contracts, importer, and tests in place, but the curated video CSV is still a
+header-only scaffold. Until `data/youtube_curated_top_n.csv` is populated and
+`scripts/apply_youtube_curated.py` is run, every exercise will use the intended
+YouTube search fallback. See
+[YOUTUBE_REFERENCE_VIDEOS.md](YOUTUBE_REFERENCE_VIDEOS.md) for the curation
+checklist and UX follow-up options.
+
 ### 5.5 Frontend — `/workout_log` is in scope
 
 The play-icon button appears on **both** `/workout_plan` and `/workout_log`. Reviewing past sessions is a primary use case where a quick form-check video is valuable; making the button plan-only would create asymmetric behavior across two pages that share the same exercise dataset.
@@ -450,7 +458,7 @@ The play-icon button appears on **both** `/workout_plan` and `/workout_log`. Rev
 **Add:**
 - `static/js/modules/exercise-video-modal.js`.
 - `templates/partials/exercise_video_modal.html`.
-- `data/youtube_curated_top_n.csv` — committed manual mapping `exercise_name, youtube_video_id` for the curated top-N (target ~50 most-used exercises).
+- `data/youtube_curated_top_n.csv` — committed manual mapping scaffold `exercise_name, youtube_video_id` for the curated top-N (target ~50 most-used exercises). This currently ships header-only; populating it is content curation, not missing modal infrastructure. See [YOUTUBE_REFERENCE_VIDEOS.md](YOUTUBE_REFERENCE_VIDEOS.md).
 - `scripts/apply_youtube_curated.py` — one-shot importer reading the CSV and writing `youtube_video_id` into `exercises` (idempotent, all-or-nothing). Validates: every `exercise_name` exists in `exercises` (case-insensitive); every `youtube_video_id` matches `^[A-Za-z0-9_-]{11}$`; no duplicate names; no blank IDs. Fails loudly on any violation.
 - `tests/test_youtube_video_id.py` — see §5.8.
 

--- a/docs/workout_cool_integration/YOUTUBE_REFERENCE_VIDEOS.md
+++ b/docs/workout_cool_integration/YOUTUBE_REFERENCE_VIDEOS.md
@@ -1,0 +1,103 @@
+# YouTube Reference Videos
+
+## Current State
+
+The reference-video feature has shipped as application infrastructure, but its
+curated video data has not been populated yet.
+
+What is complete:
+
+- `exercises.youtube_video_id` exists as a nullable text column.
+- `/get_workout_plan` and `/get_workout_logs` expose `youtube_video_id`.
+- `/workout_plan` and `/workout_log` both render the play button.
+- `static/js/modules/exercise-video-modal.js` opens either an embedded YouTube
+  iframe for valid IDs or a YouTube search fallback for missing/invalid IDs.
+- `scripts/apply_youtube_curated.py` validates and applies curated IDs
+  all-or-nothing.
+- `tests/test_youtube_video_id.py` covers schema, validation, importer, and
+  route-contract behavior.
+
+What is not complete:
+
+- `data/youtube_curated_top_n.csv` currently ships as a header-only scaffold.
+- No exercise rows are expected to have curated `youtube_video_id` values until
+  that CSV is populated and the apply script is run.
+- Because IDs are absent, users see the "Search YouTube" fallback for every
+  exercise. That is expected behavior for uncurated rows, but it can feel like an
+  unfinished feature because the useful curated-video content is missing.
+
+## User-Facing Behavior
+
+Each exercise row has one play button.
+
+- Valid 11-character YouTube ID: opens the modal with
+  `https://www.youtube.com/embed/<id>` and a "Watch on YouTube" external link.
+- NULL, blank, or malformed ID: opens the same modal in search mode, with a CTA
+  to YouTube search for `<exercise name> exercise form`.
+
+This is the planned hybrid behavior from
+[PLANNING.md §5.4](PLANNING.md#54-where-the-video-ids-come-from): manually curate
+top exercises, use search fallback for the long tail.
+
+## What Is Needed To Finish The Content
+
+1. Choose a starter curation scope.
+   A practical first batch is 30-50 common lifts and starter-plan exercises:
+   squat variants, deadlift variants, bench/incline bench, overhead press, rows,
+   pulldowns, pull-ups, dips, leg press, leg extension/curl, hip thrust, lateral
+   raise, curls, triceps pressdowns/extensions, calf raises, and common core
+   movements.
+
+2. Populate `data/youtube_curated_top_n.csv`.
+   Format:
+
+   ```csv
+   exercise_name,youtube_video_id
+   Bench Press,dQw4w9WgXcQ
+   ```
+
+   `youtube_video_id` is the 11-character ID from a YouTube URL, not the full
+   URL.
+
+3. Validate and apply:
+
+   ```powershell
+   .venv\Scripts\python.exe scripts\apply_youtube_curated.py --dry-run
+   .venv\Scripts\python.exe scripts\apply_youtube_curated.py
+   ```
+
+4. Verify:
+
+   ```powershell
+   powershell -NoProfile -ExecutionPolicy Bypass -File scripts/run-pytest.ps1 tests/test_youtube_video_id.py
+   ```
+
+   For UI confidence, also run the workout-plan and workout-log Playwright specs
+   if the curation change is committed:
+
+   ```powershell
+   powershell -NoProfile -ExecutionPolicy Bypass -File scripts/run-playwright.ps1 e2e/workout-plan.spec.ts e2e/workout-log.spec.ts
+   ```
+
+## UX Follow-Up Options
+
+The current UI always shows the play button. For uncurated rows, it opens the
+search fallback. If that feels misleading, consider one of these follow-ups:
+
+- Keep the current single button, but change the tooltip/title for uncurated rows
+  to make the search behavior explicit.
+- Use a distinct search icon for uncurated rows and a play icon only for curated
+  rows.
+- Hide the video button unless a curated ID exists, and add a separate explicit
+  search action elsewhere.
+
+Any UX change should preserve the `/workout_plan` and `/workout_log` symmetry
+documented in [PLANNING.md §5.5](PLANNING.md#55-frontend--workout_log-is-in-scope).
+
+## Related Docs
+
+- [PLANNING.md §5](PLANNING.md#5-youtube-reference-decision-pattern-a--single-button-modal) -
+  original design and accepted hybrid approach.
+- [EXECUTION_LOG.md §5 shipped](EXECUTION_LOG.md#2026-05-11--5-shipped-on-main-youtube-reference-video-modal) -
+  what landed on `main`.
+- [../../CHANGELOG.md](../CHANGELOG.md) - release note for the schema/UI ship.


### PR DESCRIPTION
## Summary
- Adds `YOUTUBE_REFERENCE_VIDEOS.md` as the anchor doc for §5 reference-video content status.
- Documents that §5 infrastructure is shipped but `data/youtube_curated_top_n.csv` is header-only.
- Clarifies current user behavior: all rows use the YouTube search fallback until curated IDs are populated and applied.
- Cross-links the status from workout.cool planning/execution docs, changelog, and AI workflow index.

## Tests
- Not run; docs-only change.