### PR TITLE
ci(static): clear tsc backlog (31→0) and make tsc --noEmit blocking

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -336,15 +336,15 @@ jobs:
         safety check --json || true
       continue-on-error: true
 
-  # MEASURE-ONLY / NON-BLOCKING static typing gate (Phase 3,
-  # docs/ci_cd_phase3/PLANNING.md). pyright + tsc surface their backlogs to the
-  # job summary + an artifact but never fail the build. Path to blocking:
-  #   tsc    -> drop continue-on-error once its backlog reaches 0 (first follow-up)
-  #   pyright-> baseline-allowlist (block only NEW errors vs the uploaded snapshot)
-  # The recorded counts are pyright 1.1.410 under the committed pyrightconfig.json
+  # Static typing gate (Phase 3, docs/ci_cd_phase3/PLANNING.md).
+  #   tsc --noEmit -> BLOCKING (backlog cleared to 0 in the tsc fast-follow).
+  #   pyright      -> measure-only / non-blocking; surfaces its count to the job
+  #                   summary + artifact. Path to blocking: baseline-allowlist
+  #                   (block only NEW errors vs the uploaded snapshot).
+  # The recorded pyright count is 1.1.410 under the committed pyrightconfig.json
   # (py3.12 + Windows platform) — approximate, not 3.11-runtime-authoritative.
   typecheck:
-    name: Type Check (pyright + tsc, non-blocking)
+    name: Type Check (tsc blocking + pyright measure-only)
     runs-on: ubuntu-latest
 
     steps:
@@ -386,18 +386,23 @@ jobs:
           echo "- Path to blocking: baseline-allowlist (block only new-vs-snapshot)."
         } >> "$GITHUB_STEP_SUMMARY"
 
-    - name: tsc --noEmit (non-blocking, measure-only)
-      continue-on-error: true
+    # BLOCKING: backlog was cleared to 0 in the tsc fast-follow. A non-zero count
+    # fails the job. The count is still written to the summary + uploaded (the
+    # artifact step is if: always()) so a regression shows what broke.
+    - name: tsc --noEmit (blocking)
       run: |
-        npx tsc --noEmit > tsc.txt 2>&1 || true
+        set +e
+        npx tsc --noEmit > tsc.txt 2>&1
+        STATUS=$?
+        set -e
         COUNT=$(grep -cE "error TS[0-9]+" tsc.txt || true)
-        echo "::notice title=tsc (non-blocking)::tsc --noEmit reported $COUNT errors (e2e + playwright.config.ts scope)"
+        echo "::notice title=tsc (blocking)::tsc --noEmit reported $COUNT errors (e2e + playwright.config.ts scope)"
         {
-          echo "### tsc --noEmit (non-blocking — measure-only)"
+          echo "### tsc --noEmit (blocking)"
           echo "- **errors**: $COUNT (scope: e2e specs + playwright.config.ts; app JS under static/js/modules/* is NOT covered)"
-          echo "- Path to blocking: clear to 0, then drop continue-on-error (recommended first follow-up)."
         } >> "$GITHUB_STEP_SUMMARY"
         cat tsc.txt
+        exit $STATUS
 
     - name: Upload static-analysis outputs
       if: always()

--- a/docs/CI_CD_IMPROVEMENT_PLAN.md
+++ b/docs/CI_CD_IMPROVEMENT_PLAN.md
@@ -256,10 +256,21 @@ deliberate, correct cost of `main` being trustworthy.
 ### Phase 3 — Cheap static gates
 **Goal:** catch type/contract errors and real lint issues for near-zero runtime.
 
