### PR TITLE
chore(body-composition): validate captured_at + JS↔Python parity test

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -167,17 +167,14 @@ npx playwright test --project=chromium --reporter=line
 
 ## 5. Current State & Risks
 
-### Verified test counts (2026-05-03 — `feat/fatigue-meter-phase-1-rebased`, post-drop)
-- **pytest**: 1160 passed (~2m 25s) on 2026-05-03 from the rebased fatigue branch — 1080 origin/main baseline (2026-04-28) + 80 new across `tests/test_fatigue.py` (55), `tests/test_priority0_filters.py` extensions in `6246854`, and a handful of rebased prerequisite tests. Lower than the 1345 figure once produced from the original feat-branch tree because origin/main lacks workout-cool §3+§4+§5 + body composition.
-- **Last full E2E Playwright (Chromium)**: **408 passed, 2 failed** in 10.6m on 2026-05-03 from a clean DB. The single repeatable red is `nav-dropdown.spec.ts:117 dark mode toggle still works after navbar restructure` — a pre-existing failure on `origin/main` itself (the toggle's bounding box renders off-viewport at 1440 width; this is what dropped commit `a0a0a18` had attempted to mask via `dispatchEvent('click')`), out of fatigue meter scope. The second failure (`program-backup.spec.ts:79 can create a backup from the dedicated page`) is a DB-state-pollution flake from sequential test execution; passes in isolation. **Effective state: 409 / 1.** See `docs/fatigue_meter/PLANNING.md §2.7` post-drop addendum.
+### Verified test counts (2026-05-21 — `main`, post-Body-Composition hygiene)
+- **pytest**: 1374 passed (~2m 53s) on `main` after Body Composition hygiene PR — 1372 post-PR-#31 baseline + 2 new `captured_at` ISO validation cases.
+- **Body Composition Playwright (Chromium)**: 5 passed (~8s; `e2e/body-composition.spec.ts`) — adds the JS↔Python BFP parity case on top of the 4 PR #31 specs.
+- **Last full E2E Playwright (Chromium)**: not re-run in this hygiene pass. Prior baseline of record is the 2026-05-20 PR #31 verification (20 passed across `body-composition.spec.ts` + `smoke-navigation.spec.ts` + `nav-dropdown.spec.ts`); the wider 408 / 2 baseline is from 2026-05-03 — see Prior counts below.
 
-### Prior verified test counts (2026-04-28, pre-rebase reference)
-- **pytest**: 1080 passed (~2m 22s) — 1054 pre-Issue-#20 + 26 new (Issue #20 reference-lift expansion).
-- **Relevant E2E Playwright**: 41 passed (~58s, Chromium; `user-profile.spec.ts` + `workout-plan.spec.ts`) — adds the Issue #20 questionnaire-grouping case.
-- **Adjacent E2E Playwright (Issue #20 sweep)**: 55 passed (~1m 18s, Chromium; `exercise-interactions.spec.ts` + `accessibility.spec.ts` + `smoke-navigation.spec.ts`).
-- **Last full E2E Playwright baseline**: 314 passed (~7.2m, Chromium; 2026-04-18).
-- **Summary-page Playwright**: 20 passed (~25s; 2026-04-18).
-- **User Profile bodymap (Issue #19) verification (2026-04-28)**: included in the refreshed pytest and Chromium E2E counts above.
+### Prior verified test counts
+- **2026-05-03, `feat/fatigue-meter-phase-1-rebased`**: pytest 1160 passed (~2m 25s); Playwright Chromium 408 passed, 2 failed (effective 409 / 1 — `nav-dropdown.spec.ts:117` dark-mode-toggle off-viewport is a pre-existing red on `origin/main`; `program-backup.spec.ts:79` is a sequential-DB flake that passes in isolation). See `docs/fatigue_meter/PLANNING.md §2.7`.
+- **2026-04-28, pre-rebase**: pytest 1080 passed (~2m 22s); relevant E2E 41 passed (`user-profile.spec.ts` + `workout-plan.spec.ts`); adjacent E2E 55 passed (`exercise-interactions.spec.ts` + `accessibility.spec.ts` + `smoke-navigation.spec.ts`); last full E2E baseline 314 passed (~7.2m, 2026-04-18); summary-page Playwright 20 passed (~25s, 2026-04-18).
 
 Re-verify after significant changes and update counts above.
 

--- a/e2e/body-composition.spec.ts
+++ b/e2e/body-composition.spec.ts
@@ -95,4 +95,32 @@ test.describe('Body Composition page', () => {
     await expect(page.locator('[data-bc-method-label]')).toHaveText('BMI method (fallback)');
     await expect(page.locator('[data-bc-bfp]')).not.toHaveText('—');
   });
+
+  test('JS preview matches Python persisted Navy BFP within rounding', async ({ page }) => {
+    await page.goto(ROUTE);
+    await waitForPageReady(page);
+
+    await page.locator('#bc-neck').fill('38');
+    await page.locator('#bc-waist').fill('85');
+
+    const previewText = await page.locator('[data-bc-bfp]').textContent();
+    const previewMatch = previewText?.match(/([\d.]+)\s*%/);
+    expect(previewMatch, `expected BFP preview text, got "${previewText}"`).not.toBeNull();
+    const previewValue = Number(previewMatch![1]);
+
+    await page.locator('#bc-save').click();
+    await expect(page.locator('[data-bc-history-body] tr')).toHaveCount(1, { timeout: 5000 });
+
+    const listResp = await page.request.get('/api/body_composition/snapshots');
+    expect(listResp.ok()).toBeTruthy();
+    const payload = await listResp.json();
+    const snap = payload?.data?.[0];
+    expect(snap, 'snapshot list should not be empty').toBeTruthy();
+    expect(snap.bfp_navy, 'Navy BFP should be persisted').not.toBeNull();
+
+    // JS displays bfp.toFixed(1); server stores the raw float. They must
+    // round-trip to within ±0.05 % BFP — anything larger means the JS and
+    // Python formulas have drifted.
+    expect(Math.abs(previewValue - Number(snap.bfp_navy.toFixed(1)))).toBeLessThanOrEqual(0.05);
+  });
 });

--- a/routes/body_composition.py
+++ b/routes/body_composition.py
@@ -97,6 +97,28 @@ def _utcnow_iso() -> str:
     return datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
 
 
+def _parse_captured_at(value: Any) -> Optional[str]:
+    """Parse a client-supplied ISO 8601 timestamp; return None if blank.
+
+    Accepts trailing `Z` as UTC. Echoes the caller's string back unchanged
+    when parseable so the saved row preserves the original offset / precision
+    the client sent.
+    """
+    if value in (None, ""):
+        return None
+    if not isinstance(value, str):
+        raise ValueError("captured_at must be an ISO 8601 timestamp string")
+    normalized = value.strip()
+    if not normalized:
+        return None
+    parse_input = normalized[:-1] + "+00:00" if normalized.endswith("Z") else normalized
+    try:
+        datetime.fromisoformat(parse_input)
+    except ValueError as exc:
+        raise ValueError("captured_at must be an ISO 8601 timestamp") from exc
+    return normalized
+
+
 def _row_to_snapshot(row: Any) -> dict[str, Any]:
     return {
         "id": row["id"],
@@ -225,7 +247,7 @@ def create_snapshot():
         fat_mass_kg = (effective_bfp / 100.0) * bodyweight_kg
         lean_mass_kg = bodyweight_kg - fat_mass_kg
 
-        captured_at = _nullable_text(data.get("captured_at")) or _utcnow_iso()
+        captured_at = _parse_captured_at(data.get("captured_at")) or _utcnow_iso()
 
         with DatabaseHandler() as db:
             db.execute_query(

--- a/tests/test_body_composition_routes.py
+++ b/tests/test_body_composition_routes.py
@@ -276,6 +276,43 @@ def test_post_snapshot_uses_provided_captured_at(client, clean_db):
     assert response.get_json()["data"]["captured_at"] == timestamp
 
 
+def test_post_snapshot_accepts_iso_offset_captured_at(client, clean_db):
+    _seed_profile(clean_db)
+    timestamp = "2026-05-21T08:00:00+02:00"
+    response = client.post(
+        "/api/body_composition/snapshot",
+        json={
+            "gender": "M",
+            "age_years": 34,
+            "height_cm": 180.0,
+            "bodyweight_kg": 80.0,
+            "captured_at": timestamp,
+        },
+        headers=XHR_HEADERS,
+    )
+    assert response.status_code == 200
+    assert response.get_json()["data"]["captured_at"] == timestamp
+
+
+def test_post_snapshot_rejects_malformed_captured_at(client, clean_db):
+    _seed_profile(clean_db)
+    response = client.post(
+        "/api/body_composition/snapshot",
+        json={
+            "gender": "M",
+            "age_years": 34,
+            "height_cm": 180.0,
+            "bodyweight_kg": 80.0,
+            "captured_at": "yesterday",
+        },
+        headers=XHR_HEADERS,
+    )
+    assert response.status_code == 400
+    payload = response.get_json()
+    assert_error(payload, "VALIDATION_ERROR")
+    assert "captured_at" in payload["error"]["message"]
+
+
 def test_list_snapshots_returns_descending(client, clean_db):
     _seed_profile(clean_db)
     earlier = {


### PR DESCRIPTION
## Summary

Three non-blocking follow-ups recorded after PR #31 (Body Composition Issue #21):

- **`captured_at` ISO validation** — [routes/body_composition.py](routes/body_composition.py) adds `_parse_captured_at()` so malformed client-supplied timestamps get a structured 400 instead of round-tripping into the snapshot column as garbage.
- **JS↔Python BFP parity** — [e2e/body-composition.spec.ts](e2e/body-composition.spec.ts) asserts the live JS preview matches the Python-persisted `bfp_navy` within ±0.05 %. Guards the *"must match JS mirror"* contract on [utils/body_fat.py](utils/body_fat.py).
- **Test-count refresh** — [CLAUDE.md §5](CLAUDE.md#L170) was stale at 2026-05-03 (1160 pytest / 408 Playwright). Refreshed to the 2026-05-21 post-merge baseline.

Scope is intentionally narrow — no behavior changes, no schema changes, no UI changes. Profile-page display hooks (Issues #17 / #18) remain owner-held.

## Test plan

- [x] `pytest tests/test_body_composition_routes.py -q` → **20 passed** (was 18; +2 new captured_at cases)
- [x] `pytest tests/ -q` → **1374 passed in 172.83s** (was 1372; +2 net)
- [x] `npx playwright test body-composition.spec.ts --project=chromium` → **5 passed in 8.4s** (was 4; +1 parity case)
- [ ] CI 6/6 green

🤖 Generated with [Claude Code](https://claude.com/claude-code)