### PR TITLE
ci(deep-gate): manual deep gate — cold-start, old-DB migration, full E2E (Phase 4)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -310,31 +310,10 @@ jobs:
         path: artifacts/pytest/junit.xml
         retention-days: 7
 
-  dependency-check:
-    name: Dependency Health Check
-    runs-on: ubuntu-latest
-    
-    steps:
-    - name: Checkout code
-      uses: actions/checkout@v4
-      
-    - name: Set up Python
-      uses: actions/setup-python@v5
-      with:
-        python-version: '3.11'
-        
-    - name: Check for outdated packages
-      run: |
-        python -m pip install --upgrade pip
-        pip install -r requirements.txt
-        pip list --outdated
-      continue-on-error: true
-      
-    - name: Check package vulnerabilities
-      run: |
-        pip install safety
-        safety check --json || true
-      continue-on-error: true
+  # NOTE: the former `dependency-check` job (outdated/safety scans) moved to the
+  # manual Deep Gate (.github/workflows/deep-gate.yml) in Phase 4.5 — it's
+  # informational and doesn't belong on the required PR path. It was never a
+  # required status check, so branch protection is unaffected.
 
   # Static typing gate (Phase 3, docs/ci_cd_phase3/PLANNING.md).
   #   tsc --noEmit -> BLOCKING (backlog cleared to 0 in the tsc fast-follow).