+> **Status (2026-06-06):** Phase 3 measure-only landed (PR #43). The **tsc
+> fast-follow is complete**: the `tsc --noEmit` backlog was cleared from 31 → **0**
+> and the gate is now **BLOCKING** in `.github/workflows/ci.yml` (job
+> "Type Check (tsc blocking + pyright measure-only)"). **pyright (138) and flake8
+> remain measure-only**; their flip paths are unchanged (pyright →
+> baseline-allowlist; flake8 → grow the blocking selection rule-by-rule). The 31
+> tsc fixes were type-only (param annotations, casts, an `e2e/app-modules.d.ts`
+> ambient declaration for `/static/js/modules/*` dynamic imports) — no runtime
+> behavior change.
+
 - **Step 3.1 — Add a `typecheck` job: `pyright` + `tsc --noEmit`.**
   Configs already exist (`pyrightconfig.json`, `tsconfig.json`). Start in a
   **non-blocking** mode for one or two PRs to measure the existing error
   backlog, then flip to blocking once clean (or once a baseline is agreed).
+  **tsc is now blocking (done, see Status above); pyright stays non-blocking.**
   Important scope/setup notes:
   - `tsc --noEmit` currently checks `e2e/**/*.ts` and `playwright.config.ts`,
     not app JS under `static/js/modules/*`.

--- a/e2e/api-integration.spec.ts
+++ b/e2e/api-integration.spec.ts
@@ -73,7 +73,7 @@ async function getValidExerciseName(request: import('@playwright/test').APIReque
 
 async function seedWorkoutPlanExercise(
   request: import('@playwright/test').APIRequestContext,
-  overrides: Partial<typeof VALID_WORKOUT_PLAN_EXERCISE> = {}
+  overrides: Partial<typeof VALID_WORKOUT_PLAN_EXERCISE> & { exercise?: string } = {}
 ) {
   const exercise = overrides.exercise ?? await getValidExerciseName(request);
   const response = await request.post(`${BASE_URL}/add_exercise`, {
@@ -406,9 +406,9 @@ test.describe('Double Progression API (v1.5.0)', () => {
     const rawPayload = await response.json();
     expect(rawPayload.ok).toBe(true);
     expect(rawPayload.status).toBe('success');
-    const data = unwrapApiData(rawPayload);
+    const data = unwrapApiData(rawPayload) as Array<{ type: string }>;
     expect(Array.isArray(data)).toBe(true);
-    
+
     // Should return "start training" type suggestion for unknown exercise
     if (data.length > 0) {
       expect(['technique', 'info', 'start']).toContain(data[0].type);

--- a/e2e/app-modules.d.ts
+++ b/e2e/app-modules.d.ts
@@ -1,0 +1,7 @@
+// App JS modules are served at runtime from /static/js/modules/ and ship without
+// type declarations. A few specs import them dynamically inside page.evaluate
+// (resolved in the browser, e.g. `await import('/static/js/modules/toast.js')`).
+// Declare them as untyped modules so `tsc --noEmit` can resolve the import
+// specifiers; imported members are typed `any` and call sites cast where needed
+// (e.g. `as never`).
+declare module '/static/js/modules/*';

--- a/e2e/body-composition.spec.ts
+++ b/e2e/body-composition.spec.ts
@@ -3,11 +3,12 @@
  *
  * Smoke + save-flow coverage for the standalone /body_composition page.
  */
+import type { Page } from '@playwright/test';
 import { test, expect, waitForPageReady } from './fixtures';
 
 const ROUTE = '/body_composition';
 
-async function seedProfile(page) {
+async function seedProfile(page: Page) {
   const res = await page.request.post('/api/user_profile', {
     data: {
       gender: 'M',
@@ -20,7 +21,7 @@ async function seedProfile(page) {
   expect(res.ok(), 'profile seed must succeed').toBeTruthy();
 }
 
-async function clearSnapshots(page) {
+async function clearSnapshots(page: Page) {
   const listResp = await page.request.get('/api/body_composition/snapshots');
   if (!listResp.ok()) return;
   const payload = await listResp.json();

--- a/e2e/browser-navigation-state.spec.ts
+++ b/e2e/browser-navigation-state.spec.ts
@@ -5,6 +5,7 @@
  * - Routine cascade always resets on back/refresh.
  * - Deep-link query for routine is ignored.
  */
+import type { Page } from '@playwright/test';
 import { test, expect, ROUTES, SELECTORS, waitForPageReady } from './fixtures';
 
 type RoutineState = {
@@ -14,7 +15,7 @@ type RoutineState = {
   hidden: string;
 };
 
-async function readRoutineState(page): Promise<RoutineState> {
+async function readRoutineState(page: Page): Promise<RoutineState> {
   const env = await page.locator(SELECTORS.ROUTINE_ENV).inputValue();
   const program = await page.locator(SELECTORS.ROUTINE_PROGRAM).inputValue();
   const day = await page.locator(SELECTORS.ROUTINE_DAY).inputValue();
@@ -22,7 +23,7 @@ async function readRoutineState(page): Promise<RoutineState> {
   return { env, program, day, hidden };
 }
 
-async function selectRoutine(page): Promise<void> {
+async function selectRoutine(page: Page): Promise<void> {
   await page.locator(SELECTORS.ROUTINE_ENV).selectOption('GYM');
   await page.waitForFunction(() => {
     const select = document.getElementById('routine-program') as HTMLSelectElement;

--- a/e2e/visual-helpers.ts
+++ b/e2e/visual-helpers.ts
@@ -18,7 +18,9 @@ export async function installDeterminism(
     // @ts-ignore - this class intentionally shadows the browser Date constructor.
     globalThis.Date = class extends NativeDate {
       constructor(...args: any[]) {
-        super(...(args.length ? args : [FIXED]));
+        // Cast to a tuple so the spread satisfies tsc (TS2556); the Date copy
+        // shim forwards all original args unchanged at runtime.
+        super(...((args.length ? args : [FIXED]) as [number]));
       }
 
       static now() {

--- a/e2e/volume-progress.spec.ts
+++ b/e2e/volume-progress.spec.ts
@@ -9,6 +9,7 @@
  *  - Deactivate / delete-active degrades to an empty state.
  *  - Drawer open state persists across reloads.
  */
+import type { Page, Response } from '@playwright/test';
 import { test, expect, ROUTES, SELECTORS, waitForPageReady, resetWorkoutPlan } from './fixtures';
 
 const VOLUME_PROGRESS_ENDPOINT = '/api/volume_progress';
@@ -19,7 +20,7 @@ const DRAWER_VIEWPORTS = [
 ];
 const DRAWER_THEMES = ['light', 'dark'] as const;
 
-async function clearActivePlans(page) {
+async function clearActivePlans(page: Page) {
     const response = await page.request.get('/api/volume_history');
     const payload = await response.json();
     const data = payload?.data ?? {};
@@ -28,7 +29,7 @@ async function clearActivePlans(page) {
     }
 }
 
-async function saveAndActivatePlan(page, body) {
+async function saveAndActivatePlan(page: Page, body: Record<string, unknown>) {
     const response = await page.request.post('/api/save_volume_plan', {
         data: { activate: true, ...body }
     });
@@ -37,7 +38,7 @@ async function saveAndActivatePlan(page, body) {
     return payload?.data?.plan_id ?? payload?.plan_id;
 }
 
-async function addExerciseToPlan(page, exercise, sets, routine = 'GYM - Full Body - Workout A') {
+async function addExerciseToPlan(page: Page, exercise: string, sets: number, routine = 'GYM - Full Body - Workout A') {
     const response = await page.request.post('/add_exercise', {
         data: {
             routine,
@@ -53,16 +54,16 @@ async function addExerciseToPlan(page, exercise, sets, routine = 'GYM - Full Bod
     expect(response.ok(), `expected /add_exercise to succeed for ${exercise}`).toBeTruthy();
 }
 
-function progressResponsePromise(page) {
+function progressResponsePromise(page: Page) {
     return page.waitForResponse(
-        (response) => response.url().includes(VOLUME_PROGRESS_ENDPOINT) && response.ok(),
+        (response: Response) => response.url().includes(VOLUME_PROGRESS_ENDPOINT) && response.ok(),
         { timeout: 5000 }
     );
 }
 
-async function dispatchVolumeChange(page, reason) {
+async function dispatchVolumeChange(page: Page, reason: string) {
     const settled = progressResponsePromise(page);
-    await page.evaluate((triggerReason) => {
+    await page.evaluate((triggerReason: string) => {
         document.dispatchEvent(new CustomEvent('workout-plan:volume-affecting-change', {
             detail: { reason: triggerReason }
         }));
@@ -70,13 +71,13 @@ async function dispatchVolumeChange(page, reason) {
     await settled;
 }
 
-async function getDrawerRowText(page, muscle) {
+async function getDrawerRowText(page: Page, muscle: string) {
     const row = page.locator('.vp-row', { has: page.locator('.vp-row__name', { hasText: muscle }) });
     await expect(row).toBeVisible();
     return (await row.locator('.vp-row__sets').innerText()).trim();
 }
 
-async function expectDrawerLayoutStable(page, theme) {
+async function expectDrawerLayoutStable(page: Page, theme: string) {
     const drawer = page.locator('#vpDrawer');
     await expect(drawer).toHaveAttribute('aria-hidden', 'false');
     await expect(drawer.locator('.vp-row').first()).toBeVisible();
@@ -90,7 +91,7 @@ async function expectDrawerLayoutStable(page, theme) {
 
     const layout = await page.evaluate(() => {
         const drawerEl = document.getElementById('vpDrawer');
-        const rectOf = (element) => {
+        const rectOf = (element: Element) => {
             const rect = element.getBoundingClientRect();
             return {
                 top: rect.top,

--- a/e2e/volume-splitter.spec.ts
+++ b/e2e/volume-splitter.spec.ts
@@ -9,12 +9,13 @@
  * - Calculate and reset buttons
  * - Export to Excel
  */
+import type { Page } from '@playwright/test';
 import { test, expect, ROUTES, SELECTORS, waitForPageReady, expectToast } from './fixtures';
 
-async function setVolumeSlider(page, muscle: string, value: number) {
+async function setVolumeSlider(page: Page, muscle: string, value: number) {
   const slider = page.locator(`#sliders input.volume-slider[data-muscle="${muscle}"]`);
   await expect(slider).toBeVisible();
-  await slider.evaluate((element, nextValue) => {
+  await slider.evaluate((element: Element, nextValue: number) => {
     const input = element as HTMLInputElement;
     input.value = String(nextValue);
     input.dispatchEvent(new Event('input', { bubbles: true }));
@@ -22,7 +23,7 @@ async function setVolumeSlider(page, muscle: string, value: number) {
   }, value);
 }
 
-async function expectVolumeSliderValue(page, muscle: string, expectedValue: number) {
+async function expectVolumeSliderValue(page: Page, muscle: string, expectedValue: number) {
   const slider = page.locator(`#sliders input.volume-slider[data-muscle="${muscle}"]`);
   const valueBadge = page.locator(`.current-value[data-muscle="${muscle}"]`);
 


### PR DESCRIPTION
## tsc fast-follow — clear the backlog, flip the gate

Follow-up on Phase 3 (`docs/CI_CD_IMPROVEMENT_PLAN.md`). tsc had the smallest static backlog, so it's the cleanest gate to turn from measure-only into a real **blocking** check before Phase 5 branch protection.

### `tsc --noEmit`: **31 → 0**
All fixes are **type-only** (TS types erase at runtime — no test/e2e/product behavior change):

| Category | Count | Fix |
|---|---|---|
| TS7006 implicit-any params | 24 | Typed helper signatures (`Page`, `Response`, `string`/`number`, `Element`) in volume-progress, volume-splitter, body-composition, browser-navigation-state specs |
| TS2307 cannot-find-module (`/static/js/modules/*` dynamic imports) | 3 | New `e2e/app-modules.d.ts` ambient wildcard declaration |
| TS18046 `unknown` data | 2 | Cast `unwrapApiData` result at the use site (matches existing pattern) |
| TS2339 missing `exercise` on overrides type | 1 | Widen param type with `& { exercise?: string }` |
| TS2556 spread-not-a-tuple (visual Date shim) | 1 | Cast to a tuple |

### CI change
- The `typecheck` job's **tsc step is now blocking** (drops `continue-on-error`, exits with tsc's status). Job renamed to **"Type Check (tsc blocking + pyright measure-only)"**.
- **pyright stays measure-only / non-blocking** (138; flip path unchanged → baseline-allowlist).
- tsc count is still written to the job summary + uploaded artifact so a future regression shows what broke.

### Scope guard
TypeScript / e2e / config / docs only. **pyright and flake8 backlogs untouched.** No Phase 4/deep-gate change. No branch protection, no cron. No product-code change (the type fixes exposed no real bugs — all were missing annotations / untyped dynamic imports).

### Verification
- `npx tsc --noEmit` → **0 errors, exit 0** locally.
- The edited functional specs run in this PR's `e2e-functional`/`e2e-backup` jobs; the new blocking tsc step gates this PR itself.

🤖 Generated with [Claude Code](https://claude.com/claude-code)