### PR TITLE
ci(e2e): broaden product gate — functional + isolated backup E2E jobs (Phase 1)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -120,6 +120,130 @@ jobs:
     - name: Run smoke spec
       run: npx playwright test e2e/smoke-navigation.spec.ts --project=chromium --reporter=line
 
+  e2e-functional:
+    name: E2E Functional (Chromium)
+    runs-on: ubuntu-latest
+    needs: frontend-build
+
+    steps:
+    - name: Checkout code
+      uses: actions/checkout@v4
+
+    - name: Set up Python
+      uses: actions/setup-python@v5
+      with:
+        python-version: '3.11'
+        cache: 'pip'
+
+    - name: Set up Node.js
+      uses: actions/setup-node@v4
+      with:
+        node-version: '20'
+        cache: 'npm'
+
+    - name: Install Python dependencies
+      run: |
+        python -m pip install --upgrade pip
+        pip install -r requirements.txt
+
+    - name: Install npm dependencies
+      run: npm ci
+
+    - name: Build Bootstrap-customized CSS
+      run: npm run build:css
+
+    - name: Install Playwright Chromium
+      run: npx playwright install --with-deps chromium
+
+    # Deterministic functional/product specs only. Excluded by design (see
+    # e2e/CLAUDE.md "CI inclusion contract"): visual + visual-baseline-thumbnails
+    # (cross-OS rendering), accessibility (manual deep gate), nav-dropdown (known
+    # red), fatigue-stage4-smokes + volume-progress (geometry/sub-pixel), and
+    # program-backup (runs isolated in e2e-backup). No --reporter flag: the
+    # CI-gated reporters in playwright.config.ts (list + html + junit) must all
+    # emit so the artifact upload below has a report to publish.
+    - name: Run functional specs
+      run: |
+        npx playwright test --project=chromium \
+          e2e/api-integration.spec.ts \
+          e2e/body-composition.spec.ts \
+          e2e/browser-navigation-state.spec.ts \
+          e2e/dark-mode.spec.ts \
+          e2e/empty-states.spec.ts \
+          e2e/error-handling.spec.ts \
+          e2e/exercise-interactions.spec.ts \
+          e2e/fatigue.spec.ts \
+          e2e/learned-calibration.spec.ts \
+          e2e/progression.spec.ts \
+          e2e/replace-exercise-errors.spec.ts \
+          e2e/smoke-navigation.spec.ts \
+          e2e/summary-pages.spec.ts \
+          e2e/superset-edge-cases.spec.ts \
+          e2e/ui-hardening.spec.ts \
+          e2e/user-profile.spec.ts \
+          e2e/validation-boundary.spec.ts \
+          e2e/volume-splitter.spec.ts \
+          e2e/workout-log.spec.ts \
+          e2e/workout-plan.spec.ts
+
+    - name: Upload Playwright artifacts
+      if: failure()
+      uses: actions/upload-artifact@v4
+      with:
+        name: playwright-functional
+        path: artifacts/playwright
+        retention-days: 7
+
+  e2e-backup:
+    name: E2E Backup (Chromium, isolated)
+    runs-on: ubuntu-latest
+    needs: frontend-build
+
+    # program-backup.spec.ts performs live backup/restore mutations. It runs in
+    # its OWN job so it gets a fresh server + freshly-seeded throwaway DB,
+    # sidestepping the documented sequential-DB pollution flake without any
+    # between-spec reset mechanism. See e2e/CLAUDE.md.
+    steps:
+    - name: Checkout code
+      uses: actions/checkout@v4
+
+    - name: Set up Python
+      uses: actions/setup-python@v5
+      with:
+        python-version: '3.11'
+        cache: 'pip'
+
+    - name: Set up Node.js
+      uses: actions/setup-node@v4
+      with:
+        node-version: '20'
+        cache: 'npm'
+
+    - name: Install Python dependencies
+      run: |
+        python -m pip install --upgrade pip
+        pip install -r requirements.txt
+
+    - name: Install npm dependencies
+      run: npm ci
+
+    - name: Build Bootstrap-customized CSS
+      run: npm run build:css
+
+    - name: Install Playwright Chromium
+      run: npx playwright install --with-deps chromium
+
+    - name: Run backup spec
+      run: npx playwright test e2e/program-backup.spec.ts --project=chromium
+
+    - name: Upload Playwright artifacts
+      if: failure()
+      uses: actions/upload-artifact@v4
+      with:
+        name: playwright-backup
+        path: artifacts/playwright
+        retention-days: 7
+
   test:
     name: Run Tests
     runs-on: ubuntu-latest
@@ -141,9 +265,17 @@ jobs:
         
     - name: Run pytest
       run: |
-        pytest tests/ -v --tb=short
+        pytest tests/ -v --tb=short --junitxml=artifacts/pytest/junit.xml
       env:
         PYTHONPATH: ${{ github.workspace }}
+
+    - name: Upload pytest JUnit XML
+      if: always()
+      uses: actions/upload-artifact@v4
+      with:
+        name: pytest-junit
+        path: artifacts/pytest/junit.xml
+        retention-days: 7
 
   dependency-check:
     name: Dependency Health Check

