### PR TITLE
ci(deep-gate): create cold-start DB directory

### DIFF
--- a/.github/workflows/deep-gate.yml
+++ b/.github/workflows/deep-gate.yml
@@ -90,6 +90,7 @@ jobs:
     - name: Boot with no database.db and assert GET / -> 200
       run: |
         export DB_FILE=artifacts/deep-gate/cold-start.db
+        mkdir -p "$(dirname "$DB_FILE")"
         rm -f "$DB_FILE" "$DB_FILE-wal" "$DB_FILE-shm" "$DB_FILE-journal"
         DB_FILE="$DB_FILE" FLASK_USE_RELOADER=0 python app.py &
         APP_PID=$!


### PR DESCRIPTION
## Summary
- create the throwaway DB parent directory before the cold-start smoke boots app.py

## Why
The manual Deep Gate run on main proved old-DB migration, dependency health, and full non-visual E2E are working, but cold-start failed because SQLite could not open artifacts/deep-gate/cold-start.db when the parent directory did not exist.

## Verification
- git diff --check -- .github/workflows/deep-gate.yml
- manual Deep Gate failure inspected: run 27045516526, cold-start job 79830562659