--- a/.github/workflows/deep-gate.yml
+++ b/.github/workflows/deep-gate.yml
@@ -1,0 +1,169 @@
+name: Deep Gate (manual)
+
+# Manually-triggered deep gate (workflow_dispatch ONLY — no cron / schedule, per
+# docs/CI_CD_IMPROVEMENT_PLAN.md §0). Runs the slow / environment-sensitive checks
+# that deliberately do NOT gate every PR: full E2E incl. accessibility, the
+# cold-start + old-DB migration smokes, and the informational dependency scan
+# (moved here from the PR pipeline). Trigger from the Actions tab or with
+# `gh workflow run deep-gate.yml --ref <branch>`.
+#
+# Visual regression (Phase 4.2) is intentionally NOT here yet — it first needs a
+# Linux-generated baseline set (the committed snapshots are Windows-rendered).
+on:
+  workflow_dispatch:
+
+jobs:
+  full-e2e:
+    name: Full E2E incl. accessibility (Chromium)
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: Checkout code
+      uses: actions/checkout@v4
+
+    - name: Set up Python
+      uses: actions/setup-python@v5
+      with:
+        python-version: '3.11'
+        cache: 'pip'
+
+    - name: Set up Node.js
+      uses: actions/setup-node@v4
+      with:
+        node-version: '20'
+        cache: 'npm'
+
+    - name: Install Python dependencies
+      run: |
+        python -m pip install --upgrade pip
+        pip install -r requirements.txt
+
+    - name: Install npm dependencies
+      run: npm ci
+
+    - name: Build Bootstrap-customized CSS
+      run: npm run build:css
+
+    - name: Install Playwright Chromium
+      run: npx playwright install --with-deps chromium
+
+    # Run every spec EXCEPT the two visual ones (visual.spec.ts,
+    # visual-baseline-thumbnails.spec.ts) — their committed baselines are
+    # Windows-rendered and diff ~100% on ubuntu until Phase 4.2 lands a
+    # Linux baseline set. Everything else runs, accessibility included; this is a
+    # manual gate, so a human reads the report (known-red nav-dropdown may fail).
+    - name: Run full suite (minus visual)
+      run: |
+        SPECS=$(ls e2e/*.spec.ts | grep -vE 'visual' | tr '\n' ' ')
+        echo "Running: $SPECS"
+        npx playwright test --project=chromium $SPECS
+
+    - name: Upload Playwright artifacts
+      if: failure()
+      uses: actions/upload-artifact@v4
+      with:
+        name: deep-gate-full-e2e
+        path: artifacts/playwright
+        retention-days: 7
+
+  cold-start:
+    name: Cold start (missing DB) smoke
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: Checkout code
+      uses: actions/checkout@v4
+
+    - name: Set up Python
+      uses: actions/setup-python@v5
+      with:
+        python-version: '3.11'
+        cache: 'pip'
+
+    - name: Install Python dependencies
+      run: |
+        python -m pip install --upgrade pip
+        pip install -r requirements.txt
+
+    # Fresh-clone / first-run path: no data/database.db present. The real app.py
+    # startup must build the schema from scratch and serve the welcome page.
+    - name: Boot with no database.db and assert GET / -> 200
+      run: |
+        rm -f data/database.db data/database.db-wal data/database.db-shm data/database.db-journal
+        FLASK_USE_RELOADER=0 python app.py &
+        APP_PID=$!
+        code=000
+        for _ in $(seq 1 30); do
+          code=$(curl -s -o /dev/null -w "%{http_code}" http://127.0.0.1:5000/ || echo 000)
+          [ "$code" = "200" ] && break
+          sleep 2
+        done
+        kill "$APP_PID" 2>/dev/null || true
+        echo "cold start: GET / -> $code"
+        [ "$code" = "200" ]
+
+  old-db-migration:
+    name: Old-DB migration compatibility
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: Checkout code
+      uses: actions/checkout@v4
+
+    - name: Set up Python
+      uses: actions/setup-python@v5
+      with:
+        python-version: '3.11'
+        cache: 'pip'
+
+    - name: Install Python dependencies
+      run: |
+        python -m pip install --upgrade pip
+        pip install -r requirements.txt
+
+    # Generate a pre-migration DB (no exercise_order, no add_*_table tables) with a
+    # seeded program row, then boot the real app.py. The startup ALTERs / add_*_table
+    # helpers must upgrade it in place and serve both the welcome and plan pages.
+    - name: Generate historical-schema DB, boot, assert upgrade
+      run: |
+        python tests/fixtures/make_old_schema_db.py --output data/database.db
+        FLASK_USE_RELOADER=0 python app.py &
+        APP_PID=$!
+        root=000
+        for _ in $(seq 1 30); do
+          root=$(curl -s -o /dev/null -w "%{http_code}" http://127.0.0.1:5000/ || echo 000)
+          [ "$root" = "200" ] && break
+          sleep 2
+        done
+        plan=$(curl -s -o /dev/null -w "%{http_code}" http://127.0.0.1:5000/workout_plan || echo 000)
+        kill "$APP_PID" 2>/dev/null || true
+        echo "old-DB migration: GET / -> $root ; GET /workout_plan -> $plan"
+        [ "$root" = "200" ] && [ "$plan" = "200" ]
+
+  dependency-health:
+    name: Dependency Health Check
+    runs-on: ubuntu-latest
+
+    # Moved out of the required PR pipeline (Phase 4.5) — outdated/safety scans are
+    # informational and don't belong on the critical merge path.
+    steps:
+    - name: Checkout code
+      uses: actions/checkout@v4
+
+    - name: Set up Python
+      uses: actions/setup-python@v5
+      with:
+        python-version: '3.11'
+
+    - name: Check for outdated packages
+      run: |
+        python -m pip install --upgrade pip
+        pip install -r requirements.txt
+        pip list --outdated
+      continue-on-error: true
+
+    - name: Check package vulnerabilities
+      run: |
+        pip install safety
+        safety check --json || true
+      continue-on-error: true

--- a/docs/CI_CD_IMPROVEMENT_PLAN.md
+++ b/docs/CI_CD_IMPROVEMENT_PLAN.md
@@ -299,6 +299,19 @@ deliberate, correct cost of `main` being trustworthy.
 **Goal:** catch slow/env-sensitive regressions during development without
 running time-based jobs in the owner's work environment.
 
+> **Status (2026-06-06): cheap parts SHIPPED; 4.2 visual deferred.**
+> `.github/workflows/deep-gate.yml` added (`workflow_dispatch` only — no cron),
+> with jobs: **full-e2e** (every spec minus the two visual ones, accessibility
+> included), **cold-start** (4.3 — boots app.py with no `data/database.db`,
+> asserts `GET /` → 200), **old-db-migration** (4.4 — generates a pre-migration
+> DB via `tests/fixtures/make_old_schema_db.py`, boots, asserts `/` + `/workout_plan`
+> → 200; verified locally to upgrade in place and preserve the seeded row), and
+> **dependency-health** (4.5 — moved off the required PR path; it was never a
+> required check, so branch protection is unaffected). **Step 4.2 (Linux visual
+> baselines) is intentionally NOT done** — it needs a Linux-generated baseline
+> set (the committed 66 snapshots are Windows-rendered) and a `{platform}` token
+> in `snapshotPathTemplate`; tracked as a separate focused effort.
+
 - **Step 4.1 — Add a manually triggered workflow.**
   Add `workflow_dispatch` only. Do **not** add `schedule` / `cron`. The workflow
   can be run against `main` or a PR branch when the owner wants a deeper pass

--- a/tests/fixtures/make_old_schema_db.py
+++ b/tests/fixtures/make_old_schema_db.py
@@ -1,0 +1,91 @@
+"""Generate a historical-schema SQLite DB to exercise the startup migration path.
+
+Produces a DB as it looked BEFORE several startup migrations landed:
+- ``user_selection`` has no ``exercise_order`` column (added later by
+  ``initialize_exercise_order``), and none of the newer ``superset_group`` /
+  ``execution_style`` / ``time_cap_seconds`` columns.
+- None of the ``add_*_table`` tables exist yet (``progression_goals``,
+  ``volume_plans`` / ``muscle_volumes``, ``user_profile*``,
+  ``body_composition_snapshots``, the strength-calibration tables,
+  ``program_backups`` / ``program_backup_items``).
+
+Booting ``app.py`` against this DB must upgrade it in place without error and
+preserve the seeded program row (CLAUDE.md §5 "exercise_order column"). The base
+schema is produced by the app's own ``initialize_database`` so it never drifts
+from production; this script only *withholds* the later migrations.
+
+Used by the manual Deep Gate workflow (``.github/workflows/deep-gate.yml``).
+"""
+from __future__ import annotations
+
+import argparse
+import sqlite3
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
+
+
+def build(output: Path) -> Path:
+    output = output.resolve()
+    output.parent.mkdir(parents=True, exist_ok=True)
+    if output.exists():
+        output.unlink()
+
+    # Point the app's initializer at the target file and build ONLY the base
+    # schema (exercises, exercise_isolated_muscles, user_selection, workout_log).
+    # The add_*_table helpers and initialize_exercise_order are deliberately not
+    # run here — that's what the startup migration under test must do.
+    import utils.config
+
+    utils.config.DB_FILE = str(output)
+    from utils.db_initializer import initialize_database
+
+    initialize_database(force=True)
+
+    con = sqlite3.connect(str(output))
+    try:
+        con.execute("PRAGMA foreign_keys = ON")
+        con.execute(
+            "INSERT OR IGNORE INTO exercises (exercise_name, primary_muscle_group) VALUES (?, ?)",
+            ("Legacy Bench Press", "Chest"),
+        )
+        con.execute(
+            """
+            INSERT INTO user_selection
+                (routine, exercise, sets, min_rep_range, max_rep_range, rir, rpe, weight)
+            VALUES (?, ?, ?, ?, ?, ?, ?, ?)
+            """,
+            ("Legacy Routine", "Legacy Bench Press", 3, 6, 8, 2, 8.0, 100.0),
+        )
+        # Age the DB further so the boot must re-add these columns too. DROP COLUMN
+        # needs SQLite 3.35+; if unavailable, the column simply stays (still a
+        # valid, if slightly less old, fixture).
+        for column in ("superset_group", "execution_style", "time_cap_seconds"):
+            try:
+                con.execute(f"ALTER TABLE user_selection DROP COLUMN {column}")
+            except sqlite3.OperationalError:
+                pass
+        con.commit()
+    finally:
+        con.close()
+
+    return output
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--output",
+        type=Path,
+        default=REPO_ROOT / "data" / "database.db",
+        help="Path to write the historical-schema DB (default: data/database.db)",
+    )
+    args = parser.parse_args()
+    print(build(args.output))
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Phase 4 — manual deep gate (cheap parts)

Implements the cheap, high-value parts of Phase 4 of `docs/CI_CD_IMPROVEMENT_PLAN.md` (4.1/4.3/4.4/4.5). **Step 4.2 (Linux visual baselines) is deferred** to its own focused effort.

New `.github/workflows/deep-gate.yml` — **`workflow_dispatch` only, no cron** (per plan §0). Trigger from the Actions tab or `gh workflow run deep-gate.yml --ref <branch>`.

| Job | What it does |
|---|---|
| **full-e2e** | Every spec **minus the two visual ones** (their committed baselines are Windows-rendered, diff ~100% on ubuntu until 4.2), accessibility included. Manual gate → a human reads the report. |
| **cold-start (4.3)** | Boots `app.py` with **no** `data/database.db`; asserts `GET /` → 200. Protects the fresh-clone / first-run path. |
| **old-db-migration (4.4)** | `tests/fixtures/make_old_schema_db.py` generates a pre-migration DB (no `exercise_order`, no `add_*_table` tables) with a seeded program row; boot must upgrade it in place and serve `/` + `/workout_plan`. **Verified locally:** the startup sequence adds the columns/tables and the seeded row is preserved (guards the CLAUDE.md §5 "exercise_order column" path). |
| **dependency-health (4.5)** | The former `dependency-check` job, **moved off the required PR path** — it's informational and was never a required check, so branch protection is unaffected. |

`ci.yml`'s `dependency-check` job is removed accordingly (the 8 required checks are untouched).

### Scope guard
No app/calculation/schema/route change. The deep gate runs **only on manual dispatch** — it doesn't touch the required PR gate. Branch protection unaffected (verified: the 8 required check names are unchanged).

### Validation note
`deep-gate.yml` is `workflow_dispatch`-only, so it does **not** run on this PR. The PR's CI exercises the 8 required checks (incl. confirming `ci.yml` still parses with `dependency-check` removed). The deep gate itself will be validated by a manual dispatch after merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)