--- a/docs/CI_CD_IMPROVEMENT_PLAN.md
+++ b/docs/CI_CD_IMPROVEMENT_PLAN.md
@@ -1,0 +1,472 @@
+# CI/CD Improvement Plan
+
+> **Status:** Reviewed draft; ready for phased implementation after the Phase 1
+> E2E shard-safety prerequisite is handled
+> **Author:** Claude Code session, 2026-06-05
+> **Branch context:** authored while on `chore/e2e-db-isolation`
+> **Scope:** Expand the GitHub Actions pipeline from a narrow smoke gate into a
+> trustworthy production gate, given that **`main` IS production** for this
+> local-first app.
+
+---
+
+## 0. Framing: what "production" means here
+
+This is a **local-first, single-user Flask app** (`localhost:5000`, no auth, no
+cloud, no remote DB — see CLAUDE.md §1 non-goals). There is no deployed server.
+The owner's definition, confirmed:
+
+> **production = push to `main`.**
+
+This single fact drives the entire design:
+
+- There is **no meaningful "post-merge gate."** Anything that runs *after* merge
+  to `main` runs *after* code has already shipped. Therefore **every check that
+  protects production must be a required PR check** enforced by branch
+  protection.
+- Manual deep-gate runs on `main` or a PR branch are **not** prevention unless
+  they are run before merge. They are for checks too slow or too
+  environment-sensitive to block every PR. Do **not** schedule cron jobs for
+  this repo; the owner wants deep checks triggered during development, not by
+  time-based automation.
+- The Codex/earlier suggestion of a "CD / package / publish / rollback" phase
+  does **not** apply as written — there is no artifact to publish. The "release
+  event" is the merge itself. If distribution ever becomes a real need
+  (tagged zip, installer), that is a *separate future decision*, noted in
+  §6 "Worth considering" but explicitly **out of scope** here.
+
+---
+
+## 1. Current state
+
+### 1.1 What exists (`.github/workflows/ci.yml`)
+Six parallel jobs:
+
+| Job | What it does | Strength |
+|---|---|---|
+| `security-audit` | `pip-audit` (one CVE ignored, no upstream fix) | Real, blocking |
+| `lint` | flake8 — **fails only on syntax/undefined-name** (`E9,F63,F7,F82`); everything else `--exit-zero` | Weak (advisory) |
+| `frontend-build` | `npm ci` + `npm run build:css` | Real, blocking |
+| `e2e-smoke` | **only `smoke-navigation.spec.ts`** (1 of 27 specs) | Token product gate |
+| `test` | full **pytest** (`tests/ -v`) | **Strong — the one real gate** |
+| `dependency-check` | `pip list --outdated`, `safety check` | Non-blocking (informational) |
+
+### 1.2 What's GOOD (keep, don't disturb)
+- **pytest is a genuinely strong gate** — ~1447 tests, real backend/business-logic
+  coverage (CLAUDE.md §5).
+- **DB isolation for E2E is being solved right now** — `playwright.config.ts`
+  seeds a throwaway `artifacts/e2e/database.e2e.db` so the suite never touches
+  live data. This is the prerequisite that makes broad E2E in CI possible.
+- Jobs are **parallel** and **pip/npm cached** — fast feedback structure is
+  already sound.
+- Security + dependency scanning already wired (pip-audit, safety).
+
+### 1.3 What's MISSING (the real gaps)
+- **Product/UI coverage in CI is ~1/27 of the E2E suite.** CI can go green while
+  workout-plan, workout-log, backup/restore, progression, summaries,
+  accessibility, validation, supersets are all broken.
+- **Backup→restore tests exist, but need stronger integrity assertions** —
+  `tests/test_program_backup.py` already covers restore behavior. The missing
+  piece is a row-for-row integrity check for the intended backup scope:
+  `user_selection` program rows only.
+- **No type checking** — `pyrightconfig.json` and `tsconfig.json` exist but
+  neither `pyright` nor `tsc --noEmit` runs.
+- **flake8 is effectively advisory** — only syntax errors fail.
+- **No coverage reporting** — we know tests pass, not what they cover.
+- **No failure artifacts** — Playwright writes HTML report + traces +
+  screenshots to `artifacts/playwright/`, but CI never uploads them. A red gives
+  a log line, not a trace.
+- **No fresh-clone / missing-DB cold-start smoke.**
+- **No old-DB migration compatibility test** (startup ALTERs / `add_*_table`
+  helpers upgrade an existing DB silently — untested against a real old DB).
+- **No JS unit/lint gate** (many JS modules, zero frontend unit tests).
+- **No branch protection** making any of this *required* before merge.
+
+### 1.4 The honest verdict
+The pipeline is **lopsided, not useless.** It catches backend regressions well
+and product regressions almost not at all. It is fast (~1.5–2 min) *because* it
+barely exercises the product — not because it is efficient. A fast green that
+doesn't mean anything is worse than a slower green that does.
+
+---
+
+## 2. Constraints that shape the plan (read before implementing)
+
+1. **`main` = production → heavy checks must be required PR checks**, not
+   post-merge. (See §0.)
+2. **Visual regression cannot be naively turned on in CI.** Snapshots in
+   `e2e/__screenshots__/` were generated on **Windows/Chromium**; CI runs
+   **ubuntu-latest**. Cross-OS font hinting / sub-pixel rendering differs, so
+   visual specs will diff ~100% on Linux. Local baselines already carry
+   documented sub-pixel reds (CLAUDE.md §5). Visual-in-CI requires a *separate
+   set of Linux-generated baselines* (or a pinned Docker render). This is real
+   work, deferred to the manual deep gate (Phase 4).
+3. **The full E2E suite has a documented red baseline** (13 fail + 17 did-not-run
+   on the last full run, CLAUDE.md §5) — partly visual, partly viewport-width,
+   partly the visual-DB preflight. The functional subset must be chosen to
+   **exclude** these known-flaky/environment families so the new gate is green
+   and trustworthy from day one.
+4. **E2E DB isolation must land first.** CI cannot run E2E reliably until
+   `chore/e2e-db-isolation` is merged (the seeded throwaway DB).
+5. **Serial E2E is slow** (`fullyParallel: false`, full suite ~12.5 min).
+   Broadening E2E without sharding would make the PR gate painfully slow →
+   sharding is part of the plan, not an afterthought.
+
+---
+
+## 3. Target pipeline shape (two tiers)
+
+```
+PR opened / updated  ──►  TIER 1: REQUIRED PR CHECKS (branch-protected)
+                          ├─ pytest (full)                              [exists]
+                          ├─ backup/restore user_selection integrity     [new]
+                          ├─ functional E2E (sharded, non-visual)        [new]
+                          ├─ pyright + tsc --noEmit                      [new]
+                          ├─ flake8 (curated, failing) + SCSS build      [harden]
+                          ├─ pip-audit                                  [exists]
+                          └─ upload traces/reports on failure            [new]
+                                   │
+                                   ▼  (all green) → merge → PRODUCTION
+
+Manual deep gate ─────►   TIER 2: DEVELOPMENT-TRIGGERED CHECKS
+(`workflow_dispatch`)     ├─ full E2E incl. accessibility                [new]
+                          ├─ visual regression (Linux baselines)         [new+setup]
+                          ├─ fresh-clone / missing-DB cold start          [new]
+                          ├─ old-DB migration compatibility               [new]
+                          └─ dependency health (outdated / safety)        [move here]
+```
+
+Expected PR-gate wall-clock: **~8–12 min** (from ~2 min). This is the
+deliberate, correct cost of `main` being trustworthy.
+
+---
+
+## 4. Phases, steps, and what each step does
+
+### Phase 0 — Land the prerequisite
+**Goal:** make E2E runnable in CI at all.
+
+- **Step 0.1 — Merge `chore/e2e-db-isolation` to `main`.**
+  Verify the seeded throwaway DB path works headless in CI (the config already
+  seeds via the web-server command to avoid the globalSetup race —
+  `playwright.config.ts:15-20`). Confirm a CI run of even the existing smoke job
+  still passes against the seeded DB on ubuntu.
+  *Improves:* unblocks every later phase. *Risk:* low — work is already done,
+  just needs the green CI confirmation + merge.
+
+---
+
+### Phase 1 — Broaden the product gate (highest value)
+**Goal:** stop CI from going green while the product is broken.
+
+- **Step 1.1 — Define the "functional E2E" set with a per-spec table.**
+  Curate the list of specs that are deterministic and environment-stable. The
+  initial target is broad required-PR coverage for functional/product specs,
+  with visual, known-red, and environment-sensitive checks in the manual deep
+  gate. Document the final inclusion/exclusion rationale in `e2e/CLAUDE.md`.
+
+  | Spec | Target | Reason / current note |
+  |---|---|---|
+  | `accessibility.spec.ts` | manual-deep initially | Valuable, but keep out of required PR until run cost and CI stability are measured. Promote later if stable. |
+  | `api-integration.spec.ts` | required-pr | Broad API contract/product integration coverage. |
+  | `body-composition.spec.ts` | required-pr | Recent product surface; should not be unaccounted. |
+  | `browser-navigation-state.spec.ts` | required-pr | Browser state, back/refresh/deep-link behavior. |
+  | `dark-mode.spec.ts` | required-pr | Theme behavior; non-visual functional assertions. |
+  | `empty-states.spec.ts` | required-pr | Important first-run and no-data behavior. |
+  | `error-handling.spec.ts` | required-pr | User-visible failure behavior and double-click paths. |
+  | `exercise-interactions.spec.ts` | required-pr | Per-row actions in core plan workflow. |
+  | `fatigue-stage4-smokes.spec.ts` | required-pr candidate | Recent feature smoke; verify CI stability before branch protection. |
+  | `fatigue.spec.ts` | required-pr | Recent analytics/product feature coverage. |
+  | `learned-calibration.spec.ts` | required-pr | Recent profile/calibration feature coverage. |
+  | `nav-dropdown.spec.ts` | manual-deep / excluded until fixed | Known current red around off-viewport navbar toggle. |
+  | `program-backup.spec.ts` | required-pr after shard-safety | High-value data-loss-adjacent flow; known historical sequential DB flake means it must wait for reset/order-safe grouping. |
+  | `progression.spec.ts` | required-pr | Core progress workflow. |
+  | `replace-exercise-errors.spec.ts` | required-pr | Edge/error states for replace flow. |
+  | `smoke-navigation.spec.ts` | required-pr | Baseline navigation smoke. |
+  | `summary-pages.spec.ts` | required-pr | Core analyze workflow. |
+  | `superset-edge-cases.spec.ts` | required-pr | Complex plan interaction state. |
+  | `ui-hardening.spec.ts` | required-pr candidate | Broad UI resilience; verify CI stability before branch protection. |
+  | `user-profile.spec.ts` | required-pr | Core profile/workout controls workflow. |
+  | `validation-boundary.spec.ts` | required-pr | Input validation and bounds. |
+  | `visual-baseline-thumbnails.spec.ts` | manual-deep | Cross-OS visual baseline setup required. |
+  | `visual.spec.ts` | manual-deep | Cross-OS visual baseline setup required. |
+  | `volume-progress.spec.ts` | required-pr candidate | Valuable product workflow; verify CI stability before branch protection. |
+  | `volume-splitter.spec.ts` | required-pr | Core distribute workflow. |
+  | `workout-log.spec.ts` | required-pr | Core log workflow. |
+  | `workout-plan.spec.ts` | required-pr | Core plan workflow. |
+
+  *Improves:* replaces the vague `~22/27` claim with an auditable contract for
+  all 27 specs.
+
+- **Step 1.2 — Add a `e2e-functional` job with sharding.**
+  Replace/augment `e2e-smoke` with a matrix-sharded job
+  (`--shard=${i}/${n}`, n=2–3) so serial-but-parallel-across-runners keeps
+  wall-clock ~5–8 min. Each shard installs Chromium, builds CSS, seeds its own
+  throwaway DB. Keep `retries: 2` (already set for CI in config).
+  *Improves:* broad coverage without a 12-min single-runner stall.
+
+- **Step 1.2a — Prove DB reset or order-safe shard groups before enforcement.**
+  `playwright.config.ts` seeds once when the web server starts. Inside one shard,
+  specs still mutate the same DB sequentially, and `program-backup.spec.ts` has
+  a documented historical sequential-DB flake. Before `e2e-functional` becomes
+  branch-protected, either reseed/reset between specs or define explicit
+  order-safe shard groups with a documented green baseline.
+
+- **Step 1.3 — Upload failure artifacts.**
+  On job failure, `actions/upload-artifact` the Playwright HTML report
+  (`artifacts/playwright/report`), traces, screenshots, and videos
+  (config already emits these on first-retry). Artifact names must include the
+  job name and shard index, e.g. `playwright-functional-shard-1-of-3`, so
+  parallel reports are easy to identify. Also upload pytest JUnit XML
+  (`pytest --junitxml=...`) with a stable artifact name.
+  *Improves:* a red CI becomes debuggable (trace viewer) instead of a log line.
+
+---
+
+### Phase 2 — Strengthen the highest-value existing test area
+**Goal:** protect against the local-first nightmare: data loss.
+
+- **Step 2.1 — Add row-for-row `user_selection` integrity assertions.**
+  `tests/test_program_backup.py` already covers backup/restore behavior. Extend
+  it with a deterministic row-for-row integrity test for the intended backup
+  scope: program/routine rows in `user_selection`. Seed a known program with
+  multiple routines, ordering, RIR/RPE/weight, rep ranges, and supersets; create
+  a backup via the same path as `POST /api/backups`; mutate/erase the active
+  program; restore; assert restored `user_selection` rows match the pre-mutation
+  snapshot exactly for the columns backup owns.
+
+  This app's documented backup scope is "snapshot/restore entire programs" in
+  the local-first sense: routines and planned exercise selections. It is
+  intentionally **not** full app-state backup. Do not assert that `workout_log`,
+  profile, reference lifts, or calibration rows survive restore. Current restore
+  behavior intentionally deletes `workout_log` when replacing the active
+  program.
+
+  Cover at least: full program restore, restore over a non-empty DB, and restore
+  of a backup taken before a schema-affecting startup ALTER.
+  *Improves:* the single most consequential untested path. *Why pytest not E2E:*
+  faster, deterministic, and exercises the actual `utils/program_backup.py`
+  logic without browser flake.
+
+- **Step 2.2 — Add it to the Tier-1 gate.** It's part of the pytest job
+  automatically once written; just confirm it runs in CI.
+
+---
+
+### Phase 3 — Cheap static gates
+**Goal:** catch type/contract errors and real lint issues for near-zero runtime.
+
+- **Step 3.1 — Add a `typecheck` job: `pyright` + `tsc --noEmit`.**
+  Configs already exist (`pyrightconfig.json`, `tsconfig.json`). Start in a
+  **non-blocking** mode for one or two PRs to measure the existing error
+  backlog, then flip to blocking once clean (or once a baseline is agreed).
+  Important scope/setup notes:
+  - `tsc --noEmit` currently checks `e2e/**/*.ts` and `playwright.config.ts`,
+    not app JS under `static/js/modules/*`.
+  - CI currently uses Python 3.11 while `pyrightconfig.json` targets Python
+    3.12. Reconcile that before making pyright blocking.
+  - `pyrightconfig.json` points at `.venv`, but CI does not currently create a
+    repo-local venv. Either add a venv setup step for the typecheck job or
+    adjust the pyright config/job so imports resolve correctly in CI.
+  *Improves:* catches type drift, bad imports, API-shape mistakes before runtime.
+
+- **Step 3.2 — Harden flake8.**
+  Curate a rule set that *fails* (not just `E9,F63,F7,F82`) — e.g. unused
+  imports/vars (F401/F841), undefined names already covered. Keep
+  `--max-line-length=127` advisory if desired, but make correctness rules
+  blocking. Measure backlog first; fix or `# noqa` the existing hits.
+  *Improves:* real lint signal instead of a no-op job.
+
+- **Step 3.3 — (Optional) coverage reporting.**
+  Add `pytest --cov` with a report artifact and a *soft* coverage comment.
+  No hard threshold initially — visibility first, ratchet later.
+  *Improves:* shows which critical modules are under-covered.
+
+---
+
+### Phase 4 — Manual deep gate (`workflow_dispatch`, not scheduled)
+**Goal:** catch slow/env-sensitive regressions during development without
+running time-based jobs in the owner's work environment.
+
+- **Step 4.1 — Add a manually triggered workflow.**
+  Add `workflow_dispatch` only. Do **not** add `schedule` / `cron`. The workflow
+  can be run against `main` or a PR branch when the owner wants a deeper pass
+  during development or pre-merge review. It runs full E2E incl.
+  `accessibility.spec.ts`, plus the items below.
+
+- **Step 4.2 — Visual regression with Linux baselines.**
+  Generate a *Linux/Chromium* baseline set (run `--update-snapshots` once in the
+  CI image, commit them under a Linux-specific snapshot path, or use a pinned
+  Docker image so local + CI render identically). Only then enable
+  `visual.spec.ts` + `visual-baseline-thumbnails.spec.ts` (the latter needs the
+  `e2e/scripts/prepare_visual_db.py` preflight). **This step has real setup cost
+  — do not bundle into Tier 1.**
+  *Improves:* catches unintended UI drift; *cost:* baseline maintenance.
+
+- **Step 4.3 — Fresh-clone / missing-DB cold-start smoke.**
+  Spin the app with **no** `data/database.db` present; assert
+  `initialize_database()` + the `add_*_table` helpers + `initialize_exercise_order`
+  bring it up cleanly and `GET /` returns 200.
+  *Improves:* protects the first-run experience for anyone who pulls `main`.
+
+- **Step 4.4 — Old-DB migration compatibility.**
+  Commit a historical `database.db` fixture (pre-`exercise_order`, pre-profile
+  tables). Assert startup upgrades it without error and core routes work.
+  *Improves:* guards the silent startup ALTER path (CLAUDE.md §5
+  "exercise_order column").
+
+- **Step 4.5 — Move `dependency-check` here.** Outdated/safety scans are
+  informational; they don't belong on the critical PR path.
+
+---
+
+### Phase 5 — Enforcement
+**Goal:** make the gate actually gate.
+
+- **Step 5.1 — Enable branch protection on `main`.**
+  Require: pytest, e2e-functional (all shards), typecheck, flake8, frontend-build,
+  pip-audit, backup-restore (via pytest). Require branches up-to-date before
+  merge. Require PR (no direct pushes to `main`).
+  *Improves:* turns the whole plan from "exists" into "enforced."
+  *Note:* aligns with the documented PR workflow (auto-merge on green CI).
+
+---
+
+## 5. What this improves (summary)
+
+| Gap today | After this plan |
+|---|---|
+| 1/27 product specs in CI | Audited functional spec set required on every PR |
+| Backup/restore integrity under-specified | Row-for-row `user_selection` integrity required |
+| No type checking | pyright + tsc blocking |
+| Advisory lint | Correctness lint blocking |
+| Red CI = log line | Red CI = trace + report + video artifacts |
+| Cold start untested | Fresh-clone + old-DB migration smokes in manual deep gate |
+| No UI drift detection | Visual regression in manual deep gate after Linux baselines |
+| Nothing enforced | Branch protection makes `main` trustworthy |
+| Fast-but-meaningless green | ~8–12 min green that actually means "safe to ship" |
+
+---
+
+## 6. Worth considering (not scheduled — owner decision)
+
+- **Distribution / real CD.** If `main` ever needs to ship as an artifact
+  (zip, installer, tagged GitHub Release), add a release workflow on tag push:
+  build → smoke the artifact → attach to release → changelog/version check.
+  Out of scope while "production = push to main."
+- **Cross-browser (Firefox/WebKit).** Currently commented out in
+  `playwright.config.ts:82-90`. Likely low ROI for a single-user localhost app;
+  reconsider only if non-Chromium use is real.
+- **Mobile/tablet viewport coverage** — same reasoning; add to the manual deep
+  gate if needed.
+- **JS unit tests** (Vitest/Jest) for the `static/js/modules/*` logic — worth it
+  if JS complexity grows; currently zero coverage there.
+- **Coverage thresholds** — ratchet up once Step 3.3 gives a baseline.
+- **Required-vs-flaky audit of the existing 13+17 red baseline** — decide,
+  per failing test, fix-or-quarantine, so "known reds" don't mask new reds.
+
+---
+
+## 7. Risks & mitigations
+
+| Risk | Mitigation |
+|---|---|
+| PR gate too slow → friction | Shard E2E (Step 1.2); keep visual/accessibility out of Tier 1 |
+| New E2E job flaky on CI | Curate stable subset (Step 1.1); prove DB reset or order-safe shard groups before branch protection |
+| Type/lint backlog blocks all PRs | Introduce non-blocking first, measure, then flip (Steps 3.1, 3.2) |
+| Visual baselines unmaintainable | Linux baseline set + manual-deep only; never Tier 1 |
+| Branch protection locks out hotfixes | Keep an admin override path documented |
+
+---
+
+## 8. Recommended execution order
+
+1. **Phase 0** (merge DB isolation) — unblocks everything.
+2. **Phase 2.1** (backup/restore integrity test) — highest-value test, independent of CI.
+3. **Phase 1** (functional E2E + sharding + artifacts) — closes the biggest gap.
+4. **Phase 3** (type/lint static gates) — cheap wins.
+5. **Phase 5** (branch protection) — enforce Tiers once green and stable.
+6. **Phase 4** (manual deep gate + visual Linux baselines) — last, highest setup cost.
+
+> Suggested process: run `/council-plan` on Phases 1, 3, 5 (they touch the
+> test-gate contract) before implementing, then `/verify-suite` after each phase.
+
+---
+
+## 9. Codex review findings (2026-06-05)
+
+> **Reviewer:** Codex
+> **Review stance:** The plan is directionally strong, but should be tightened
+> before implementation or branch-protection enforcement.
+> **Opus adjudication:** All findings accepted. Finding 1 downgraded from High
+> to Medium because it is precision/contract clarity rather than an immediate
+> correctness risk. Finding 2 and Finding 3 remain High.
+
+### 9.1 Findings
+
+1. **Medium — E2E coverage math and spec selection were inconsistent.**
+   Original Phase 1 claimed `~22/27` meaningful product flows, but the include
+   list named only 15 specs and excluded 4. Several important specs were
+   unaccounted for: `user-profile`, `volume-splitter`, `body-composition`,
+   `learned-calibration`, `ui-hardening`, `volume-progress`, `fatigue`, and
+   `fatigue-stage4-smokes`. Resolution: Phase 1 now has a per-spec decision
+   table for all 27 specs with `required-pr`, `manual-deep`, or excluded status.
+
+2. **High — The backup/restore proposal conflicts with current behavior and
+   existing tests.** The plan says there is no backup/restore round-trip test,
+   but `tests/test_program_backup.py` already covers restore replacement,
+   rollback, missing exercises, API restore, delete/prune behavior, and commit
+   behavior. The real gap is stronger row-for-row integrity coverage. Also,
+   Step 2.1 proposes seeding `workout_log` and profile as if restore should
+   preserve them, but `utils/program_backup.py` currently snapshots only
+   `user_selection` and restore intentionally deletes `workout_log`. Rewrite
+   this phase as "strengthen existing backup/restore integrity tests." Opus
+   confirmed the open product-scope question is already answered by CLAUDE.md:
+   backup means snapshot/restore entire planned programs, not logs/profile/full
+   app state.
+
+3. **High — Sharding may not be safe without DB reset boundaries.** Each shard
+   gets its own runner and throwaway DB, but tests within a shard still mutate
+   a shared DB sequentially. The repo documents historical sequential
+   DB-pollution flakes, including `program-backup.spec.ts`. Resolution: Phase 1
+   now has an explicit DB reset or order-safe shard-group prerequisite before
+   `e2e-functional` becomes required.
+
+4. **Medium — Typecheck scope is narrower than the plan implies.** `tsc
+   --noEmit` currently covers `e2e/**/*.ts` and `playwright.config.ts`, not the
+   app's `static/js/modules/*.js` files. This is still useful, but it should be
+   described as Playwright/config TypeScript checking, not app-JS checking.
+   Also align the Python version story before requiring `pyright`: CI uses
+   Python 3.11 while `pyrightconfig.json` currently targets Python 3.12. Opus
+   added one practical setup note: pyright currently points at `.venv`, which CI
+   does not create, so the typecheck job needs venv setup or config adjustment.
+
+5. **Medium — Failure artifacts need shard-safe names.** Artifact upload is the
+   right move, but parallel E2E shards should upload with names that include
+   shard index and job name so reports/traces are easy to identify and do not
+   collide in downloads.
+
+### 9.2 Open questions
+
+- **Closed:** Program backup is intentionally `user_selection` program state,
+  not full app state. Do not expand backup semantics as part of CI hardening.
+- **Still open:** Should accessibility remain manual-deep only? If it is stable
+  after DB isolation, it may deserve required PR coverage for UI-heavy changes.
+
+### 9.3 Recommended edits before implementation
+
+- Replace the Phase 1 include/exclude prose with a complete per-spec decision
+  table. **Done in this draft.**
+- Reword Phase 2 from "missing backup/restore test" to "strengthen existing
+  backup/restore integrity coverage." **Done in this draft.**
+- Add an explicit DB-reset/shard-safety prerequisite before enabling
+  branch-protected E2E shards. **Done in this draft.**
+- Clarify that TypeScript checking does not currently cover app JS modules and
+  note pyright venv setup. **Done in this draft.**
+- Add artifact naming conventions for E2E shards. **Done in this draft.**
+- Replace scheduled/nightly language with owner-triggered `workflow_dispatch`
+  manual deep gates. **Done in this draft.**
+
+---
+
+*End of draft — awaiting Opus review.*

--- a/docs/ci_cd_phase1/PLANNING.md
+++ b/docs/ci_cd_phase1/PLANNING.md
@@ -1,0 +1,172 @@
+# Plan Review — CI/CD Phase 1: Broaden the product gate
+
+*Council-plan for Phase 1 of [`docs/CI_CD_IMPROVEMENT_PLAN.md`](../CI_CD_IMPROVEMENT_PLAN.md). Phase 0 (E2E DB isolation, PR #40) and Phase 2.1 (backup/restore integrity, PR #41) are already shipped on `main`.*
+
+---
+
+## Plan v1
+
+**Goal**: Stop CI from going green while the product is broken — expand E2E coverage in CI from 1 spec (`smoke-navigation`) to the full functional/product spec set, sharded for wall-clock, with debuggable failure artifacts. (Branch protection making it *required* is Phase 5, out of scope here.)
+
+**Scope**
+- **In**:
+  - (1.1) Finalize the per-spec functional-E2E inclusion contract (which of the 27 specs run in the new job) and document the rationale in `e2e/CLAUDE.md`.
+  - (1.2) Add an `e2e-functional` GitHub Actions job using a matrix shard strategy (`--shard=i/n`), each shard self-contained (Python deps, Chromium, CSS build, its own seeded throwaway DB).
+  - (1.2a) Establish DB-reset-or-order-safe-shard-groups so the new job is green and deterministic *before* Phase 5 makes it required. Handle the documented `program-backup.spec.ts` sequential-DB flake.
+  - (1.3) Upload failure artifacts (Playwright HTML report, traces, screenshots, videos; pytest JUnit XML) with shard-safe names (`playwright-functional-shard-<i>-of-<n>`).
+- **Out**:
+  - Branch protection / required-check enforcement (Phase 5).
+  - Visual specs (`visual.spec.ts`, `visual-baseline-thumbnails.spec.ts`) — cross-OS rendering, deferred to Phase 4 manual deep gate.
+  - `accessibility.spec.ts` as required — plan §4 keeps it manual-deep "initially".
+  - `nav-dropdown.spec.ts` — documented current red (off-viewport toggle).
+  - pyright / tsc / flake8 hardening (Phase 3).
+  - Any `schedule`/`cron` trigger (explicitly forbidden by plan §0).
+  - Any production-code or app-behavior change.
+
+**Artifacts**
+| Path | Change | Notes |
+|---|---|---|
+| `.github/workflows/ci.yml` | modify | Add `e2e-functional` matrix job; keep `e2e-smoke` or fold it in; add artifact upload steps; add JUnit XML to `test` job |
+| `e2e/CLAUDE.md` | modify | Document the per-spec inclusion/exclusion contract + shard-group rationale |
+| `playwright.config.ts` | modify (maybe) | Add `junit`/`blob` reporter if needed for shard merge; possibly a `grep`/project for the functional set |
+| `e2e/scripts/prepare_e2e_db.py` | modify (maybe, 1.2a) | If per-spec reset is chosen, expose a reset entry point or HTTP-triggerable wipe |
+| `docs/ci_cd_phase1/PLANNING.md` | new | This doc |
+
+**Effort**: M · **Owner**: Claude · **Depends on**: Phase 0 (done), Phase 2.1 (done)
+
+**Sequence**
+1. **1.1 — Inclusion contract.** Adopt the §4 per-spec table. Required-PR functional set (proposed): `api-integration`, `body-composition`, `browser-navigation-state`, `dark-mode`, `empty-states`, `error-handling`, `exercise-interactions`, `fatigue`, `learned-calibration`, `progression`, `replace-exercise-errors`, `smoke-navigation`, `summary-pages`, `superset-edge-cases`, `user-profile`, `validation-boundary`, `volume-splitter`, `workout-log`, `workout-plan`. **Candidates needing a stability run first** (included in the job but flagged, not yet relied on for Phase 5): `fatigue-stage4-smokes`, `ui-hardening`, `volume-progress`, `program-backup`. **Excluded**: `accessibility` (manual-deep), `nav-dropdown` (known red), `visual`, `visual-baseline-thumbnails` (cross-OS).
+2. **1.2a first (de-risk before wiring the matrix).** Decide the shard-safety mechanism. Three options to evaluate:
+   - (a) **Order-safe single-shard-group** — keep `fullyParallel: false`, run the functional set in one job (no matrix), rely on the existing once-per-run seed. Simplest; slowest (~8–10 min); doesn't solve in-run mutation flakes, only avoids cross-shard nondeterminism.
+   - (b) **Per-spec reset** — add a mechanism to re-wipe user-state between spec files (e.g. a `globalSetup`-independent reset call, or a test-only reset route hit in `beforeAll`). Removes sequential-DB pollution entirely; most robust; most work.
+   - (c) **Sharded by file with self-contained DB per shard** — `--shard=i/n`; each shard is its own runner/server/seed. Cross-shard is clean by construction; *within* a shard the sequential-mutation flake (`program-backup.spec.ts`) still exists, so pair (c) with grouping that keeps the backup/erase specs isolated or with (b).
+   Proposed direction: **(c) + isolate the mutation-heavy specs** (put `program-backup` in its own shard or run it last), and only promote `program-backup` to relied-upon after a documented green baseline.
+3. **1.2 — Matrix job.** Add `e2e-functional` with `strategy.matrix.shard: [1,2,3]` and `fail-fast: false`; run `npx playwright test <functional set> --project=chromium --shard=${{ matrix.shard }}/3 --reporter=line,junit`. Reuse the smoke job's setup steps (Python, Node, npm ci, build:css, playwright install --with-deps chromium). The webServer command already seeds per server start.
+4. **1.3 — Artifacts.** `actions/upload-artifact@v4` `if: failure()` for `artifacts/playwright/report`, `test-results` (traces/screenshots/videos), named `playwright-functional-shard-${{ matrix.shard }}-of-3`. Add `--junitxml` to the pytest `test` job and upload as `pytest-junit`.
+5. **1.1 doc close.** Write the final inclusion/exclusion table + shard grouping into `e2e/CLAUDE.md`.
+6. Verify on the PR's own CI run (the new job runs on the PR), iterate on reds, confirm green + stable across at least 2 runs before declaring done. Do **not** enable branch protection (Phase 5).
+
+**Expected gates** (filled in by `test-strategist`)
+- pytest: unchanged (no Python logic change) — full `tests/` still green.
+- e2e: the new functional set must pass on ubuntu Chromium; measure per-shard wall-clock.
+- other: `/build-css` parity (job builds CSS); no visual snapshot changes.
+
+**Open questions for the council**
+1. Is sharding worth it vs. a single order-safe job, given total functional wall-clock may be ~8 min and matrix triples runner usage? (cost vs. latency)
+2. For 1.2a, is a **test-only reset route** an acceptable addition to a no-auth local app, or does it violate a security/non-goal invariant? Alternative: per-shard `globalSetup` reseed without an app route.
+3. Should `program-backup.spec.ts` be in the required set at all for Phase 1, or held as a candidate until the flake is provably fixed?
+4. Does adding a `junit`/`blob` reporter to `playwright.config.ts` risk changing local-dev behavior or the visual baseline workflow?
+5. Is folding `e2e-smoke` into `e2e-functional` safe, or should smoke stay as a fast separate signal?
+
+---
+
+## Reviewer findings
+
+### architecture-reviewer (agent a9f1e26d03a939b06) — verdict: Needs revision
+- **BLOCKING (plan-correctness):** Q2 reinvents the shipped `POST /erase-data` route (`app.py:162-224`), which already drops all user-state and re-runs the initializer chain. Adding a second reset route would be the real non-goal violation. Strike the "add a test-only reset route" alternative; if per-spec reset is needed, use existing `/erase-data` (confirm token) or the lighter `/clear_workout_plan` already used in `program-backup.spec.ts:45`. Note `/erase-data` runs `create_startup_backup()` — too heavy for `beforeEach`.
+- **BLOCKING (would break the job):** `--reporter=line,junit` on the CLI *replaces* the config reporter array (`playwright.config.ts:43-46`), so the HTML report uploaded in 1.3 won't be produced; per-shard JUnit also collides on a fixed filename. Decide reporters in `playwright.config.ts` (CI branch), route JUnit/blob output to a per-shard env-var'd path.
+- **non-blocking:** option (b) references a `globalSetup` that does not exist (seed runs in `webServer.command` precisely because globalSetup races). Drop that framing.
+- **non-blocking:** `--shard=i/n` cannot order specs or pin a spec to a shard — "run program-backup last" needs a separate job/`--grep-invert`, not shard math.
+- **non-blocking:** confirm each shard reseeds independently because `reuseExistingServer` is forced false under `CI` (`playwright.config.ts:9`); don't add `PW_REUSE_SERVER` to job env.
+- **answered Q4:** reporters are independent of `snapshotPathTemplate`; CI-gate the junit/blob reporter → no local-dev or visual-baseline impact.
+- **answered Q5:** keep `e2e-smoke` separate (fast independent signal) and include `smoke-navigation` in the functional set; pick explicitly.
+
+### test-strategist (agent a10fa85ae96bb5418) — verdict: Needs revision; red-baseline accounting VERIFIED COMPLETE (19 required + 4 candidate + 4 excluded = 27)
+- **BLOCKING B1:** `program-backup.spec.ts` must not be in the sharded job for Phase 1 — direction (c) does not fix *intra-shard* sequential pollution (seed runs once per server start; the spec does live backup saves while other specs mutate `user_selection`). Hold it out: run as a separate single-file job (own server/seed = free isolation) or defer. Answers open Q3 = "no, not in the required job for Phase 1." (Also: the `program-backup.spec.ts:79` citation is stale.)
+- **BLOCKING B2:** `fatigue-stage4-smokes.spec.ts` asserts live geometry/tap-target/overflow at 375px — same cross-OS sub-pixel class the plan defers visual specs for; will flap on ubuntu. Exclude from Phase 1; its functional coverage already lives in `fatigue.spec.ts` + pytest.
+- **non-blocking N1:** `volume-progress.spec.ts` is a viewport/geometry spec — downgrade to measure-first (covered by `volume-splitter.spec.ts`).
+- **non-blocking N2:** `ui-hardening.spec.ts` is DOM-contract (toast/focus-trap/Escape), no pixel/geometry — the safest candidate to promote first.
+- **non-blocking N3:** sharding n=3 is premature; ship Phase 1 as a single order-safe job (option a), get a documented green baseline, then shard to n=2 in a follow-up once per-spec timings are known. Phase 1's deliverable is a *green, trustworthy* gate, not minimal latency.
+- **non-blocking N4/N5:** CI-gate junit/blob reporter; pytest `--junitxml` upload safe (use `if: always()` for trend data).
+- **nits:** keep `e2e-smoke` standalone + in set; cite spec+describe block, not line 79.
+- **Verification under-specified:** must run on ubuntu/Chromium; "stable across 2 runs" = 2 consecutive full runs with **zero retries consumed** on flaky families (`retries: 2` otherwise masks the B1 flake).
+
+### product-risk-reviewer (agent aef36dd1b52484e75) — verdict: Needs revision (one blocking non-goal item)
+- **BLOCKING Finding 1:** Step 1.2a option (b) "test-only reset route" adds a destructive production code path against the no-auth/local-first stance (CLAUDE.md §1 non-goals; `main` IS production). Drop the app-route reset; reset at the DB layer out-of-process by reusing the shipped, reviewed `wipe_user_state()` / `prepare()` in `prepare_e2e_db.py`. (Converges with arch BLOCKING #1.)
+- **non-blocking Finding 2:** any reset path must reuse the single `USER_STATE_TABLES` source of truth and never touch the `exercises`/`exercise_isolated_muscles` catalog — no second table list, or specs depending on "catalog-full, user-state-empty" drift.
+- **nit Finding 3:** artifact upload is privacy-safe *because* the suite is seed-only + user-state-wiped; document in `e2e/CLAUDE.md` that CI must never upload `data/database.db` or `data/auto_backup/`.
+- **confirmed clean:** no telemetry/cloud/multi-user/cron; no calculation-semantics, terminology, or backup-contract drift; no user-facing copy change.
+- **note:** the inclusion contract should state fatigue specs assert *current shipped* behavior, so a future Stage-4 threshold tweak isn't silently gated (parked-workstream guard).
+
+---
+
+## Response matrix
+
+| Finding | Reviewer | Disposition | Action in v2 |
+|---|---|---|---|
+| Q2 reset reinvents shipped `/erase-data`; a new reset route is the real non-goal violation | architecture + product-risk | **accept** (blocking) | Remove all "new/test-only reset route" language. Phase 1 needs **no** between-spec reset — isolation comes from giving the one mutation-heavy spec its own job (own server+seed). No app-route change. |
+| `--reporter=line,junit` CLI override suppresses the HTML report and collides per-shard | architecture | **accept** (blocking) | Move reporters into `playwright.config.ts` under a `process.env.CI` branch (`list`+`html`+`junit`/`blob`); route output to per-shard env-var'd paths. No CLI `--reporter` override. |
+| `program-backup.spec.ts` not safe in a shared-DB job; (c) doesn't fix intra-shard pollution | test-strategist | **accept** (blocking) | Run `program-backup.spec.ts` as its **own** isolated `e2e-backup` job (separate runner → fresh seed). Out of the main functional invocation. |
+| `fatigue-stage4-smokes.spec.ts` geometry will flap cross-OS | test-strategist | **accept** (blocking) | Exclude from Phase 1. Functional fatigue coverage stays via `fatigue.spec.ts`. |
+| Sharding n=3 premature; ship single order-safe job first | test-strategist | **accept** | Phase 1 ships a **single order-safe `e2e-functional` job** (no matrix) + a separate `e2e-backup` job. Sharding to n=2 deferred to a fast-follow (documented in v2 "Deferred"). |
+| `volume-progress.spec.ts` geometry — measure-first | test-strategist | **accept** | Exclude from Phase 1 job; note as measure-first candidate. |
+| `ui-hardening.spec.ts` is the safe candidate to include | test-strategist | **accept** | Include `ui-hardening` in the functional set (DOM-contract, deterministic). |
+| Keep `e2e-smoke` standalone AND include smoke in functional set | architecture + test-strategist | **accept** | Keep `e2e-smoke` job; `smoke-navigation` also runs in `e2e-functional`. |
+| `--shard` can't order/pin specs | architecture | **accept** (moot for v2) | v2 has no matrix; isolation is by separate job, not shard math. Re-applies when sharding is revisited. |
+| Reset must reuse `wipe_user_state` single table source; never touch catalog | product-risk | **accept** (moot for v2) | No reset path added in v2; recorded as a constraint for any future per-spec reset. |
+| Artifact privacy: document seed-only safety; never upload live DB / auto_backup | product-risk | **accept** | Add the privacy note + "never upload `data/database.db`/`data/auto_backup/`" to `e2e/CLAUDE.md`. |
+| pytest `--junitxml` upload `if: always()` | test-strategist | **accept** | Add `--junitxml`, upload `if: always()`. |
+| Verification must be ubuntu/Chromium, 2 consecutive runs, zero retries consumed on the set | test-strategist | **accept** | Restate step 6 accordingly; treat any consumed retry on the functional set as a non-green signal to fix before done. |
+| Inclusion contract should state fatigue specs assert *current shipped* behavior | product-risk | **accept** (nit) | Add that sentence to the `e2e/CLAUDE.md` contract. |
+| `globalSetup`-independent reset references a non-existent file | architecture | **accept** | Drop the phrasing (moot — no reset added). |
+| Stale `program-backup.spec.ts:79` citation | test-strategist | **accept** (nit) | Cite spec + describe block in docs, not a line number. |
+
+---
+
+## Plan v2
+
+**Goal**: Unchanged — broaden CI E2E from 1 spec to the full functional/product set so CI stops going green while the product is broken, with debuggable failure artifacts. (Branch protection = Phase 5.)
+
+**Key change from v1:** No sharding and **no reset mechanism** in Phase 1. The council showed (a) sharding is premature before per-spec timings exist and its only hard problem (intra-shard mutation pollution) is solved more simply by job isolation, and (b) every proposed between-spec reset either reinvents the shipped `/erase-data` route or violates the local-first non-goal. So Phase 1 = **two plain jobs sharing the existing seed-once-per-server model**, which is already proven by the current `e2e-smoke` job.
+
+**Scope**
+- **In**:
+  - `e2e-functional` job — single runner, `fullyParallel:false`/`workers:1` (existing config), runs the deterministic functional set in one server/seed lifecycle.
+  - `e2e-backup` job — single runner, runs only `program-backup.spec.ts` against its own fresh server/seed (free isolation for the one mutation-heavy spec).
+  - Keep `e2e-smoke` as the fast standalone signal.
+  - Reporters: add `junit` (+ keep `html`,`list`) in `playwright.config.ts` under a `process.env.CI` branch; route JUnit output to a job-named path.
+  - Failure-artifact upload (`actions/upload-artifact@v4`) for the Playwright HTML report + `test-results` (traces/screenshots/videos), named per job. pytest `--junitxml` uploaded `if: always()`.
+  - `e2e/CLAUDE.md`: the per-spec inclusion/exclusion contract, the job split + rationale, the "current shipped behavior" note, and the artifact-privacy guardrail.
+- **Out**: sharding/matrix (deferred fast-follow), any reset route or `prepare_e2e_db.py` reset entry point, visual/accessibility/nav-dropdown/geometry specs, branch protection (Phase 5), Phase 3 static gates, any production-code/app-behavior change, cron/schedule.
+
+**Functional set (e2e-functional job), 18 specs:**
+`api-integration`, `body-composition`, `browser-navigation-state`, `dark-mode`, `empty-states`, `error-handling`, `exercise-interactions`, `fatigue`, `learned-calibration`, `progression`, `replace-exercise-errors`, `smoke-navigation`, `summary-pages`, `superset-edge-cases`, `ui-hardening`, `user-profile`, `validation-boundary`, `volume-splitter`, `workout-log`, `workout-plan`.
+(That is 20 entries — `smoke-navigation` also has its own job; `ui-hardening` promoted from candidate.)
+
+**Isolated job (e2e-backup):** `program-backup.spec.ts`.
+
+**Excluded from Phase 1 CI (with reason):**
+- `accessibility` — manual-deep (Phase 4), run-cost not yet measured.
+- `nav-dropdown` — documented current red (off-viewport toggle).
+- `visual`, `visual-baseline-thumbnails` — cross-OS rendering + visual-DB preflight (Phase 4).
+- `fatigue-stage4-smokes`, `volume-progress` — geometry/sub-pixel assertions, measure-first before any inclusion.
+
+**Artifacts**
+| Path | Change | Notes |
+|---|---|---|
+| `.github/workflows/ci.yml` | modify | Add `e2e-functional` + `e2e-backup` jobs (reuse smoke setup steps); keep `e2e-smoke`; add `--junitxml` + uploads; per-job artifact names |
+| `playwright.config.ts` | modify | Add `junit` reporter under `process.env.CI` branch; keep `list`+`html`; JUnit output path via env var |
+| `e2e/CLAUDE.md` | modify | Inclusion/exclusion contract, job-split rationale, shipped-behavior note, artifact-privacy guardrail; fix stale flake citation |
+| `docs/ci_cd_phase1/PLANNING.md` | new | This doc |
+
+**Sequence**
+1. Write the inclusion/exclusion contract + job split into `e2e/CLAUDE.md`.
+2. Add the `process.env.CI`-gated `junit` reporter to `playwright.config.ts` (verify local `npx playwright test` still uses `list`+`html` only).
+3. Add `e2e-functional` (explicit spec list or `--grep-invert` of the excluded/backup specs) and `e2e-backup` jobs to `ci.yml`, reusing the smoke job's setup; add artifact-upload steps (`if: failure()` for Playwright, `if: always()` for pytest JUnit).
+4. Open PR; let the new jobs run on the PR's own CI. Iterate until **green on ubuntu/Chromium with zero retries consumed** on the functional + backup jobs across **2 consecutive runs**.
+5. Do **not** enable branch protection (Phase 5). Update `docs/CI_CD_IMPROVEMENT_PLAN.md` Phase 1 status + CLAUDE.md §5 counts after green.
+
+**Deferred to fast-follow (post-Phase-1, pre-Phase-5):** shard `e2e-functional` to n=2 once per-spec timings from step 4 show it's worth it; re-evaluate promoting `fatigue-stage4-smokes` / `volume-progress` / `accessibility` after a measured ubuntu stability run.
+
+**Expected gates**
+- pytest: unchanged — full `tests/` still green (no Python logic touched).
+- e2e: `e2e-functional` + `e2e-backup` green on ubuntu/Chromium, zero retries consumed, 2 consecutive runs.
+- other: `/build-css` parity (jobs build CSS); no visual snapshot changes; local-dev Playwright reporters unchanged.
+
+---
+
+## Sign-off
+
+- [x] Every finding has a disposition.
+- [x] User approved Plan v2 (2026-06-05: follow council — no sharding in Phase 1; accept council spec scope).
+- [x] Ready to implement.

--- a/e2e/CLAUDE.md
+++ b/e2e/CLAUDE.md
@@ -33,9 +33,26 @@ Full per-spec test count map: `.claude/rules/testing.md`.
 - With `PW_REUSE_SERVER=1` and a server already running, the command (and reseed) is skipped — the reused server owns its own DB.
 - Off-viewport navbar toggles (`#muscleModeToggle`, `#darkModeToggle`) can't be reached by actionability clicks at desktop width — dispatch via `page.evaluate(() => el?.click())` (see `clickMuscleModeToggle` in `workout-plan.spec.ts`, `clickDarkModeToggle` in `nav-dropdown.spec.ts`).
 
+## CI inclusion contract (Phase 1 — `e2e-functional` / `e2e-backup` jobs)
+The GitHub Actions gate runs a curated, deterministic subset on **ubuntu/Chromium** (not every spec). Auditable contract for all specs:
+
+| Spec | CI placement | Reason |
+|---|---|---|
+| `api-integration`, `body-composition`, `browser-navigation-state`, `dark-mode`, `empty-states`, `error-handling`, `exercise-interactions`, `fatigue`, `learned-calibration`, `progression`, `replace-exercise-errors`, `smoke-navigation`, `summary-pages`, `superset-edge-cases`, `ui-hardening`, `user-profile`, `validation-boundary`, `volume-splitter`, `workout-log`, `workout-plan` | `e2e-functional` job | Deterministic functional/product coverage |
+| `smoke-navigation` | also `e2e-smoke` job | Fast standalone "is the app up" signal |
+| `program-backup` | `e2e-backup` job (isolated) | Live backup/restore mutations — own server + fresh seed avoids intra-run sequential-DB pollution without any between-spec reset |
+| `accessibility` | excluded (Phase 4 manual deep gate) | Run-cost/stability not yet measured on CI |
+| `nav-dropdown` | excluded | Documented current red (off-viewport toggle) |
+| `fatigue-stage4-smokes`, `volume-progress` | excluded (measure-first) | Live geometry / sub-pixel / tap-target asserts — same cross-OS rendering class as visual specs; revisit after a measured ubuntu stability run |
+| `visual`, `visual-baseline-thumbnails` | excluded (Phase 4) | Windows-generated baselines diff on Linux; thumbnails need the `prepare_visual_db.py` preflight |
+
+- The functional/backup specs assert **current shipped behavior**. A future intentional behavior change (e.g. a fatigue Stage-4 threshold tweak) must update the spec deliberately — it should not be treated as "CI caught a regression."
+- **No sharding in Phase 1** (single order-safe job). Sharding to n=2 is a deferred fast-follow once per-spec timings justify it (`docs/ci_cd_phase1/PLANNING.md`).
+- **Artifact-upload privacy**: trace/screenshot/video/HTML-report uploads are safe *because* the suite runs only against the committed, user-state-wiped seed (`prepare_e2e_db.py`) — no real user data. CI must **never** upload the developer's live `data/database.db` or `data/auto_backup/`.
+
 ## Gotchas
 - **Known current red (out-of-scope)**: `nav-dropdown.spec.ts:117` — dark-mode toggle off-viewport at 1440 width. Do not "fix" this without an explicit task.
-- **Known historical flake**: `program-backup.spec.ts:79` — sequential DB-pollution flake observed in earlier full runs; it passed in the 2026-05-10 full run and passes in isolation.
+- **Known historical flake**: `program-backup.spec.ts` (`Backup Center Page` describe block) — sequential DB-pollution flake observed in earlier full runs; passes in isolation. This is why CI runs it in the isolated `e2e-backup` job (see CI inclusion contract above), not alongside other DB-mutating specs.
 - Visual snapshot regressions need an intentional re-baseline. Don't blanket-`--update-snapshots`.
 - Chromium is the only configured project (`playwright.config.ts`).
 

--- a/e2e/workout-plan.spec.ts
+++ b/e2e/workout-plan.spec.ts
@@ -779,6 +779,17 @@ test.describe('Muscle selector body-map variants', () => {
 test.describe('Exercise reference video modal (workout-plan)', () => {
   test.beforeEach(async ({ page, consoleErrors }) => {
     consoleErrors.startCollecting();
+
+    // Block the real YouTube embed network. These specs assert the iframe `src`
+    // attribute + link wiring, not playback; loading the real embed pulls in
+    // YouTube scripts that emit intermittent console errors (e.g. a
+    // compute-pressure permissions-policy violation) which flake the
+    // console-error collector in CI. Fulfilling with an empty document keeps the
+    // src attribute set while loading nothing third-party.
+    await page.route(/^https:\/\/www\.youtube\.com\/embed\//, (route) =>
+      route.fulfill({ status: 200, contentType: 'text/html', body: '' }),
+    );
+
     await page.goto(ROUTES.WORKOUT_PLAN);
     await waitForPageReady(page);
 
@@ -856,9 +867,18 @@ test.describe('Exercise reference video modal (workout-plan)', () => {
     // Drive the modal directly via its public API. This exercises the JS
     // logic without mutating the live exercises table — equivalent to a
     // curated youtube_video_id arriving in the row data.
+    // Open and wait for Bootstrap to FINISH the show transition
+    // (`shown.bs.modal`). Interacting before the transition completes makes
+    // Bootstrap drop the dismiss click — hide() is a no-op while transitioning —
+    // which left the modal open (the actual 1-in-N CI flake here). Registering
+    // the listener before show() closes the race.
     await page.evaluate(() => {
-      // @ts-expect-error - exposed by static/js/modules/exercise-video-modal.js
-      window.openExerciseVideoModal('dQw4w9WgXcQ', 'Test Exercise');
+      return new Promise<void>((resolve) => {
+        const el = document.getElementById('exerciseVideoModal');
+        el?.addEventListener('shown.bs.modal', () => resolve(), { once: true });
+        // @ts-expect-error - exposed by static/js/modules/exercise-video-modal.js
+        window.openExerciseVideoModal('dQw4w9WgXcQ', 'Test Exercise');
+      });
     });
 
     const modal = page.locator('#exerciseVideoModal');
@@ -869,8 +889,12 @@ test.describe('Exercise reference video modal (workout-plan)', () => {
     await expect(page.locator('#exerciseVideoSearchWrap')).toBeHidden();
 
     const iframe = page.locator('#exerciseVideoIframe');
-    const src = await iframe.getAttribute('src');
-    expect(src).toMatch(/^https:\/\/www\.youtube\.com\/embed\/dQw4w9WgXcQ/);
+    // Auto-retrying assertion (not a one-shot getAttribute) — robust even though
+    // openExerciseVideoModal sets src synchronously.
+    await expect(iframe).toHaveAttribute(
+      'src',
+      /^https:\/\/www\.youtube\.com\/embed\/dQw4w9WgXcQ/,
+    );
 
     const externalLink = page.locator('#exerciseVideoExternalLink');
     const externalHref = await externalLink.getAttribute('href');
@@ -878,11 +902,18 @@ test.describe('Exercise reference video modal (workout-plan)', () => {
     expect(await externalLink.getAttribute('target')).toBe('_blank');
     expect(await externalLink.getAttribute('rel')).toBe('noopener noreferrer');
 
-    // Close — iframe src must be blanked so playback stops.
+    // Close — iframe src must be blanked so playback stops. The blank happens in
+    // the `hidden.bs.modal` handler (exercise-video-modal.js), which can fire a
+    // tick after Playwright considers the modal hidden; poll so the read can't
+    // race the handler.
     await page.locator('#exerciseVideoModal .btn-close').click();
     await expect(modal).toBeHidden();
-    const srcAfter = await iframe.getAttribute('src');
-    expect(srcAfter === '' || srcAfter === null).toBe(true);
+    await expect
+      .poll(async () => {
+        const srcAfter = await iframe.getAttribute('src');
+        return srcAfter === '' || srcAfter === null;
+      })
+      .toBe(true);
   });
 
   test('opening for a different exercise swaps the URL cleanly', async ({ page }) => {

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -12,6 +12,14 @@ const workers = Number.isFinite(configuredWorkers) && configuredWorkers > 0 ? co
 const artifactsRoot = process.env.TEST_ARTIFACTS_DIR ?? 'artifacts';
 const playwrightArtifactsDir = path.join(artifactsRoot, 'playwright');
 
+/* CI-only JUnit reporter, gated on process.env.CI so local `npx playwright test`
+   (and the --update-snapshots visual-baseline workflow) keep the interactive
+   list + html reporters untouched. Each CI job runs on its own runner, so a
+   fixed filename never collides — the uploaded artifact is named per job. */
+const ciReporters: import('@playwright/test').ReporterDescription[] = process.env.CI
+  ? [['junit', { outputFile: path.join(playwrightArtifactsDir, 'junit.xml') }]]
+  : [];
+
 /* Throwaway DB the web server runs against (under gitignored artifacts/), so the
    suite never touches the developer's live data/database.db. It is seeded by the
    web-server command itself — Playwright starts webServer before globalSetup, so
@@ -43,6 +51,7 @@ export default defineConfig({
   reporter: [
     ['list'],
     ['html', { outputFolder: path.join(playwrightArtifactsDir, 'report') }],
+    ...ciReporters,
   ],
   outputDir: path.join(playwrightArtifactsDir, 'test-results'),
   snapshotPathTemplate: '{testDir}/__screenshots__/{testFilePath}-snapshots/{arg}{ext}',


### PR DESCRIPTION
## Phase 1 — Broaden the product gate

Implements Phase 1 of `docs/CI_CD_IMPROVEMENT_PLAN.md`, council-reviewed before implementation (full record: `docs/ci_cd_phase1/PLANNING.md`). Phase 0 (DB isolation, #40) and Phase 2.1 (backup integrity, #41) already shipped.

**Problem:** CI ran 1 of 27 E2E specs (`smoke-navigation`), so it could go green while workout-plan/log, backup/restore, progression, summaries, supersets, validation, etc. were all broken.

### What's added
- **`e2e-functional`** — single order-safe Chromium job running the 20 deterministic functional/product specs against one server + one seeded throwaway DB.
- **`e2e-backup`** — `program-backup.spec.ts` in its **own** job (fresh server + seed) so the documented sequential-DB pollution flake is sidestepped structurally — no between-spec reset, no new app route.
- **Failure artifacts** — Playwright HTML report + traces/screenshots/videos uploaded per job (`if: failure()`); pytest `--junitxml` uploaded `if: always()`.
- **CI-gated `junit` reporter** in `playwright.config.ts` under a `process.env.CI` branch — local `list`+`html` reporters and the `--update-snapshots` visual workflow are untouched. The new jobs pass **no** `--reporter` flag (a CLI override would suppress the uploaded HTML report).
- **`e2e/CLAUDE.md`** — auditable per-spec inclusion/exclusion contract, job-split rationale, artifact-privacy guardrail, de-staled flake citation.

### Excluded from Phase 1 (with reason, in the contract)
`visual` + `visual-baseline-thumbnails` (cross-OS rendering, Phase 4) · `accessibility` (manual deep gate) · `nav-dropdown` (known red) · `fatigue-stage4-smokes` + `volume-progress` (geometry/sub-pixel, measure-first).

### Council outcome (4 blocking findings, all accepted)
1. No new reset route — reuse the structural isolation of a separate job (local-first non-goal).
2. `program-backup` can't share a DB → isolated `e2e-backup` job.
3. `fatigue-stage4-smokes` geometry flaps cross-OS → excluded.
4. `--reporter` on CLI suppresses the HTML report → reporter moved into CI-gated config.

Per the council, **sharding is deferred** to a fast-follow once per-spec timings exist; Phase 1 prioritizes a green-from-day-one gate.

### Scope guard
No production code or app-behavior change. No `cron`/`schedule`. Branch protection / required-check enforcement is **Phase 5** — not in this PR.

### Verification
- pytest unchanged (no Python logic touched).
- `playwright.config.ts` type-checks clean; smoke spec green under `CI=1` with `junit.xml` emitted; local reporters unaffected.
- The new jobs run on this PR's own CI — watching for green on ubuntu/Chromium with zero retries consumed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)