### PR TITLE
feat(calibration): related exercise transfer plumbing (Phase 2A)

### DIFF
--- a/app.py
+++ b/app.py
@@ -176,6 +176,8 @@ def erase_data():
             tables = [
                 'program_backup_items',  # Drop child table first (FK constraint)
                 'program_backups',        # Then parent backup table
+                'ignored_calibration_transfers',
+                'exercise_transfer_ratios',
                 'learned_strength_calibrations',
                 'user_calibration_settings',
                 'user_profile_preferences',

--- a/docs/user_profile/LEARNED_CALIBRATION_PLAN.md
+++ b/docs/user_profile/LEARNED_CALIBRATION_PLAN.md
@@ -2,7 +2,12 @@
 
 ## Status
 
-This is a planning document, not an implementation ticket ready to code without review. The MVP should be a low-risk exact-exercise learning feature. Related-exercise propagation belongs in Phase 2.
+MVP learned calibration is shipped on `main`:
+
+- PR #37 / `fd2e2f5`: exact-exercise learned calibration backend, settings, estimator integration, Profile controls, Workout Controls source UI/actions, workout-log notifications, tests, and E2E.
+- PR #39 / `62db541`: separate profile-estimator dumbbell/total-load reference fix.
+
+This document is now the planning source for Phase 2. Phase 2 is not ready to code without design review because related-exercise transfer can change suggestion behavior across many exercises and needs explicit product choices.
 
 ## Goal
 
@@ -17,14 +22,15 @@ Example target behavior:
 
 ## Current Behavior
 
-The current estimate flow prioritizes:
+The shipped estimate flow prioritizes:
 
-1. Last logged set for the exact exercise.
-2. Profile reference lifts.
-3. Cold-start demographics.
-4. Static default.
+1. Exact exercise learned calibration, when settings mode is `suggest` and confidence is usable.
+2. Last logged set for the exact exercise.
+3. Profile reference lifts.
+4. Cold-start demographics.
+5. Static default.
 
-Exact exercises adapt today, but only by mirroring the latest logged row. Similar exercises do not learn from logs. Cross-exercise propagation exists only through Profile reference lifts, and workout logs do not write back to those reference lifts.
+Exact exercises now adapt from recent valid scored logs instead of only mirroring the latest row. Similar exercises still do not learn from logs. Cross-exercise propagation exists only through Profile reference lifts, and workout logs do not write back to those reference lifts.
 
 ## Desired Result
 
@@ -80,6 +86,223 @@ Phase 2 can add:
 - Manual `Promote to Profile reference lift` action.
 - Fatigue-aware and volume-aware set suggestions.
 - E2E coverage for the full related-learning UI flow.
+
+### Phase 2 Scope Split
+
+Phase 2 should be split into reviewable stages:
+
+1. **Phase 2A - related-exercise suggestions only.** Add read-only transfer from one exercise's learned calibration to a related target exercise. No Profile writes, no plan-row writes, no dashboard, no auto-apply.
+2. **Phase 2B - review and control surface.** Add an audit/dashboard view, ignored-transfer controls, and bulk reset only after 2A behavior is stable.
+3. **Phase 2C - promote to Profile.** Add manual promote-to-Profile as its own explicit action with route tests, response-contract tests, and clear copy that it changes the user's declared baseline.
+4. **Phase 2D - fatigue/volume-aware suggestions.** Keep this separate from strength transfer so fatigue logic does not become a hidden modifier inside Workout Controls.
+
+Only Phase 2A should be considered for the next implementation slice.
+
+## Phase 2A Related-Exercise Transfer Plan
+
+### Product Principle
+
+Related transfer should be conservative and explainable:
+
+- Use related logs only when the target exercise has no usable exact learned calibration and no exact last-log fallback.
+- Keep the existing Profile reference chain as the fallback if related evidence is weak, stale, or hard to explain.
+- Never silently overwrite Profile lifts, planned program rows, or historical logs.
+- Show that a suggestion is transferred, not exact: e.g. `Related: learned from Barbell Bench Press`.
+- Allow the user to reset/ignore a transferred source without deleting the source exercise's exact calibration.
+
+### Priority
+
+Phase 2A estimator priority should be:
+
+1. Exact exercise learned calibration.
+2. Exact last-log fallback.
+3. Related exercise learned calibration.
+4. Profile reference lifts.
+5. Cold-start demographics.
+6. Static default.
+
+This keeps exact user evidence above transferred evidence. It also means a single target-exercise log immediately suppresses related transfer for that target.
+
+### Settings
+
+Use the existing reserved settings fields before adding new user-facing modes:
+
+- `user_calibration_settings.mode`: remains `off` / `suggest`.
+- `user_calibration_settings.allow_related_exercise_learning`: must default to `0`.
+- No settings row must still behave as fully off.
+- Related transfer can only run when `mode == 'suggest'` and `allow_related_exercise_learning == 1`.
+
+Do not add `auto_apply` in Phase 2A.
+
+### Transfer Eligibility
+
+A source calibration may transfer to a target exercise only when all are true:
+
+- Source has usable confidence (`medium` or `high`) and at least `MIN_RELATED_LOGS` valid source logs.
+- Source is not stale by exact-calibration rules.
+- Source and target are not the same exact exercise.
+- Target has no usable exact learned calibration and no exact last-log fallback.
+- Target is not excluded by `classify_tier()`.
+- Source and target pass a deterministic relationship rule.
+- The relationship has an explainable transfer ratio.
+- The user has not ignored this source-target pair.
+
+### Relationship Rules
+
+Start with a deterministic, testable relationship score. Do not use fuzzy text similarity as the primary signal.
+
+Inputs available today:
+
+- `lift_key` from `utils.lift_matching.match_direct_lift_key()`.
+- `primary_muscle_group`.
+- `movement_pattern`.
+- `equipment`.
+- `mechanic`.
+- Existing per-hand vs total-load handling via `_load_basis_factor()`.
+
+Initial allowed relations:
+
+1. **Same direct lift key**: e.g. barbell bench variants that map to the same key-lift vocabulary.
+2. **Same primary muscle + same movement pattern + compatible mechanic**: e.g. horizontal push to horizontal push, squat to squat.
+3. **Equipment-compatible pairs only**: barbell/machine/cable/dumbbell/bodyweight compatibility must be explicit, not inferred from names.
+
+Initial blocked relations:
+
+- Different primary muscle.
+- Different movement pattern, unless manually whitelisted.
+- Unilateral vs bilateral transfers until a ratio is explicitly defined.
+- Bodyweight exercises where external load is not the main performance variable.
+- Exercises classified as `excluded`.
+- Any pair whose load basis cannot be explained as total-load or per-hand.
+
+### Transfer Ratios
+
+Do not hard-code one universal ratio for all related exercises.
+
+Recommended first slice:
+
+- Add a small `exercise_transfer_ratios` table for curated source-target pairs.
+- Store directional ratios (`source_exercise_name`, `target_exercise_name`, `ratio`, `basis`, `confidence`, `notes`).
+- Seed only a tiny safe set after review, or allow the table to start empty and prove the plumbing first.
+- Direction matters: `bench -> incline dumbbell press` is not necessarily the same as `incline dumbbell press -> bench`.
+
+If an MVP-without-seed is preferred, Phase 2A can first compute candidates but never return them until ratios exist. That gives tests and dashboard/audit visibility without changing Workout Controls behavior.
+
+### Suggested Schema
+
+Additive, idempotent tables:
+
+#### `exercise_transfer_ratios`
+
+- `id`
+- `source_exercise_name`
+- `target_exercise_name`
+- `source_lift_key`
+- `target_lift_key`
+- `ratio`
+- `load_basis`: `total_to_total`, `total_to_per_hand`, `per_hand_to_total`, `per_hand_to_per_hand`
+- `relationship_type`: `same_lift_key`, `same_pattern`, `manual`
+- `confidence`: `low`, `medium`, `high`
+- `notes`
+- `created_at`
+- `updated_at`
+
+#### `ignored_calibration_transfers`
+
+- `id`
+- `source_exercise_name`
+- `target_exercise_name`
+- `created_at`
+
+Optional later table for Phase 2B:
+
+#### `calibration_events`
+
+- `id`
+- `event_type`
+- `exercise_name`
+- `related_source_exercise_name`
+- `payload_json`
+- `created_at`
+
+### Algorithm Sketch
+
+When estimating a target exercise:
+
+1. Run the shipped exact learned lookup.
+2. Run the shipped exact last-log lookup.
+3. If both miss, and related learning is enabled, query candidate source calibrations.
+4. Join candidate source rows to explicit transfer ratios for the target.
+5. Discard ignored source-target pairs.
+6. Discard low-confidence, stale, excluded, or unsupported-basis candidates.
+7. Convert source `estimated_1rm` through the directional ratio and load-basis factor to produce target `estimated_1rm`.
+8. Use the target exercise's rep goals and the existing progression helper to derive target `suggested_weight` where possible.
+9. Pick the highest-confidence candidate; tie-break by most recent `last_observed_at`, then largest sample count.
+10. Return `source: "related_learned"`, `reason: "related_calibration"`, and a trace that names the source exercise and ratio.
+
+### Trace Requirements
+
+Workout Controls trace must show:
+
+- Source exercise.
+- Source confidence and sample count.
+- Source observed top set / e1RM.
+- Relationship type.
+- Transfer ratio and load-basis conversion.
+- Final progression decision.
+- Why exact learned/log data did not apply.
+
+Example:
+
+```text
+Source: Related learned calibration
+Learned from: Barbell Bench Press, 4 recent logs, confidence high
+Transfer: Bench Press -> Incline Dumbbell Press, ratio 0.72, total-load to per-hand
+Estimated strength: 92 kg source e1RM -> 33 kg/hand target
+Progression: maintain and build reps
+```
+
+### User Controls
+
+Phase 2A controls:
+
+- Enable/disable related learned suggestions in Profile.
+- Reset learned data for the target exercise (already exists for exact rows).
+- Ignore this related source for this target.
+- Keep current.
+- Apply suggestion client-side only.
+
+Do not add promote-to-Profile or auto-apply in Phase 2A.
+
+### Data Lifecycle
+
+- `/erase-data` must clear transfer ratios only if they are user-generated. If curated app-default ratios are shipped, they should be recreated by startup/seed logic rather than deleted permanently.
+- Deleting a source workout log should recompute the exact source calibration; related suggestions should derive from the new exact row at read time instead of storing copied related rows.
+- Deleting a target log should not delete source calibration.
+- Backup/restore must be safe with old snapshots missing Phase 2 tables.
+- The workout-log write path must continue reusing the open `DatabaseHandler`.
+
+### Open Decisions For Opus Review
+
+1. Should Phase 2A ship with zero default transfer ratios first, proving plumbing without behavior change?
+2. Which first 10-20 source-target pairs are safe enough to seed?
+3. Should related transfer use source `suggested_weight` or source `estimated_1rm` as the ratio input?
+4. Should exact last-log fallback always beat related learned evidence, or should stale/low-quality exact logs fall below high-confidence related evidence?
+5. Should unilateral/bilateral pairs be blocked for the whole first slice?
+6. Should machine/cable exercises require manual ratios only?
+7. Is a per-exercise ignore enough, or do we need ignore-by-source-target pair from the start?
+8. How should bodyweight-loaded movements be represented, or should they remain blocked?
+
+### Phase 2A Acceptance Criteria
+
+- With related learning disabled, estimate endpoint output is byte-for-byte equivalent to shipped MVP behavior.
+- With related learning enabled but no transfer ratios, output is still unchanged.
+- The first Phase 2A implementation slice ships with zero seeded transfer ratios.
+- With one valid curated transfer ratio, target uses related calibration only after exact learned and exact log miss.
+- Exact target log immediately suppresses related transfer.
+- Low/stale source confidence does not override Profile reference lifts.
+- Trace clearly names source exercise, relationship, ratio, confidence, and fallback reason.
+- Reset/ignore controls do not delete the source exercise's exact learned calibration.
 
 ## Strength Formula
 
@@ -244,7 +467,7 @@ Phase 2 actions:
 
 ## Data Model
 
-Likely MVP tables:
+Shipped MVP tables:
 
 ### `learned_strength_calibrations`
 
@@ -279,7 +502,7 @@ Normalize before persisting:
 - `min_sessions_for_related`, reserved for Phase 2
 - `updated_at`
 
-Phase 2 can add `calibration_events` when the Profile dashboard or audit history needs a real consumer.
+Phase 2A should add `exercise_transfer_ratios` and `ignored_calibration_transfers` only if related transfer is enabled. Phase 2B can add `calibration_events` when the Profile dashboard or audit history has a real consumer.
 
 ## Data Lifecycle
 
@@ -304,7 +527,7 @@ The workout-log hook must reuse the open `DatabaseHandler`.
 
 When `/update_workout_log` updates a row, call calibration with `db=db` inside the same handler block. Do not open a nested `DatabaseHandler` while the write path is active.
 
-## Development Tasks
+## Shipped MVP Tasks
 
 1. Create `utils/strength_calibration.py`.
 2. Add numeric confidence constants.
@@ -323,9 +546,26 @@ When `/update_workout_log` updates a row, call calibration with `db=db` inside t
 15. Add Workout Controls source badges and explanation details.
 16. Add migration notes because estimator priority changes product behavior.
 
+## Phase 2A Development Tasks
+
+1. Lock the transfer model after Opus/product review.
+2. Add additive Phase 2A tables in `utils/database.py`.
+3. Register table creation during app startup and tests.
+4. Register table cleanup in test fixtures and production erase-data flow.
+5. Extend settings helpers to read/write `allow_related_exercise_learning`.
+6. Add a small backend helper that returns eligible related candidates for a target exercise.
+7. Add explicit transfer-ratio lookup and load-basis conversion.
+8. Add ignored source-target pair helpers and reset/ignore endpoints.
+9. Extend `utils/profile_estimator.py` with related learned lookup after exact log fallback.
+10. Add trace fields for related learned calibration.
+11. Add Profile UI toggle for related suggestions, gated behind learned suggestions.
+12. Add Workout Controls copy/actions for related-source suggestions.
+13. Add migration notes because estimator priority can change behavior.
+14. Keep promote-to-Profile, dashboard, auto-apply, and fatigue-aware changes out of Phase 2A.
+
 ## Testing Plan
 
-### Unit Tests
+### Shipped MVP Unit Tests
 
 - Canonical `epley_1rm()` is used; no RIR-adjusted formula is introduced.
 - RIR/RPE affect quality/progression, not e1RM definition.
@@ -340,7 +580,22 @@ When `/update_workout_log` updates a row, call calibration with `db=db` inside t
 - Profile fallback still works when learned calibration is disabled or unavailable.
 - Existing last-log fallback still works.
 
-### Route Tests
+### Phase 2A Unit Tests
+
+- Relationship rules allow only explicit same-lift-key / same-pattern compatible pairs.
+- Blocked relations do not produce candidates.
+- Transfer ratios are directional.
+- Per-hand vs total-load conversion is applied once.
+- Related confidence uses source confidence, sample count, staleness, and `MIN_RELATED_LOGS`.
+- Ignored source-target pairs are excluded.
+- Related transfer is unavailable when no settings row exists.
+- Related transfer is unavailable when `mode == 'off'`.
+- Related transfer is unavailable when `allow_related_exercise_learning == 0`.
+- Exact learned calibration outranks related learned calibration.
+- Exact last-log fallback outranks related learned calibration.
+- Related learned calibration outranks Profile only when all eligibility gates pass.
+
+### Shipped MVP Route Tests
 
 - `/update_workout_log` updates calibration after scored data changes.
 - `/update_workout_log` reuses the existing DB handler path without nested writes.
@@ -350,7 +605,18 @@ When `/update_workout_log` updates a row, call calibration with `db=db` inside t
 - Delete-log endpoint invalidates or recomputes affected calibration.
 - All new responses use `success_response()` / `error_response()`.
 
-### Integration Tests
+### Phase 2A Route Tests
+
+- Settings endpoint persists `allow_related_exercise_learning`.
+- Invalid related settings values return structured errors.
+- Estimate endpoint returns related source only when both learned and related settings are enabled.
+- Estimate endpoint falls back unchanged when related is disabled.
+- Estimate endpoint falls back unchanged when no transfer ratio exists.
+- Ignore endpoint clears only the selected source-target relation.
+- Ignore endpoint does not delete source exact calibration.
+- All new responses use `success_response()` / `error_response()`.
+
+### Shipped MVP Integration Tests
 
 - With settings off, log `120 kg` squat and verify current estimator output is unchanged.
 - With settings on, log `120 kg` squat and verify learned exact-exercise output.
@@ -358,7 +624,18 @@ When `/update_workout_log` updates a row, call calibration with `db=db` inside t
 - Verify current exact-log behavior remains available as fallback.
 - Verify erase-data removes calibration tables.
 
-### E2E Tests
+### Phase 2A Integration Tests
+
+- With related disabled, a source calibration plus transfer ratio does not affect target estimate.
+- With related enabled and no exact target data, target estimate uses the related source.
+- After logging the target exercise once, target estimate uses exact last-log fallback instead of related.
+- After creating usable exact target calibration, target estimate uses exact learned instead of related.
+- Deleting the source's last usable log removes the related suggestion.
+- Ignoring a source-target pair restores Profile/cold-start fallback for that target.
+- Profile reference lift rows are not overwritten.
+- Existing exact-calibration MVP tests remain green unchanged.
+
+### Shipped MVP E2E Tests
 
 - User enables learned suggestions in Profile.
 - User edits scored workout log.
@@ -367,6 +644,15 @@ When `/update_workout_log` updates a row, call calibration with `db=db` inside t
 - User sees learned source badge and explanation.
 - User resets learned calibration.
 - User disables learned suggestions and sees fallback behavior.
+
+### Phase 2A E2E Tests
+
+- User enables related learned suggestions in Profile.
+- User opens Workout Controls for a related target with no exact logs.
+- User sees related-source badge, source exercise name, confidence, and trace details.
+- User applies the related suggestion client-side.
+- User ignores the related source and sees fallback behavior.
+- User disables related learned suggestions and sees fallback behavior while exact learned suggestions remain available.
 
 ### Visual Testing
 
@@ -392,6 +678,8 @@ Required gate:
 
 ## Recommended Build Order
 
+MVP build order is complete through item 8 below:
+
 1. Exact exercise calibration backend.
 2. Settings default-off behavior and regression guard.
 3. Estimator priority integration.
@@ -400,6 +688,17 @@ Required gate:
 6. Trace/source display in Workout Controls.
 7. Profile settings UI.
 8. E2E and visual coverage.
-9. Phase 2 related-exercise calibration plan.
 
-This order gives the user a meaningful exact-exercise learning improvement first, while keeping cross-exercise learning behind a separate, more deliberate design pass.
+Phase 2A recommended order:
+
+1. Opus/product review of the transfer model and first allowed ratio set.
+2. Add Phase 2A tables and cleanup/reinit paths.
+3. Extend settings backend and Profile toggle.
+4. Implement candidate generation behind `allow_related_exercise_learning`.
+5. Implement transfer-ratio lookup and related trace construction.
+6. Integrate estimator priority after exact last-log fallback.
+7. Add ignore source-target endpoint and Workout Controls action.
+8. Add focused pytest, then E2E for the related-source UI.
+9. Run full pytest and relevant Chromium Playwright specs.
+
+This order keeps related transfer behind an explicit second switch until the model is reviewable and testable.

--- a/docs/user_profile/RELATED_EXERCISE_TRANSFER_DESIGN.md
+++ b/docs/user_profile/RELATED_EXERCISE_TRANSFER_DESIGN.md
@@ -1,0 +1,173 @@
+# Related Exercise Transfer Design (Phase 2A)
+
+This document narrows Phase 2 to the first safe implementation slice: related
+exercise suggestions only. It intentionally preserves the shipped MVP model in
+which `learned_strength_calibrations.exercise_name` stores exact exercise rows.
+
+Canonical planning source: `docs/user_profile/LEARNED_CALIBRATION_PLAN.md`.
+
+## Problem
+
+Learned Calibration now works for the exact exercise the user logged. If the
+user logs `Barbell Bench Press`, Workout Controls can learn that exact exercise,
+but a related target such as `Incline Dumbbell Bench Press` still falls through
+to exact log, Profile, cold-start, or static defaults unless that target has its
+own history.
+
+Phase 2A should make related evidence available without mutating exact rows or
+pretending transferred evidence is the same as exact evidence.
+
+## Design Principle
+
+Do related transfer at read time.
+
+- Keep exact learned rows keyed by the real logged exercise name.
+- Do not normalize variant logs into parent key-lift rows.
+- Do not overwrite Profile reference lifts.
+- Do not write planned `user_selection` rows.
+- Do not auto-apply.
+- Do not create related rows copied from source rows.
+- Always show source provenance and transfer math in the estimator trace.
+
+This keeps the data model auditable: exact evidence remains exact, and related
+evidence is a derived suggestion.
+
+## Estimator Priority
+
+Phase 2A priority:
+
+1. Exact exercise learned calibration.
+2. Exact last-log fallback.
+3. Related exercise learned calibration.
+4. Profile reference lifts.
+5. Cold-start demographics.
+6. Static default.
+
+An exact target log immediately suppresses related transfer for that target.
+
+## Settings Gate
+
+Related transfer must require both:
+
+- `user_calibration_settings.mode == 'suggest'`
+- `user_calibration_settings.allow_related_exercise_learning == 1`
+
+No settings row must behave as fully off. The existing `off` / `suggest` mode
+should remain unchanged; do not add `auto_apply` in Phase 2A.
+
+## Transfer Ratios
+
+Use explicit directional ratios. Do not infer ratios from exercise names.
+
+Suggested table:
+
+```text
+exercise_transfer_ratios
+- id
+- source_exercise_name
+- target_exercise_name
+- source_lift_key
+- target_lift_key
+- ratio
+- load_basis
+- relationship_type
+- confidence
+- notes
+- created_at
+- updated_at
+```
+
+Direction matters. `Barbell Bench Press -> Incline Dumbbell Bench Press` is not
+the same claim as the reverse direction.
+
+The first Phase 2A implementation slice should ship with zero default ratios,
+proving plumbing without changing Workout Controls behavior. If seeded ratios
+are added later, keep the set tiny and reviewed.
+
+## Ignore Controls
+
+Suggested table:
+
+```text
+ignored_calibration_transfers
+- id
+- source_exercise_name
+- target_exercise_name
+- created_at
+```
+
+Ignoring a related suggestion should suppress only that source-target pair. It
+must not delete the source exercise's exact learned calibration.
+
+## Read Path
+
+When estimating a target exercise:
+
+1. Run exact learned lookup.
+2. Run exact last-log lookup.
+3. If both miss and related transfer is enabled, find eligible source
+   calibrations.
+4. Join sources to explicit transfer ratios for the target.
+5. Exclude ignored source-target pairs.
+6. Exclude low-confidence, stale, excluded, or unsupported-basis candidates.
+7. Apply the directional ratio and load-basis conversion once.
+8. Reuse the existing progression helper where possible for target reps/weight.
+9. Pick the strongest candidate by confidence, recency, then sample count.
+10. Return `source: "related_learned"` and `reason: "related_calibration"`.
+
+## Write Path
+
+The workout-log write path should remain exact-exercise only:
+
+- A scored log recomputes the exact row for that logged exercise.
+- Deleting a log recomputes or clears the exact row for that logged exercise.
+- Related suggestions are derived later by the estimator.
+- The open `DatabaseHandler` reuse requirement still applies.
+
+Do not upsert related or parent-key rows from a variant log in Phase 2A.
+
+## Trace Payload
+
+The trace must make transfer explicit:
+
+```text
+Source: Related learned calibration
+Learned from: Barbell Bench Press, 4 scored logs, confidence high
+Transfer: Barbell Bench Press -> Incline Dumbbell Bench Press, ratio 0.72
+Load basis: total-load to per-hand
+Progression: maintain and build reps
+```
+
+Trace fields should include:
+
+- source exercise
+- target exercise
+- source confidence
+- source sample count
+- source e1RM
+- relationship type
+- transfer ratio
+- load-basis conversion
+- final suggested target
+- fallback reason explaining why exact learned/log data did not apply
+
+## First Slice Tasks
+
+1. Add additive Phase 2A tables.
+2. Extend settings read/write helpers for `allow_related_exercise_learning`.
+3. Implement read-only related candidate lookup.
+4. Integrate related lookup after exact last-log fallback.
+5. Add related trace construction.
+6. Add ignore source-target endpoint.
+7. Add Profile toggle and Workout Controls related-source copy/actions.
+8. Add focused unit, route, integration, and E2E tests.
+
+## Review Questions
+
+1. Should the first slice ship with zero seeded ratios?
+2. Which source-target pairs are safe enough to seed later?
+3. Should related projection use source `estimated_1rm` or source
+   `suggested_weight` as the input?
+4. Should unilateral/bilateral pairs remain blocked for Phase 2A?
+5. Should all machine/cable transfers require manual ratios?
+6. Should bodyweight-loaded movements remain blocked?

--- a/e2e/learned-calibration.spec.ts
+++ b/e2e/learned-calibration.spec.ts
@@ -16,15 +16,20 @@ import type { Page } from '@playwright/test';
 
 const CALIBRATION_SETTINGS = '/api/user_profile/calibration_settings';
 const CALIBRATION_RESET = '/api/user_profile/calibration/reset';
+const CALIBRATION_IGNORE = '/api/user_profile/calibration/ignore_transfer';
 const ESTIMATE = '/api/user_profile/estimate';
 
 // Keep the shared DB clean: calibration mode is persistent, so force it back
 // off around every test.
 test.beforeEach(async ({ page }) => {
-  await page.request.post(CALIBRATION_SETTINGS, { data: { mode: 'off' } });
+  await page.request.post(CALIBRATION_SETTINGS, {
+    data: { mode: 'off', allow_related_exercise_learning: false },
+  });
 });
 test.afterEach(async ({ page }) => {
-  await page.request.post(CALIBRATION_SETTINGS, { data: { mode: 'off' } });
+  await page.request.post(CALIBRATION_SETTINGS, {
+    data: { mode: 'off', allow_related_exercise_learning: false },
+  });
 });
 
 test.describe('Learned Calibration — Profile settings', () => {
@@ -39,7 +44,9 @@ test.describe('Learned Calibration — Profile settings', () => {
 
     const offRadio = section.locator('input[name="calibration_mode"][value="off"]');
     const suggestRadio = section.locator('input[name="calibration_mode"][value="suggest"]');
+    const relatedCheckbox = section.locator('input[name="allow_related_exercise_learning"]');
     await expect(offRadio).toBeChecked();
+    await expect(relatedCheckbox).toBeDisabled();
 
     // Enable — radios are visually hidden, so click the wrapping label.
     const enableResp = page.waitForResponse(
@@ -48,8 +55,17 @@ test.describe('Learned Calibration — Profile settings', () => {
     await section.locator('.segmented-option', { hasText: 'Suggest' }).click();
     await enableResp;
     await expect(suggestRadio).toBeChecked();
+    await expect(relatedCheckbox).toBeEnabled();
     await expect(page.locator(SELECTORS.TOAST_BODY)).toContainText('Learned suggestions enabled');
     await expect(section.locator('[data-calibration-text]')).toContainText('On');
+
+    const relatedResp = page.waitForResponse(
+      (r) => r.url().includes(CALIBRATION_SETTINGS) && r.request().method() === 'POST',
+    );
+    await relatedCheckbox.check();
+    await relatedResp;
+    await expect(relatedCheckbox).toBeChecked();
+    await expect(section.locator('[data-calibration-text]')).toContainText('related learned');
 
     // Disable — back to off.
     const disableResp = page.waitForResponse(
@@ -58,18 +74,23 @@ test.describe('Learned Calibration — Profile settings', () => {
     await section.locator('.segmented-option', { hasText: 'Off' }).click();
     await disableResp;
     await expect(offRadio).toBeChecked();
+    await expect(relatedCheckbox).toBeDisabled();
+    await expect(relatedCheckbox).not.toBeChecked();
     await expect(page.locator(SELECTORS.TOAST_BODY)).toContainText('turned off');
 
     consoleErrors.assertNoErrors();
   });
 
   test('suggest mode persists across reload', async ({ page }) => {
-    await page.request.post(CALIBRATION_SETTINGS, { data: { mode: 'suggest' } });
+    await page.request.post(CALIBRATION_SETTINGS, {
+      data: { mode: 'suggest', allow_related_exercise_learning: true },
+    });
     await page.goto(ROUTES.USER_PROFILE);
     await waitForPageReady(page);
     await expect(
       page.locator('input[name="calibration_mode"][value="suggest"]'),
     ).toBeChecked();
+    await expect(page.locator('input[name="allow_related_exercise_learning"]')).toBeChecked();
   });
 });
 
@@ -95,7 +116,7 @@ test.describe('Learned Calibration — Workout Controls badge & actions', () => 
           {
             label: 'Learned from your logged sets',
             value: '120 kg × 6–8',
-            detail: 'Calibrated from 3 recent scored logs for this exact exercise (confidence: high).',
+            detail: 'Calibrated from 3 scored logs for this exact exercise (confidence: high).',
           },
           {
             label: 'Estimated strength',
@@ -122,6 +143,43 @@ test.describe('Learned Calibration — Workout Controls badge & actions', () => 
       trace: {
         source: 'log',
         steps: [{ label: 'From your last logged set', value: '60 kg × 6–8' }],
+      },
+    },
+  };
+
+  const RELATED_ESTIMATE = {
+    ok: true,
+    status: 'success',
+    data: {
+      weight: 35,
+      sets: 3,
+      min_rep: 8,
+      max_rep: 10,
+      rir: 2,
+      rpe: 8,
+      source: 'related_learned',
+      reason: 'related_calibration',
+      is_dumbbell: true,
+      trace: {
+        source: 'related_learned',
+        confidence: 'high',
+        sample_count: 4,
+        source_exercise: 'Barbell Bench Press',
+        target_exercise: 'Incline Dumbbell Bench Press',
+        transfer_ratio: 0.72,
+        load_basis: 'total_to_per_hand',
+        steps: [
+          {
+            label: 'Related learned calibration',
+            value: 'Learned from Barbell Bench Press',
+            detail: '4 scored logs, confidence: high. Exact learned/log data for Incline Dumbbell Bench Press was not available.',
+          },
+          {
+            label: 'Transfer',
+            value: 'Barbell Bench Press -> Incline Dumbbell Bench Press',
+            detail: 'Relationship: manual; ratio 0.72; load basis: total to per hand (factor 0.5).',
+          },
+        ],
       },
     },
   };
@@ -227,6 +285,173 @@ test.describe('Learned Calibration — Workout Controls badge & actions', () => 
     await expect(toggle).toHaveAttribute('aria-expanded', 'false');
     // Badge stays — Keep current does not dismiss the learned source.
     await expect(page.locator('#workout-estimate-learned-badge')).toBeVisible();
+
+    consoleErrors.assertNoErrors();
+  });
+
+  test('shows related badge and Ignore source fallback', async ({ page, consoleErrors }) => {
+    consoleErrors.startCollecting();
+
+    let relatedActive = true;
+    await page.route(`**${ESTIMATE}**`, async (route) => {
+      await route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify(relatedActive ? RELATED_ESTIMATE : FALLBACK_ESTIMATE),
+      });
+    });
+    await page.route(`**${CALIBRATION_IGNORE}`, async (route) => {
+      relatedActive = false;
+      await route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify({
+          ok: true,
+          status: 'success',
+          data: {
+            source_exercise: 'Barbell Bench Press',
+            target_exercise: 'Incline Dumbbell Bench Press',
+          },
+        }),
+      });
+    });
+
+    await page.goto(ROUTES.WORKOUT_PLAN);
+    await waitForPageReady(page);
+    await selectFirstExercise(page);
+
+    const badge = page.locator('#workout-estimate-learned-badge');
+    await expect(badge).toBeVisible();
+    await expect(badge).toContainText('Related');
+    await expect(page.locator('#workout-estimate-provenance')).toContainText('related exercise');
+
+    const toggle = page.locator('#workout-estimate-trace-toggle');
+    const container = page.locator('#workout-estimate-trace');
+    await toggle.click();
+    await expect(container).toContainText('Learned from a related exercise');
+    await expect(container).toContainText('Barbell Bench Press');
+    await expect(page.locator('[data-related-ignore]')).toBeVisible();
+
+    const ignoreDone = page.waitForResponse((r) => r.url().includes(CALIBRATION_IGNORE));
+    const refetch = page.waitForResponse((r) => r.url().includes(ESTIMATE));
+    await page.locator('[data-related-ignore]').click();
+    await ignoreDone;
+    await refetch;
+    await expect(badge).toBeHidden();
+    await expect(page.locator('#workout-estimate-provenance')).toContainText('from your last set');
+
+    consoleErrors.assertNoErrors();
+  });
+});
+
+test.describe('Learned Calibration — Golden Path (Real Data)', () => {
+  // Test the full end-to-end loop without route mocks:
+  // 1. Seed plan with an exercise
+  // 2. Import into Workout Log
+  // 3. Edit scored metrics to simulate an aggressive set
+  // 4. Return to Workout Plan and verify the real Learned Estimate is shown
+  test('end-to-end loop triggers auto-calibration on log save', async ({ page, consoleErrors }) => {
+    consoleErrors.startCollecting();
+
+    // 1. Enable suggestion mode
+    const settingsResponse = await page.request.post(CALIBRATION_SETTINGS, { data: { mode: 'suggest' } });
+    expect(settingsResponse.ok()).toBeTruthy();
+
+    // 2. Seed the workout plan with Barbell Bench Press
+    await page.goto(ROUTES.WORKOUT_PLAN);
+    await waitForPageReady(page);
+
+    // Select the routine structure
+    await page.locator(SELECTORS.ROUTINE_ENV).selectOption('GYM');
+    await page.waitForFunction(() => {
+      const s = document.getElementById('routine-program') as HTMLSelectElement | null;
+      return Boolean(s && s.options.length > 1);
+    });
+    await page.locator(SELECTORS.ROUTINE_PROGRAM).selectOption('Full Body');
+    await page.waitForFunction(() => {
+      const s = document.getElementById('routine-day') as HTMLSelectElement | null;
+      return Boolean(s && s.options.length > 1);
+    });
+    await page.locator(SELECTORS.ROUTINE_DAY).selectOption('Workout A');
+
+    const estimateDoneSeed = page.waitForResponse((r) => r.url().includes(ESTIMATE));
+    await page.locator(SELECTORS.EXERCISE_SEARCH).selectOption('Barbell Bench Press');
+    await estimateDoneSeed;
+
+    // Add one plan row. A single recent valid scored log is enough for the
+    // shipped MVP to reach usable medium confidence.
+    await page.locator(SELECTORS.ADD_EXERCISE_BTN).click();
+    await page.waitForSelector('#workout_plan_table_body tr');
+
+    // 3. Go to Workout Log
+    await page.goto(ROUTES.WORKOUT_LOG);
+    await waitForPageReady(page);
+
+    // Import the planned row, then use the UI to create the real scored log.
+    const importResponse = page.waitForResponse((r) => r.url().includes('/export_to_workout_log') && r.request().method() === 'POST');
+    await page.locator('#import-from-plan-btn').click();
+    expect((await importResponse).ok()).toBeTruthy();
+
+    // Wait for the row to be present
+    await page.waitForSelector('.workout-log-table tbody tr');
+    const row = page.locator('.workout-log-table tbody tr').first();
+
+    // Weight
+    const weightCell = row.locator('td[data-field="scored_weight"]');
+    await weightCell.locator('.editable-text').click();
+    await weightCell.locator('input').fill('140');
+    await weightCell.locator('input').blur();
+
+    // Min Reps
+    const minRepsCell = row.locator('td[data-field="scored_min_reps"]');
+    await minRepsCell.locator('.editable-text').click();
+    await minRepsCell.locator('input').fill('6');
+    await minRepsCell.locator('input').blur();
+
+    // Max Reps
+    const maxRepsCell = row.locator('td[data-field="scored_max_reps"]');
+    await maxRepsCell.locator('.editable-text').click();
+    await maxRepsCell.locator('input').fill('6');
+    await maxRepsCell.locator('input').blur();
+
+    // RIR
+    const rirCell = row.locator('td[data-field="scored_rir"]');
+    await rirCell.locator('.editable-text').click();
+    await rirCell.locator('input').fill('2');
+
+    const updateResponse = page.waitForResponse((r) => r.url().includes('/update_workout_log') && r.request().method() === 'POST');
+    await rirCell.locator('input').blur();
+    expect((await updateResponse).ok()).toBeTruthy();
+
+    await page.waitForSelector(SELECTORS.TOAST_CONTAINER + ' .toast.show');
+    await page.locator(SELECTORS.TOAST_CONTAINER).locator('.btn-close').first().click();
+
+    // 5. Go back to Workout Plan and select the exercise to see the learned estimate
+    await page.goto(ROUTES.WORKOUT_PLAN);
+    await waitForPageReady(page);
+
+    await page.locator(SELECTORS.ROUTINE_ENV).selectOption('GYM');
+    await page.waitForFunction(() => {
+      const s = document.getElementById('routine-program') as HTMLSelectElement | null;
+      return Boolean(s && s.options.length > 1);
+    });
+    await page.locator(SELECTORS.ROUTINE_PROGRAM).selectOption('Full Body');
+    await page.waitForFunction(() => {
+      const s = document.getElementById('routine-day') as HTMLSelectElement | null;
+      return Boolean(s && s.options.length > 1);
+    });
+    await page.locator(SELECTORS.ROUTINE_DAY).selectOption('Workout A');
+
+    const estimateDoneReal = page.waitForResponse((r) => r.url().includes(ESTIMATE));
+    await page.locator(SELECTORS.EXERCISE_SEARCH).selectOption('Barbell Bench Press');
+    await estimateDoneReal;
+
+    // 6. Verify real badge (no mocks)
+    const badge = page.locator('#workout-estimate-learned-badge');
+    await expect(badge).toBeVisible();
+    await expect(badge).toContainText('Learned');
+    await expect(badge).toContainText('medium');
+    await expect(page.locator('#workout-estimate-provenance')).toContainText('learned');
 
     consoleErrors.assertNoErrors();
   });

--- a/routes/user_profile.py
+++ b/routes/user_profile.py
@@ -15,9 +15,10 @@ from utils.errors import error_response, success_response
 from utils.logger import get_logger
 from utils.strength_calibration import (
     VALID_CALIBRATION_MODES,
-    get_calibration_mode,
+    get_calibration_settings,
+    ignore_calibration_transfer,
     reset_calibration_for_exercise,
-    set_calibration_mode,
+    set_calibration_settings,
 )
 from utils.profile_estimator import (
     DEFAULT_PREFERENCES,
@@ -193,6 +194,17 @@ def _nullable_int(value: Any, field_name: str, minimum: int, maximum: int) -> Op
     return parsed
 
 
+def _optional_bool(data: dict[str, Any], field_name: str) -> Optional[bool]:
+    if field_name not in data or data.get(field_name) is None:
+        return None
+    value = data.get(field_name)
+    if isinstance(value, bool):
+        return value
+    if value in (0, 1):
+        return bool(value)
+    raise ValueError(f"{field_name} must be true or false")
+
+
 def _load_latest_body_composition(db: DatabaseHandler) -> Optional[dict[str, Any]]:
     """Return the most recent `body_composition_snapshots` row enriched with
     the effective BFP (Navy if measured, else BMI), the ACE band label, and
@@ -273,9 +285,11 @@ def _load_profile_context(db: DatabaseHandler) -> dict[str, Any]:
     ]
     insights = _build_profile_insights(profile or {}, lift_rows)
     latest_body_composition = _load_latest_body_composition(db)
+    calibration_settings = get_calibration_settings(db=db)
     return {
         "profile": profile or {},
-        "calibration_mode": get_calibration_mode(db=db),
+        "calibration_mode": calibration_settings["mode"],
+        "calibration_allow_related": calibration_settings["allow_related_exercise_learning"],
         "reference_lifts": reference_lifts,
         "reference_lift_groups": reference_lift_groups,
         "reference_lift_groups_anterior": reference_lift_groups_anterior,
@@ -497,8 +511,8 @@ def calibration_settings():
     if request.method == "GET":
         try:
             with DatabaseHandler() as db:
-                mode = get_calibration_mode(db=db)
-            return jsonify(success_response(data={"mode": mode}))
+                settings = get_calibration_settings(db=db)
+            return jsonify(success_response(data=settings))
         except Exception:
             logger.exception("Failed to read calibration settings")
             return error_response("INTERNAL_ERROR", "Failed to read calibration settings", 500)
@@ -511,10 +525,15 @@ def calibration_settings():
         mode = _nullable_text(data.get("mode"))
         if mode not in VALID_CALIBRATION_MODES:
             raise ValueError(f"mode must be one of {', '.join(VALID_CALIBRATION_MODES)}")
+        allow_related = _optional_bool(data, "allow_related_exercise_learning")
 
         with DatabaseHandler() as db:
-            saved = set_calibration_mode(mode, db=db)
-        return jsonify(success_response(data={"mode": saved}, message="Calibration settings saved"))
+            saved = set_calibration_settings(
+                mode,
+                db=db,
+                allow_related_exercise_learning=allow_related,
+            )
+        return jsonify(success_response(data=saved, message="Calibration settings saved"))
     except ValueError as exc:
         logger.warning("Validation error saving calibration settings", extra={"error": str(exc)})
         return error_response("VALIDATION_ERROR", str(exc), 400)
@@ -546,3 +565,34 @@ def reset_calibration():
     except Exception:
         logger.exception("Failed to reset calibration", extra={"payload": data})
         return error_response("INTERNAL_ERROR", "Failed to reset calibration", 500)
+
+
+@user_profile_bp.route("/api/user_profile/calibration/ignore_transfer", methods=["POST"])
+def ignore_calibration_transfer_route():
+    """Ignore one related source-target calibration pair."""
+    data = None
+    try:
+        data = _get_json_payload("ignore_calibration_transfer")
+        if not isinstance(data, dict):
+            raise ValueError("Invalid JSON data")
+        source = _nullable_text(data.get("source_exercise"))
+        target = _nullable_text(data.get("target_exercise"))
+        if source is None:
+            raise ValueError("source_exercise is required")
+        if target is None:
+            raise ValueError("target_exercise is required")
+
+        with DatabaseHandler() as db:
+            ignore_calibration_transfer(source, target, db=db)
+        return jsonify(
+            success_response(
+                data={"source_exercise": source, "target_exercise": target},
+                message="Related calibration ignored",
+            )
+        )
+    except ValueError as exc:
+        logger.warning("Validation error ignoring calibration transfer", extra={"error": str(exc)})
+        return error_response("VALIDATION_ERROR", str(exc), 400)
+    except Exception:
+        logger.exception("Failed to ignore calibration transfer", extra={"payload": data})
+        return error_response("INTERNAL_ERROR", "Failed to ignore calibration transfer", 500)

--- a/static/css/pages-user-profile.css
+++ b/static/css/pages-user-profile.css
@@ -573,6 +573,32 @@
     outline-offset: -2px;
 }
 
+.profile-checkbox-option {
+    align-items: center;
+    background: color-mix(in srgb, var(--surface-2, #f5f7fb) 74%, transparent);
+    border: 1px solid color-mix(in srgb, var(--ink-3, #7c849c) 18%, transparent);
+    border-radius: 8px;
+    color: var(--ink-2, #4a5170);
+    cursor: pointer;
+    display: flex;
+    font-size: 0.86rem;
+    font-weight: 650;
+    gap: 0.55rem;
+    margin: 0;
+    min-height: 38px;
+    padding: 0.45rem 0.65rem;
+}
+
+.profile-checkbox-option input {
+    accent-color: var(--accent, #4c6ef5);
+    flex: 0 0 auto;
+}
+
+.profile-checkbox-option:has(input:disabled) {
+    cursor: not-allowed;
+    opacity: 0.62;
+}
+
 [data-theme='dark'] .profile-field .form-label,
 [data-theme='dark'] .preference-group legend {
     color: var(--ink-2, #b4bad0);
@@ -598,6 +624,12 @@
 [data-theme='dark'] .segmented-option input:checked + span {
     background: color-mix(in srgb, var(--accent, #6d8dff) 24%, var(--surface-1, #161a2d));
     color: var(--ink-1, #eef1f6);
+}
+
+[data-theme='dark'] .profile-checkbox-option {
+    background: color-mix(in srgb, var(--surface-1, #161a2d) 80%, black);
+    border-color: color-mix(in srgb, var(--ink-3, #939bb2) 22%, transparent);
+    color: var(--ink-2, #b4bad0);
 }
 
 @media (min-width: 1200px) {

--- a/static/js/modules/user-profile.js
+++ b/static/js/modules/user-profile.js
@@ -1064,37 +1064,85 @@ const CALIBRATION_MODE_TEXT = {
     suggest: 'On — Workout Controls learns from your recent scored logs',
 };
 
-function updateCalibrationStatusText(mode) {
+function updateCalibrationStatusText(mode, allowRelated = false) {
     const text = document.querySelector('[data-calibration-text]');
     if (text) {
-        text.textContent = CALIBRATION_MODE_TEXT[mode] || CALIBRATION_MODE_TEXT.off;
+        if (mode === 'suggest' && allowRelated) {
+            text.textContent = 'On — exact and related learned suggestions are enabled';
+        } else {
+            text.textContent = CALIBRATION_MODE_TEXT[mode] || CALIBRATION_MODE_TEXT.off;
+        }
+    }
+}
+
+function readCalibrationForm(form) {
+    const checkedMode = form.querySelector('input[name="calibration_mode"]:checked');
+    const related = form.querySelector('input[name="allow_related_exercise_learning"]');
+    const mode = checkedMode ? checkedMode.value : 'off';
+    return {
+        mode,
+        allow_related_exercise_learning: mode === 'suggest' && Boolean(related?.checked),
+    };
+}
+
+function syncRelatedCalibrationControl(form, settings) {
+    const related = form.querySelector('input[name="allow_related_exercise_learning"]');
+    if (!related) return;
+    related.disabled = settings.mode !== 'suggest';
+    if (settings.mode !== 'suggest') {
+        related.checked = false;
     }
 }
 
 function bindCalibrationSettings() {
     const form = document.getElementById('profile-calibration-form');
     if (!form) return;
-    const checked = form.querySelector('input[name="calibration_mode"]:checked');
-    updateCalibrationStatusText(checked ? checked.value : 'off');
+    let currentSettings = readCalibrationForm(form);
+    syncRelatedCalibrationControl(form, currentSettings);
+    updateCalibrationStatusText(
+        currentSettings.mode,
+        currentSettings.allow_related_exercise_learning,
+    );
 
     form.addEventListener('change', async (event) => {
         const input = event.target;
-        if (!input || input.name !== 'calibration_mode') return;
-        const mode = input.value;
+        if (
+            !input
+            || !['calibration_mode', 'allow_related_exercise_learning'].includes(input.name)
+        ) return;
+        const previousSettings = currentSettings;
+        const settings = readCalibrationForm(form);
+        syncRelatedCalibrationControl(form, settings);
         try {
             const response = await api.post(
                 '/api/user_profile/calibration_settings',
-                { mode },
+                settings,
             );
-            const saved = response?.data?.mode || mode;
-            updateCalibrationStatusText(saved);
+            const saved = {
+                ...settings,
+                ...(response?.data || {}),
+            };
+            currentSettings = saved;
+            syncRelatedCalibrationControl(form, saved);
+            updateCalibrationStatusText(saved.mode, saved.allow_related_exercise_learning);
             showToast(
                 'success',
-                saved === 'suggest'
+                saved.mode === 'suggest'
                     ? 'Learned suggestions enabled'
                     : 'Learned suggestions turned off',
             );
         } catch (error) {
+            const modeInput = form.querySelector(
+                `input[name="calibration_mode"][value="${previousSettings.mode}"]`,
+            );
+            if (modeInput) modeInput.checked = true;
+            const related = form.querySelector('input[name="allow_related_exercise_learning"]');
+            if (related) related.checked = previousSettings.allow_related_exercise_learning;
+            syncRelatedCalibrationControl(form, previousSettings);
+            updateCalibrationStatusText(
+                previousSettings.mode,
+                previousSettings.allow_related_exercise_learning,
+            );
             showToast('error', error?.message || 'Failed to save calibration settings', {
                 requestId: error?.requestId,
             });

--- a/static/js/modules/workout-plan.js
+++ b/static/js/modules/workout-plan.js
@@ -149,6 +149,7 @@ const DEFAULT_PROFILE_ESTIMATE = {
 
 const ESTIMATE_SOURCE_LABELS = {
     learned: 'learned from your recent logs',
+    related_learned: 'learned from a related exercise',
     log: 'from your last set',
     profile: 'from your profile',
     cold_start: 'from population estimate',
@@ -827,7 +828,7 @@ function applyEstimateToWorkoutControls(estimate) {
 function updateLearnedBadge(estimate) {
     const badge = document.getElementById('workout-estimate-learned-badge');
     if (!badge) return;
-    const isLearned = estimate?.source === 'learned';
+    const isLearned = ['learned', 'related_learned'].includes(estimate?.source);
     if (!isLearned) {
         badge.hidden = true;
         badge.dataset.confidence = '';
@@ -840,13 +841,21 @@ function updateLearnedBadge(estimate) {
     badge.dataset.confidence = confidence;
     const label = badge.querySelector('.workout-estimate-learned-badge-label');
     if (label) {
+        const prefix = estimate?.source === 'related_learned' ? 'Related' : 'Learned';
         label.textContent = confidence
-            ? `Learned · ${CONFIDENCE_LABELS[confidence] || confidence}`
-            : 'Learned';
+            ? `${prefix} · ${CONFIDENCE_LABELS[confidence] || confidence}`
+            : prefix;
     }
-    badge.title = sampleCount
-        ? `Suggested from ${sampleCount} recent scored ${sampleCount === 1 ? 'log' : 'logs'} for this exercise`
-        : 'Suggested from your recent scored logs';
+    if (estimate?.source === 'related_learned') {
+        const source = estimate?.trace?.source_exercise || 'a related exercise';
+        badge.title = sampleCount
+            ? `Suggested from ${sampleCount} scored ${sampleCount === 1 ? 'log' : 'logs'} for ${source}`
+            : `Suggested from ${source}`;
+    } else {
+        badge.title = sampleCount
+            ? `Suggested from ${sampleCount} scored ${sampleCount === 1 ? 'log' : 'logs'} for this exercise`
+            : 'Suggested from your scored logs';
+    }
 }
 
 // Force the current learned suggestion into the Workout Controls inputs.
@@ -877,6 +886,27 @@ async function resetLearnedForCurrentExercise() {
         await applyUserProfileEstimateForSelectedExercise();
     } catch (error) {
         showToast('error', error?.message || 'Failed to reset learned data', {
+            requestId: error?.requestId,
+        });
+    }
+}
+
+async function ignoreRelatedTransferForCurrentExercise() {
+    const estimate = latestTracePayload;
+    const sourceExercise = estimate?.trace?.source_exercise || '';
+    const targetExercise = estimate?.trace?.target_exercise
+        || document.getElementById('exercise')?.value
+        || '';
+    if (!sourceExercise || !targetExercise) return;
+    try {
+        await api.post('/api/user_profile/calibration/ignore_transfer', {
+            source_exercise: sourceExercise,
+            target_exercise: targetExercise,
+        });
+        showToast('success', 'Related suggestion ignored for this exercise');
+        await applyUserProfileEstimateForSelectedExercise();
+    } catch (error) {
+        showToast('error', error?.message || 'Failed to ignore related suggestion', {
             requestId: error?.requestId,
         });
     }
@@ -919,6 +949,7 @@ function renderEstimateTrace(estimate) {
 
     const headlineMap = {
         learned: 'Learned from your recent logs',
+        related_learned: 'Learned from a related exercise',
         log: 'From your last logged set',
         profile: 'From your saved reference lift',
         cold_start: 'From a population estimate',
@@ -978,7 +1009,7 @@ function renderEstimateTrace(estimate) {
         container.appendChild(hint);
     }
 
-    if (trace.source === 'learned') {
+    if (['learned', 'related_learned'].includes(trace.source)) {
         container.appendChild(buildLearnedActions());
     }
 }
@@ -1011,6 +1042,15 @@ function buildLearnedActions() {
     reset.addEventListener('click', resetLearnedForCurrentExercise);
 
     actions.append(apply, keep, reset);
+    if (latestTracePayload?.source === 'related_learned') {
+        const ignore = document.createElement('button');
+        ignore.type = 'button';
+        ignore.className = 'workout-estimate-trace-action is-reset';
+        ignore.setAttribute('data-related-ignore', '');
+        ignore.textContent = 'Ignore this source';
+        ignore.addEventListener('click', ignoreRelatedTransferForCurrentExercise);
+        actions.append(ignore);
+    }
     return actions;
 }
 

--- a/templates/user_profile.html
+++ b/templates/user_profile.html
@@ -514,6 +514,13 @@
                                 </label>
                             </div>
                         </fieldset>
+                        <fieldset class="preference-group" data-setting="related-calibration">
+                            <legend>Related exercise suggestions</legend>
+                            <label class="profile-checkbox-option">
+                                <input type="checkbox" name="allow_related_exercise_learning" {% if calibration_allow_related %}checked{% endif %} {% if calibration_mode != 'suggest' %}disabled{% endif %}>
+                                <span>Use related learned lifts when this exercise has no exact log</span>
+                            </label>
+                        </fieldset>
                         <div class="profile-actions profile-actions-end">
                             <div class="profile-autosave-status" data-calibration-status="idle" role="status" aria-live="polite">
                                 <i class="fas fa-cloud-check profile-autosave-icon" aria-hidden="true"></i>

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -112,6 +112,8 @@ def app(test_db_path):
                 tables = [
                     'program_backup_items',  # Drop child table first (FK constraint)
                     'program_backups',        # Then parent backup table
+                    'ignored_calibration_transfers',
+                    'exercise_transfer_ratios',
                     'learned_strength_calibrations',
                     'user_calibration_settings',
                     'user_profile_preferences',
@@ -175,6 +177,10 @@ def clean_db(db_handler):
         tables = [
             'program_backup_items',
             'program_backups',
+            'ignored_calibration_transfers',
+            'exercise_transfer_ratios',
+            'learned_strength_calibrations',
+            'user_calibration_settings',
             'user_profile_preferences',
             'user_profile_lifts',
             'user_profile',

--- a/tests/test_calibration_integration.py
+++ b/tests/test_calibration_integration.py
@@ -8,11 +8,15 @@ calibration. See ``docs/user_profile/LEARNED_CALIBRATION_PLAN.md``.
 """
 from utils.strength_calibration import (
     get_calibration_mode,
+    get_calibration_settings,
     set_calibration_mode,
+    set_calibration_settings,
     update_calibration_for_exercise,
 )
 
 SQUAT = "Barbell Back Squat"
+BENCH = "Barbell Bench Press"
+INCLINE_DB_BENCH = "Incline Dumbbell Bench Press"
 
 
 def _seed_exercise(exercise_factory):
@@ -38,6 +42,62 @@ def _seed_log(clean_db, workout_plan_factory, workout_log_factory, **scored):
     return workout_log_factory(plan_id=plan_id, **defaults)
 
 
+def _seed_related_bench_pair(exercise_factory):
+    exercise_factory(
+        BENCH,
+        primary_muscle_group="Chest",
+        equipment="Barbell",
+        mechanic="Compound",
+    )
+    exercise_factory(
+        INCLINE_DB_BENCH,
+        primary_muscle_group="Chest",
+        equipment="Dumbbells",
+        mechanic="Compound",
+    )
+
+
+def _seed_high_confidence_bench_source(
+    clean_db, workout_plan_factory, workout_log_factory
+):
+    plan_id = workout_plan_factory(exercise_name=BENCH)
+    for _ in range(3):
+        workout_log_factory(
+            plan_id=plan_id,
+            exercise=BENCH,
+            scored_weight=100.0,
+            scored_min_reps=8,
+            scored_max_reps=8,
+            scored_rir=2,
+        )
+    calibration = update_calibration_for_exercise(BENCH, db=clean_db)
+    assert calibration["confidence"] == "high"
+    return calibration
+
+
+def _insert_bench_to_incline_ratio(clean_db):
+    clean_db.execute_query(
+        """
+        INSERT INTO exercise_transfer_ratios (
+            source_exercise_name, target_exercise_name,
+            source_lift_key, target_lift_key, ratio, load_basis,
+            relationship_type, confidence, notes
+        ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
+        """,
+        (
+            BENCH,
+            INCLINE_DB_BENCH,
+            "barbell_bench_press",
+            "incline_bench_press",
+            0.72,
+            "total_to_per_hand",
+            "manual",
+            "high",
+            "Test-only explicit directional ratio.",
+        ),
+    )
+
+
 # --------------------------------------------------------------------------- #
 # Settings endpoint
 # --------------------------------------------------------------------------- #
@@ -59,6 +119,34 @@ def test_settings_set_suggest_round_trips(client, clean_db):
 
     get = client.get("/api/user_profile/calibration_settings")
     assert get.get_json()["data"]["mode"] == "suggest"
+    assert get.get_json()["data"]["allow_related_exercise_learning"] is False
+
+
+def test_settings_related_flag_round_trips(client, clean_db):
+    post = client.post(
+        "/api/user_profile/calibration_settings",
+        json={"mode": "suggest", "allow_related_exercise_learning": True},
+    )
+    assert post.status_code == 200
+    assert post.get_json()["data"] == {
+        "mode": "suggest",
+        "allow_related_exercise_learning": True,
+        "min_sessions_for_related": None,
+    }
+
+    settings = get_calibration_settings(db=clean_db)
+    assert settings["mode"] == "suggest"
+    assert settings["allow_related_exercise_learning"] is True
+
+
+def test_settings_rejects_invalid_related_flag(client, clean_db):
+    resp = client.post(
+        "/api/user_profile/calibration_settings",
+        json={"mode": "suggest", "allow_related_exercise_learning": "yes"},
+    )
+    assert resp.status_code == 400
+    assert resp.get_json()["error"]["code"] == "VALIDATION_ERROR"
+    assert get_calibration_settings(db=clean_db)["mode"] == "off"
 
 
 def test_settings_rejects_invalid_mode(client, clean_db):
@@ -151,6 +239,128 @@ def test_suggest_mode_falls_back_when_no_calibration_row(
     resp = client.get("/api/user_profile/estimate", query_string={"exercise": SQUAT})
     estimate = resp.get_json()["data"]
     assert estimate["source"] == "log"
+
+
+# --------------------------------------------------------------------------- #
+# Related learned transfer (Phase 2A)
+# --------------------------------------------------------------------------- #
+
+def test_related_disabled_keeps_existing_fallback_unchanged(
+    client, clean_db, exercise_factory, workout_plan_factory, workout_log_factory
+):
+    _seed_related_bench_pair(exercise_factory)
+    _seed_high_confidence_bench_source(clean_db, workout_plan_factory, workout_log_factory)
+    _insert_bench_to_incline_ratio(clean_db)
+    set_calibration_mode("suggest", db=clean_db)
+
+    resp = client.get(
+        "/api/user_profile/estimate", query_string={"exercise": INCLINE_DB_BENCH}
+    )
+    estimate = resp.get_json()["data"]
+    assert estimate["source"] == "default"
+    assert estimate["reason"] == "default_no_reference"
+
+
+def test_related_enabled_without_ratio_keeps_existing_fallback(
+    client, clean_db, exercise_factory, workout_plan_factory, workout_log_factory
+):
+    _seed_related_bench_pair(exercise_factory)
+    _seed_high_confidence_bench_source(clean_db, workout_plan_factory, workout_log_factory)
+    set_calibration_settings(
+        "suggest", db=clean_db, allow_related_exercise_learning=True
+    )
+
+    resp = client.get(
+        "/api/user_profile/estimate", query_string={"exercise": INCLINE_DB_BENCH}
+    )
+    estimate = resp.get_json()["data"]
+    assert estimate["source"] == "default"
+    assert estimate["reason"] == "default_no_reference"
+
+
+def test_related_enabled_with_ratio_surfaces_related_source(
+    client, clean_db, exercise_factory, workout_plan_factory, workout_log_factory
+):
+    _seed_related_bench_pair(exercise_factory)
+    source = _seed_high_confidence_bench_source(
+        clean_db, workout_plan_factory, workout_log_factory
+    )
+    _insert_bench_to_incline_ratio(clean_db)
+    set_calibration_settings(
+        "suggest", db=clean_db, allow_related_exercise_learning=True
+    )
+
+    resp = client.get(
+        "/api/user_profile/estimate", query_string={"exercise": INCLINE_DB_BENCH}
+    )
+    estimate = resp.get_json()["data"]
+    assert estimate["source"] == "related_learned"
+    assert estimate["reason"] == "related_calibration"
+    assert estimate["trace"]["source_exercise"] == BENCH
+    assert estimate["trace"]["target_exercise"] == INCLINE_DB_BENCH
+    assert estimate["trace"]["transfer_ratio"] == 0.72
+    assert estimate["trace"]["load_basis"] == "total_to_per_hand"
+    assert estimate["trace"]["sample_count"] == source["sample_count"]
+    expected_target_e1rm = source["estimated_1rm"] * 0.72 * 0.5
+    assert estimate["trace"]["steps"][2]["value"] == f"~{expected_target_e1rm:g} kg e1RM"
+    assert estimate["weight"] == 39.0
+
+
+def test_exact_target_log_outranks_related_transfer(
+    client, clean_db, exercise_factory, workout_plan_factory, workout_log_factory
+):
+    _seed_related_bench_pair(exercise_factory)
+    _seed_high_confidence_bench_source(clean_db, workout_plan_factory, workout_log_factory)
+    _insert_bench_to_incline_ratio(clean_db)
+    set_calibration_settings(
+        "suggest", db=clean_db, allow_related_exercise_learning=True
+    )
+    target_plan = workout_plan_factory(exercise_name=INCLINE_DB_BENCH)
+    workout_log_factory(
+        plan_id=target_plan,
+        exercise=INCLINE_DB_BENCH,
+        scored_weight=35.0,
+        scored_min_reps=8,
+        scored_max_reps=8,
+    )
+
+    resp = client.get(
+        "/api/user_profile/estimate", query_string={"exercise": INCLINE_DB_BENCH}
+    )
+    estimate = resp.get_json()["data"]
+    assert estimate["source"] == "log"
+    assert estimate["weight"] == 35.0
+
+
+def test_ignore_transfer_endpoint_suppresses_pair_only(
+    client, clean_db, exercise_factory, workout_plan_factory, workout_log_factory
+):
+    _seed_related_bench_pair(exercise_factory)
+    _seed_high_confidence_bench_source(clean_db, workout_plan_factory, workout_log_factory)
+    _insert_bench_to_incline_ratio(clean_db)
+    set_calibration_settings(
+        "suggest", db=clean_db, allow_related_exercise_learning=True
+    )
+
+    ignored = client.post(
+        "/api/user_profile/calibration/ignore_transfer",
+        json={"source_exercise": BENCH, "target_exercise": INCLINE_DB_BENCH},
+    )
+    assert ignored.status_code == 200
+    assert ignored.get_json()["ok"] is True
+
+    source_row = clean_db.fetch_one(
+        "SELECT * FROM learned_strength_calibrations WHERE exercise_name = ?",
+        (BENCH,),
+    )
+    assert source_row is not None
+
+    resp = client.get(
+        "/api/user_profile/estimate", query_string={"exercise": INCLINE_DB_BENCH}
+    )
+    estimate = resp.get_json()["data"]
+    assert estimate["source"] == "default"
+    assert estimate["reason"] == "default_no_reference"
 
 
 # --------------------------------------------------------------------------- #

--- a/tests/test_user_profile_routes.py
+++ b/tests/test_user_profile_routes.py
@@ -186,18 +186,24 @@ def test_profile_page_renders_calibration_off_by_default(client, clean_db):
     html = response.get_data(as_text=True)
     assert "Learned Calibration" in html
     assert 'name="calibration_mode"' in html
+    assert 'name="allow_related_exercise_learning"' in html
     # `off` radio is checked, `suggest` is not.
     assert 'value="off" checked' in html
     assert 'value="suggest" checked' not in html
+    assert 'name="allow_related_exercise_learning"  disabled' in html
 
 
 def test_profile_page_reflects_suggest_mode(client, clean_db):
     """Enabling `suggest` is reflected in the rendered control state."""
-    client.post("/api/user_profile/calibration_settings", json={"mode": "suggest"})
+    client.post(
+        "/api/user_profile/calibration_settings",
+        json={"mode": "suggest", "allow_related_exercise_learning": True},
+    )
 
     html = client.get("/user_profile").get_data(as_text=True)
     assert 'value="suggest" checked' in html
     assert 'value="off" checked' not in html
+    assert 'name="allow_related_exercise_learning" checked' in html
 
 
 def test_user_profile_page_renders_grouped_questionnaire(client, clean_db):

--- a/utils/database.py
+++ b/utils/database.py
@@ -641,9 +641,48 @@ def add_strength_calibration_tables() -> None:
             updated_at DATETIME
         )
     """
+    ddl_transfer_ratios = """
+        CREATE TABLE IF NOT EXISTS exercise_transfer_ratios (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            source_exercise_name TEXT NOT NULL,
+            target_exercise_name TEXT NOT NULL,
+            source_lift_key TEXT,
+            target_lift_key TEXT,
+            ratio REAL NOT NULL CHECK (ratio > 0),
+            load_basis TEXT NOT NULL CHECK (
+                load_basis IN (
+                    'total_to_total',
+                    'total_to_per_hand',
+                    'per_hand_to_total',
+                    'per_hand_to_per_hand'
+                )
+            ),
+            relationship_type TEXT NOT NULL CHECK (
+                relationship_type IN ('same_lift_key', 'same_pattern', 'manual')
+            ),
+            confidence TEXT NOT NULL DEFAULT 'medium' CHECK (
+                confidence IN ('low', 'medium', 'high')
+            ),
+            notes TEXT,
+            created_at DATETIME DEFAULT CURRENT_TIMESTAMP,
+            updated_at DATETIME DEFAULT CURRENT_TIMESTAMP,
+            UNIQUE(source_exercise_name, target_exercise_name)
+        )
+    """
+    ddl_ignored_transfers = """
+        CREATE TABLE IF NOT EXISTS ignored_calibration_transfers (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            source_exercise_name TEXT NOT NULL,
+            target_exercise_name TEXT NOT NULL,
+            created_at DATETIME DEFAULT CURRENT_TIMESTAMP,
+            UNIQUE(source_exercise_name, target_exercise_name)
+        )
+    """
     with DatabaseHandler() as db:
         db.execute_query(ddl_calibrations)
         db.execute_query(ddl_settings)
+        db.execute_query(ddl_transfer_ratios)
+        db.execute_query(ddl_ignored_transfers)
 
 
 def add_body_composition_snapshots_table() -> None:

--- a/utils/lift_matching.py
+++ b/utils/lift_matching.py
@@ -1,0 +1,195 @@
+"""Shared exercise-name → key-lift slug matching.
+
+Extracted from ``profile_estimator.py`` so both the estimator and
+``strength_calibration.py`` can reference the matching logic without a
+circular import chain.
+
+The ``DIRECT_LIFT_MATCHERS`` table and the ``match_direct_lift_key()``
+function are the only public API. Order in ``DIRECT_LIFT_MATCHERS``
+matters: longer/more-specific keywords must come before shorter ones
+(e.g. "weighted pull up" before "pull up").
+"""
+from __future__ import annotations
+
+from typing import Optional
+
+# Exercise-name keywords that map directly to a key_lift slug. When the
+# exercise being estimated matches one of these, the corresponding lift is
+# used as the primary reference (no cross_factor penalty), regardless of
+# the muscle's chain order. Order matters: longer/more-specific keywords
+# must come before shorter ones (e.g. "weighted pull up" before "pull up").
+DIRECT_LIFT_MATCHERS: tuple[tuple[str, str], ...] = (
+    # Weighted pull-up / chin-up / dip variants — must precede bare forms.
+    ("weighted pull-up", "weighted_pullups"),
+    ("weighted pull up", "weighted_pullups"),
+    ("weighted pullup", "weighted_pullups"),
+    ("weighted chin-up", "weighted_pullups"),
+    ("weighted chin up", "weighted_pullups"),
+    ("weighted chinup", "weighted_pullups"),
+    ("weighted dip", "weighted_dips"),
+    # Squat variants — barbell-back/front first, dumbbell variants own slug.
+    ("barbell back squat", "barbell_back_squat"),
+    ("back squat", "barbell_back_squat"),
+    ("front squat", "barbell_back_squat"),
+    # Issue #20 — Bulgarian / split-squat variant before bare squat fallbacks.
+    ("bulgarian split squat", "bulgarian_split_squat"),
+    ("split squat", "bulgarian_split_squat"),
+    ("goblet squat", "dumbbell_squat"),
+    ("dumbbell squat", "dumbbell_squat"),
+    # Lunges and step-ups (longest-first).
+    # Issue #20 — reverse-lunge variant must precede bare lunge match.
+    ("reverse lunge", "reverse_lunge"),
+    ("dumbbell lunge", "dumbbell_lunge"),
+    ("dumbbell step-up", "dumbbell_step_up"),
+    ("dumbbell step up", "dumbbell_step_up"),
+    ("step-up", "dumbbell_step_up"),
+    ("step up", "dumbbell_step_up"),
+    ("lunge", "dumbbell_lunge"),
+    # Deadlift family — Issue #9 splits + Issue #6 hamstring additions.
+    ("single-leg rdl", "single_leg_rdl"),
+    ("single leg rdl", "single_leg_rdl"),
+    ("single-leg romanian deadlift", "single_leg_rdl"),
+    ("single leg romanian deadlift", "single_leg_rdl"),
+    ("stiff-leg deadlift", "stiff_leg_deadlift"),
+    ("stiff leg deadlift", "stiff_leg_deadlift"),
+    ("romanian deadlift", "romanian_deadlift"),
+    ("conventional deadlift", "conventional_deadlift"),
+    # Issue #20 — sumo deadlift now has its own slug (was routed to
+    # conventional_deadlift). The trap-bar variant stays mapped to
+    # conventional_deadlift since it remains a hip-dominant trap-bar pull
+    # and we don't have a dedicated slug for it.
+    ("sumo deadlift", "sumo_deadlift"),
+    ("trap bar deadlift", "conventional_deadlift"),
+    # Issue #20 — Jefferson curl is a loaded spinal-flexion accessory.
+    ("jefferson curl", "jefferson_curl"),
+    # Issue #20 — seated good morning before bare good-morning match.
+    ("seated good morning", "seated_good_morning"),
+    ("good morning", "good_morning"),
+    # Bench-press family — Issue #9 split + Issue #6 chest additions.
+    ("incline barbell bench", "incline_bench_press"),
+    ("incline dumbbell bench", "incline_bench_press"),
+    ("incline bench press", "incline_bench_press"),
+    ("smith machine bench", "smith_machine_bench_press"),
+    ("smith bench", "smith_machine_bench_press"),
+    ("machine chest press", "machine_chest_press"),
+    ("machine bench press", "machine_chest_press"),
+    ("dumbbell fly", "dumbbell_fly"),
+    ("dumbbell flye", "dumbbell_fly"),
+    ("chest fly", "dumbbell_fly"),
+    ("dumbbell bench press", "dumbbell_bench_press"),
+    ("flat dumbbell bench press", "dumbbell_bench_press"),
+    ("flat dumbbell bench", "dumbbell_bench_press"),
+    ("barbell bench press", "barbell_bench_press"),
+    ("flat bench press", "barbell_bench_press"),
+    # Hip thrust — Issue #20 splits B-stance and barbell glute bridge first.
+    ("b-stance hip thrust", "b_stance_hip_thrust"),
+    ("b stance hip thrust", "b_stance_hip_thrust"),
+    ("barbell glute bridge", "barbell_glute_bridge"),
+    ("glute bridge", "barbell_glute_bridge"),
+    ("hip thrust", "hip_thrust"),
+    # Issue #20 — pull-through and cable-kickback glute accessories.
+    ("cable pull-through", "cable_pull_through"),
+    ("cable pull through", "cable_pull_through"),
+    ("pull-through", "cable_pull_through"),
+    ("pull through", "cable_pull_through"),
+    ("cable kickback", "cable_kickback"),
+    ("glute kickback", "cable_kickback"),
+    ("kickback", "cable_kickback"),
+    # Leg press — Issue #20: leg-press calf raise routes ahead of bare leg press.
+    ("leg press calf raise", "leg_press_calf_raise"),
+    ("leg press", "leg_press"),
+    # Rows — barbell-row family + machine row split-out.
+    ("barbell row", "barbell_row"),
+    ("bent-over row", "barbell_row"),
+    ("bent over row", "barbell_row"),
+    ("pendlay row", "barbell_row"),
+    ("t-bar row", "barbell_row"),
+    ("machine row", "machine_row"),
+    # Overhead / shoulder press family — Issue #6 additions.
+    ("arnold press", "arnold_press"),
+    ("dumbbell shoulder press", "dumbbell_shoulder_press"),
+    ("dumbbell overhead press", "dumbbell_shoulder_press"),
+    ("machine shoulder press", "machine_shoulder_press"),
+    ("machine overhead press", "machine_shoulder_press"),
+    ("military press", "military_press"),
+    ("overhead press", "military_press"),
+    ("barbell shoulder press", "military_press"),
+    # Face pulls / shrugs.
+    ("face pull", "face_pulls"),
+    ("barbell shrug", "barbell_shrugs"),
+    ("shrug", "barbell_shrugs"),
+    # Bicep curls — split out new dumbbell / preacher / incline variants.
+    ("incline dumbbell curl", "incline_dumbbell_curl"),
+    ("incline curl", "incline_dumbbell_curl"),
+    ("preacher curl", "preacher_curl"),
+    ("hammer curl", "dumbbell_curl"),
+    ("dumbbell bicep curl", "dumbbell_curl"),
+    ("dumbbell curl", "dumbbell_curl"),
+    ("barbell bicep curl", "barbell_bicep_curl"),
+    ("barbell curl", "barbell_bicep_curl"),
+    ("ez bar curl", "barbell_bicep_curl"),
+    # Triceps — skull crusher / JM press split out.
+    ("skull crusher", "skull_crusher"),
+    ("jm press", "jm_press"),
+    ("triceps extension", "triceps_extension"),
+    ("tricep extension", "triceps_extension"),
+    # Lower-body isolation.
+    ("leg curl", "leg_curl"),
+    ("leg extension", "leg_extension"),
+    # Lateral raise.
+    ("lateral raise", "dumbbell_lateral_raise"),
+    # Calves — Issue #20: variant slugs (longest-first) precede bare match.
+    ("single-leg standing calf raise", "single_leg_standing_calf_raise"),
+    ("single leg standing calf raise", "single_leg_standing_calf_raise"),
+    ("seated calf raise", "seated_calf_raise"),
+    ("smith machine calf raise", "smith_machine_calf_raise"),
+    ("smith calf raise", "smith_machine_calf_raise"),
+    ("donkey calf raise", "donkey_calf_raise"),
+    ("standing calf raise", "standing_calf_raise"),
+    ("calf raise", "standing_calf_raise"),
+    # Hip abduction.
+    ("hip abduction", "machine_hip_abduction"),
+    ("machine abduction", "machine_hip_abduction"),
+    # Core / abs.
+    ("cable crunch", "cable_crunch"),
+    ("machine crunch", "machine_crunch"),
+    ("weighted crunch", "weighted_crunch"),
+    ("cable woodchop", "cable_woodchop"),
+    ("wood chop", "cable_woodchop"),
+    ("woodchop", "cable_woodchop"),
+    ("side bend", "side_bend"),
+    # Lower back — Issue #20: loaded / reverse variants precede bare matches.
+    ("loaded back extension", "loaded_back_extension"),
+    ("loaded hyperextension", "loaded_back_extension"),
+    ("45 back extension", "loaded_back_extension"),
+    ("45 degree back extension", "loaded_back_extension"),
+    ("reverse hyperextension", "reverse_hyperextension"),
+    ("reverse hyper", "reverse_hyperextension"),
+    ("back extension", "back_extension"),
+    ("hyperextension", "back_extension"),
+    # Bare pull-up / chin-up — bodyweight (must come AFTER weighted entries).
+    ("pull-up", "bodyweight_pullups"),
+    ("pull up", "bodyweight_pullups"),
+    ("pullup", "bodyweight_pullups"),
+    ("chin-up", "bodyweight_chinups"),
+    ("chin up", "bodyweight_chinups"),
+    ("chinup", "bodyweight_chinups"),
+)
+
+
+def match_direct_lift_key(exercise_name: str) -> Optional[str]:
+    """Return the key_lift slug that directly matches the given exercise name.
+
+    Used to bypass the muscle-chain cross_factor penalty when the exercise
+    being estimated is itself one of the questionnaire reference lifts
+    (e.g. estimating "Barbell Romanian Deadlift" should use the user's
+    ``romanian_deadlift`` reference directly, not fall through Hamstrings'
+    leg_curl-first chain).
+    """
+    name = (exercise_name or "").lower()
+    if not name:
+        return None
+    for keyword, lift_key in DIRECT_LIFT_MATCHERS:
+        if keyword in name:
+            return lift_key
+    return None

--- a/utils/profile_estimator.py
+++ b/utils/profile_estimator.py
@@ -586,168 +586,16 @@ ACCURACY_MAJOR_MUSCLE_GROUPS: tuple[tuple[str, tuple[str, ...]], ...] = (
     )),
 )
 
-# Exercise-name keywords that map directly to a key_lift slug. When the
-# exercise being estimated matches one of these, the corresponding lift is
-# used as the primary reference (no cross_factor penalty), regardless of
-# the muscle's chain order. Order matters: longer/more-specific keywords
-# must come before shorter ones (e.g. "weighted pull up" before "pull up").
-DIRECT_LIFT_MATCHERS: tuple[tuple[str, str], ...] = (
-    # Weighted pull-up / chin-up / dip variants — must precede bare forms.
-    ("weighted pull-up", "weighted_pullups"),
-    ("weighted pull up", "weighted_pullups"),
-    ("weighted pullup", "weighted_pullups"),
-    ("weighted chin-up", "weighted_pullups"),
-    ("weighted chin up", "weighted_pullups"),
-    ("weighted chinup", "weighted_pullups"),
-    ("weighted dip", "weighted_dips"),
-    # Squat variants — barbell-back/front first, dumbbell variants own slug.
-    ("barbell back squat", "barbell_back_squat"),
-    ("back squat", "barbell_back_squat"),
-    ("front squat", "barbell_back_squat"),
-    # Issue #20 — Bulgarian / split-squat variant before bare squat fallbacks.
-    ("bulgarian split squat", "bulgarian_split_squat"),
-    ("split squat", "bulgarian_split_squat"),
-    ("goblet squat", "dumbbell_squat"),
-    ("dumbbell squat", "dumbbell_squat"),
-    # Lunges and step-ups (longest-first).
-    # Issue #20 — reverse-lunge variant must precede bare lunge match.
-    ("reverse lunge", "reverse_lunge"),
-    ("dumbbell lunge", "dumbbell_lunge"),
-    ("dumbbell step-up", "dumbbell_step_up"),
-    ("dumbbell step up", "dumbbell_step_up"),
-    ("step-up", "dumbbell_step_up"),
-    ("step up", "dumbbell_step_up"),
-    ("lunge", "dumbbell_lunge"),
-    # Deadlift family — Issue #9 splits + Issue #6 hamstring additions.
-    ("single-leg rdl", "single_leg_rdl"),
-    ("single leg rdl", "single_leg_rdl"),
-    ("single-leg romanian deadlift", "single_leg_rdl"),
-    ("single leg romanian deadlift", "single_leg_rdl"),
-    ("stiff-leg deadlift", "stiff_leg_deadlift"),
-    ("stiff leg deadlift", "stiff_leg_deadlift"),
-    ("romanian deadlift", "romanian_deadlift"),
-    ("conventional deadlift", "conventional_deadlift"),
-    # Issue #20 — sumo deadlift now has its own slug (was routed to
-    # conventional_deadlift). The trap-bar variant stays mapped to
-    # conventional_deadlift since it remains a hip-dominant trap-bar pull
-    # and we don't have a dedicated slug for it.
-    ("sumo deadlift", "sumo_deadlift"),
-    ("trap bar deadlift", "conventional_deadlift"),
-    # Issue #20 — Jefferson curl is a loaded spinal-flexion accessory.
-    ("jefferson curl", "jefferson_curl"),
-    # Issue #20 — seated good morning before bare good-morning match.
-    ("seated good morning", "seated_good_morning"),
-    ("good morning", "good_morning"),
-    # Bench-press family — Issue #9 split + Issue #6 chest additions.
-    ("incline barbell bench", "incline_bench_press"),
-    ("incline dumbbell bench", "incline_bench_press"),
-    ("incline bench press", "incline_bench_press"),
-    ("smith machine bench", "smith_machine_bench_press"),
-    ("smith bench", "smith_machine_bench_press"),
-    ("machine chest press", "machine_chest_press"),
-    ("machine bench press", "machine_chest_press"),
-    ("dumbbell fly", "dumbbell_fly"),
-    ("dumbbell flye", "dumbbell_fly"),
-    ("chest fly", "dumbbell_fly"),
-    ("dumbbell bench press", "dumbbell_bench_press"),
-    ("flat dumbbell bench press", "dumbbell_bench_press"),
-    ("flat dumbbell bench", "dumbbell_bench_press"),
-    ("barbell bench press", "barbell_bench_press"),
-    ("flat bench press", "barbell_bench_press"),
-    # Hip thrust — Issue #20 splits B-stance and barbell glute bridge first.
-    ("b-stance hip thrust", "b_stance_hip_thrust"),
-    ("b stance hip thrust", "b_stance_hip_thrust"),
-    ("barbell glute bridge", "barbell_glute_bridge"),
-    ("glute bridge", "barbell_glute_bridge"),
-    ("hip thrust", "hip_thrust"),
-    # Issue #20 — pull-through and cable-kickback glute accessories.
-    ("cable pull-through", "cable_pull_through"),
-    ("cable pull through", "cable_pull_through"),
-    ("pull-through", "cable_pull_through"),
-    ("pull through", "cable_pull_through"),
-    ("cable kickback", "cable_kickback"),
-    ("glute kickback", "cable_kickback"),
-    ("kickback", "cable_kickback"),
-    # Leg press — Issue #20: leg-press calf raise routes ahead of bare leg press.
-    ("leg press calf raise", "leg_press_calf_raise"),
-    ("leg press", "leg_press"),
-    # Rows — barbell-row family + machine row split-out.
-    ("barbell row", "barbell_row"),
-    ("bent-over row", "barbell_row"),
-    ("bent over row", "barbell_row"),
-    ("pendlay row", "barbell_row"),
-    ("t-bar row", "barbell_row"),
-    ("machine row", "machine_row"),
-    # Overhead / shoulder press family — Issue #6 additions.
-    ("arnold press", "arnold_press"),
-    ("dumbbell shoulder press", "dumbbell_shoulder_press"),
-    ("dumbbell overhead press", "dumbbell_shoulder_press"),
-    ("machine shoulder press", "machine_shoulder_press"),
-    ("machine overhead press", "machine_shoulder_press"),
-    ("military press", "military_press"),
-    ("overhead press", "military_press"),
-    ("barbell shoulder press", "military_press"),
-    # Face pulls / shrugs.
-    ("face pull", "face_pulls"),
-    ("barbell shrug", "barbell_shrugs"),
-    ("shrug", "barbell_shrugs"),
-    # Bicep curls — split out new dumbbell / preacher / incline variants.
-    ("incline dumbbell curl", "incline_dumbbell_curl"),
-    ("incline curl", "incline_dumbbell_curl"),
-    ("preacher curl", "preacher_curl"),
-    ("hammer curl", "dumbbell_curl"),
-    ("dumbbell bicep curl", "dumbbell_curl"),
-    ("dumbbell curl", "dumbbell_curl"),
-    ("barbell bicep curl", "barbell_bicep_curl"),
-    ("barbell curl", "barbell_bicep_curl"),
-    ("ez bar curl", "barbell_bicep_curl"),
-    # Triceps — skull crusher / JM press split out.
-    ("skull crusher", "skull_crusher"),
-    ("jm press", "jm_press"),
-    ("triceps extension", "triceps_extension"),
-    ("tricep extension", "triceps_extension"),
-    # Lower-body isolation.
-    ("leg curl", "leg_curl"),
-    ("leg extension", "leg_extension"),
-    # Lateral raise.
-    ("lateral raise", "dumbbell_lateral_raise"),
-    # Calves — Issue #20: variant slugs (longest-first) precede bare match.
-    ("single-leg standing calf raise", "single_leg_standing_calf_raise"),
-    ("single leg standing calf raise", "single_leg_standing_calf_raise"),
-    ("seated calf raise", "seated_calf_raise"),
-    ("smith machine calf raise", "smith_machine_calf_raise"),
-    ("smith calf raise", "smith_machine_calf_raise"),
-    ("donkey calf raise", "donkey_calf_raise"),
-    ("standing calf raise", "standing_calf_raise"),
-    ("calf raise", "standing_calf_raise"),
-    # Hip abduction.
-    ("hip abduction", "machine_hip_abduction"),
-    ("machine abduction", "machine_hip_abduction"),
-    # Core / abs.
-    ("cable crunch", "cable_crunch"),
-    ("machine crunch", "machine_crunch"),
-    ("weighted crunch", "weighted_crunch"),
-    ("cable woodchop", "cable_woodchop"),
-    ("wood chop", "cable_woodchop"),
-    ("woodchop", "cable_woodchop"),
-    ("side bend", "side_bend"),
-    # Lower back — Issue #20: loaded / reverse variants precede bare matches.
-    ("loaded back extension", "loaded_back_extension"),
-    ("loaded hyperextension", "loaded_back_extension"),
-    ("45 back extension", "loaded_back_extension"),
-    ("45 degree back extension", "loaded_back_extension"),
-    ("reverse hyperextension", "reverse_hyperextension"),
-    ("reverse hyper", "reverse_hyperextension"),
-    ("back extension", "back_extension"),
-    ("hyperextension", "back_extension"),
-    # Bare pull-up / chin-up — bodyweight (must come AFTER weighted entries).
-    ("pull-up", "bodyweight_pullups"),
-    ("pull up", "bodyweight_pullups"),
-    ("pullup", "bodyweight_pullups"),
-    ("chin-up", "bodyweight_chinups"),
-    ("chin up", "bodyweight_chinups"),
-    ("chinup", "bodyweight_chinups"),
-)
+# Exercise-name → key-lift slug matching now lives in ``utils.lift_matching``
+# (shared by both this module and ``strength_calibration``). Re-exported here
+# so existing internal callers (trace builders, estimator chain) continue to
+# work without change.
+from utils.lift_matching import DIRECT_LIFT_MATCHERS  # noqa: F401
+from utils.lift_matching import match_direct_lift_key as match_direct_lift_key  # noqa: F401
+
+# Backward-compatible private alias used by internal callers (trace builders,
+# estimator chain). New code should use ``match_direct_lift_key`` directly.
+_match_direct_lift_key = match_direct_lift_key
 
 MUSCLE_TO_KEY_LIFT = {
     "Chest": [
@@ -1532,22 +1380,8 @@ def _build_learned_trace(
     }
 
 
-def _match_direct_lift_key(exercise_name: str) -> Optional[str]:
-    """Return the key_lift slug that directly matches the given exercise name.
-
-    Used to bypass the muscle-chain cross_factor penalty when the exercise
-    being estimated is itself one of the questionnaire reference lifts
-    (e.g. estimating "Barbell Romanian Deadlift" should use the user's
-    `romanian_deadlift` reference directly, not fall through Hamstrings'
-    leg_curl-first chain).
-    """
-    name = (exercise_name or "").lower()
-    if not name:
-        return None
-    for keyword, lift_key in DIRECT_LIFT_MATCHERS:
-        if keyword in name:
-            return lift_key
-    return None
+# _match_direct_lift_key is now imported from utils.lift_matching (see top of
+# this section). The backward-compatible alias is defined next to the import.
 
 
 def _estimate_from_profile(

--- a/utils/profile_estimator.py
+++ b/utils/profile_estimator.py
@@ -1220,6 +1220,11 @@ def estimate_for_exercise(exercise_name: str, *, db: DatabaseHandler) -> dict[st
             logged["is_dumbbell"] = is_dumbbell
             return logged
 
+        related = _lookup_related_learned_calibration(exercise_row, db)
+        if related:
+            related["is_dumbbell"] = is_dumbbell
+            return related
+
         profile_lifts = db.fetch_all(
             "SELECT lift_key, weight_kg, reps FROM user_profile_lifts"
         )
@@ -1282,6 +1287,63 @@ def _lookup_last_logged(exercise_name: str, db: DatabaseHandler) -> Optional[dic
         "reason": "log",
         "trace": _build_log_trace(
             weight=weight, reps_low=min_rep, reps_high=max_rep
+        ),
+    }
+
+
+def _lookup_related_learned_calibration(
+    exercise_row: dict[str, Any], db: DatabaseHandler
+) -> Optional[dict[str, Any]]:
+    """Read-only related learned estimate, after exact learned/log fallbacks."""
+    from utils.strength_calibration import get_related_calibration_candidate
+
+    candidate = get_related_calibration_candidate(exercise_row, db=db)
+    if not candidate:
+        return None
+
+    target_tier = classify_tier(exercise_row)
+    if target_tier == "excluded":
+        return None
+
+    preferences = db.fetch_all("SELECT tier, rep_range FROM user_profile_preferences")
+    preference_by_tier = {
+        row.get("tier"): row.get("rep_range")
+        for row in preferences
+        if row.get("tier") and row.get("rep_range")
+    }
+    preset_key = preference_by_tier.get(target_tier, DEFAULT_PREFERENCES[target_tier])
+    preset = REP_RANGE_PRESETS[preset_key]
+
+    try:
+        target_1rm = float(candidate["target_estimated_1rm"])
+    except (TypeError, ValueError):
+        return None
+    if target_1rm <= 0:
+        return None
+
+    pre_round_weight = target_1rm * preset["pct_1rm"]
+    working_weight = round_weight(
+        pre_round_weight,
+        exercise_row.get("equipment"),
+        target_tier,
+    )
+    return {
+        "weight": working_weight,
+        "sets": PROFILE_DEFAULT_SETS,
+        "min_rep": preset["min_rep"],
+        "max_rep": preset["max_rep"],
+        "rir": preset["rir"],
+        "rpe": preset["rpe"],
+        "source": "related_learned",
+        "reason": "related_calibration",
+        "trace": _build_related_learned_trace(
+            candidate,
+            target_tier=target_tier,
+            preset_key=preset_key,
+            preset=preset,
+            pre_round_weight=pre_round_weight,
+            working_weight=working_weight,
+            equipment=exercise_row.get("equipment"),
         ),
     }
 
@@ -1360,7 +1422,7 @@ def _build_learned_trace(
             "label": "Learned from your logged sets",
             "value": f"{weight:g} kg × {rep_label}",
             "detail": (
-                f"Calibrated from {sample_count} recent scored "
+                f"Calibrated from {sample_count} scored "
                 f"{'log' if sample_count == 1 else 'logs'} for this exact "
                 f"exercise (confidence: {confidence})."
             ),
@@ -1377,6 +1439,77 @@ def _build_learned_trace(
         "confidence": confidence,
         "sample_count": sample_count,
         "steps": steps,
+    }
+
+
+def _build_related_learned_trace(
+    candidate: dict[str, Any],
+    *,
+    target_tier: str,
+    preset_key: str,
+    preset: dict[str, Any],
+    pre_round_weight: float,
+    working_weight: float,
+    equipment: Optional[str],
+) -> dict[str, Any]:
+    source_e1rm = float(candidate.get("source_estimated_1rm") or 0)
+    target_e1rm = float(candidate.get("target_estimated_1rm") or 0)
+    ratio = float(candidate.get("transfer_ratio") or 0)
+    basis_factor = float(candidate.get("load_basis_factor") or 1)
+    source_name = candidate.get("source_exercise_name") or "related exercise"
+    target_name = candidate.get("target_exercise_name") or "target exercise"
+    sample_count = int(candidate.get("source_sample_count") or 0)
+    confidence = candidate.get("source_confidence")
+    load_basis = str(candidate.get("load_basis") or "").replace("_", " ")
+    relationship = str(candidate.get("relationship_type") or "").replace("_", " ")
+
+    return {
+        "source": "related_learned",
+        "confidence": confidence,
+        "sample_count": sample_count,
+        "source_exercise": source_name,
+        "target_exercise": target_name,
+        "relationship_type": candidate.get("relationship_type"),
+        "transfer_ratio": ratio,
+        "load_basis": candidate.get("load_basis"),
+        "steps": [
+            {
+                "label": "Related learned calibration",
+                "value": f"Learned from {source_name}",
+                "detail": (
+                    f"{sample_count} scored "
+                    f"{'log' if sample_count == 1 else 'logs'}, "
+                    f"confidence: {confidence}. Exact learned/log data for "
+                    f"{target_name} was not available."
+                ),
+            },
+            {
+                "label": "Transfer",
+                "value": f"{source_name} -> {target_name}",
+                "detail": (
+                    f"Relationship: {relationship}; ratio {ratio:g}; "
+                    f"load basis: {load_basis} (factor {basis_factor:g})."
+                ),
+            },
+            {
+                "label": "Estimated strength",
+                "value": f"~{target_e1rm:g} kg e1RM",
+                "detail": (
+                    f"Source e1RM ~{source_e1rm:g} kg × ratio {ratio:g} × "
+                    f"basis factor {basis_factor:g}."
+                ),
+            },
+            {
+                "label": "Progression target",
+                "value": f"{working_weight:g} kg × {preset['min_rep']}–{preset['max_rep']}",
+                "detail": (
+                    f"{preset_key.title()} preset for {target_tier} tier "
+                    f"({preset['pct_1rm']:.0%} e1RM), then rounded for "
+                    f"{normalize_equipment(equipment) or 'equipment'} from "
+                    f"{round(pre_round_weight, 2)} kg."
+                ),
+            },
+        ],
     }
 
 

--- a/utils/strength_calibration.py
+++ b/utils/strength_calibration.py
@@ -26,9 +26,9 @@ from typing import Any, Optional
 from utils.database import DatabaseHandler
 from utils.logger import get_logger
 from utils.normalization import normalize_muscle
+from utils.lift_matching import match_direct_lift_key
 from utils.profile_estimator import (
     DEFAULT_ESTIMATE,
-    _match_direct_lift_key,
     classify_tier,
     epley_1rm,
 )
@@ -309,7 +309,7 @@ def update_calibration_for_exercise(
 
     payload = {
         "exercise_name": canonical_name,
-        "lift_key": _match_direct_lift_key(canonical_name),
+        "lift_key": match_direct_lift_key(canonical_name),
         "primary_muscle": normalize_muscle(exercise_row.get("primary_muscle_group")),
         "estimated_1rm": round(e1rms[0], 2),
         "suggested_weight": decision["suggested_weight"],

--- a/utils/strength_calibration.py
+++ b/utils/strength_calibration.py
@@ -42,7 +42,7 @@ MIN_EXACT_LOGS_HIGH = 3
 MAX_RECENT_DAYS = 90
 STALE_AFTER_DAYS = 180
 MAX_E1RM_VARIANCE_PCT_HIGH = 10
-# Phase 2 reserved constants (not used by the MVP).
+# Related transfer gates (Phase 2A).
 MIN_RELATED_LOGS = 3
 MIN_RELATED_CONFIDENCE = "medium"
 
@@ -85,9 +85,74 @@ def get_calibration_mode(*, db: DatabaseHandler) -> str:
     current estimator (no learned suggestions) — this is the regression guard
     the plan calls out under §"Settings Default".
     """
-    row = db.fetch_one("SELECT mode FROM user_calibration_settings WHERE id = 1")
+    return get_calibration_settings(db=db)["mode"]
+
+
+def get_calibration_settings(*, db: DatabaseHandler) -> dict[str, Any]:
+    """Return learned-calibration settings with safe default-off semantics."""
+    row = db.fetch_one(
+        """
+        SELECT mode, allow_related_exercise_learning, min_sessions_for_related
+        FROM user_calibration_settings
+        WHERE id = 1
+        """
+    )
     mode = (row or {}).get("mode")
-    return mode if mode in VALID_CALIBRATION_MODES else DEFAULT_CALIBRATION_MODE
+    if mode not in VALID_CALIBRATION_MODES:
+        mode = DEFAULT_CALIBRATION_MODE
+    allow_related = bool((row or {}).get("allow_related_exercise_learning") or 0)
+    return {
+        "mode": mode,
+        "allow_related_exercise_learning": allow_related,
+        "min_sessions_for_related": (row or {}).get("min_sessions_for_related"),
+    }
+
+
+def related_exercise_learning_enabled(*, db: DatabaseHandler) -> bool:
+    """True only when learned suggestions and related transfer are both enabled."""
+    settings = get_calibration_settings(db=db)
+    return (
+        settings["mode"] == "suggest"
+        and settings["allow_related_exercise_learning"] is True
+    )
+
+
+def set_calibration_settings(
+    mode: str,
+    *,
+    db: DatabaseHandler,
+    allow_related_exercise_learning: Optional[bool] = None,
+) -> dict[str, Any]:
+    """Upsert calibration settings; preserve the related flag when omitted."""
+    if mode not in VALID_CALIBRATION_MODES:
+        raise ValueError(f"mode must be one of {VALID_CALIBRATION_MODES}")
+
+    if allow_related_exercise_learning is None:
+        db.execute_query(
+            """
+            INSERT INTO user_calibration_settings (id, mode, updated_at)
+            VALUES (1, ?, CURRENT_TIMESTAMP)
+            ON CONFLICT(id) DO UPDATE SET
+                mode = excluded.mode,
+                updated_at = CURRENT_TIMESTAMP
+            """,
+            (mode,),
+        )
+    else:
+        db.execute_query(
+            """
+            INSERT INTO user_calibration_settings (
+                id, mode, allow_related_exercise_learning, updated_at
+            )
+            VALUES (1, ?, ?, CURRENT_TIMESTAMP)
+            ON CONFLICT(id) DO UPDATE SET
+                mode = excluded.mode,
+                allow_related_exercise_learning = excluded.allow_related_exercise_learning,
+                updated_at = CURRENT_TIMESTAMP
+            """,
+            (mode, 1 if allow_related_exercise_learning else 0),
+        )
+    return get_calibration_settings(db=db)
 
 
 def set_calibration_mode(mode: str, *, db: DatabaseHandler) -> str:
@@ -96,19 +161,7 @@ def set_calibration_mode(mode: str, *, db: DatabaseHandler) -> str:
     Turning learned suggestions on is an explicit user action (plan §"Settings
     Default"). Reserved Phase 2 columns keep their schema defaults.
     """
-    if mode not in VALID_CALIBRATION_MODES:
-        raise ValueError(f"mode must be one of {VALID_CALIBRATION_MODES}")
-    db.execute_query(
-        """
-        INSERT INTO user_calibration_settings (id, mode, updated_at)
-        VALUES (1, ?, CURRENT_TIMESTAMP)
-        ON CONFLICT(id) DO UPDATE SET
-            mode = excluded.mode,
-            updated_at = CURRENT_TIMESTAMP
-        """,
-        (mode,),
-    )
-    return mode
+    return set_calibration_settings(mode, db=db)["mode"]
 
 
 def get_learned_calibration(
@@ -125,6 +178,149 @@ def get_learned_calibration(
         "SELECT * FROM learned_strength_calibrations WHERE exercise_name = ? COLLATE NOCASE",
         (exercise_name.strip(),),
     )
+
+
+_CONFIDENCE_RANK = {
+    CONFIDENCE_LOW: 1,
+    CONFIDENCE_MEDIUM: 2,
+    CONFIDENCE_HIGH: 3,
+}
+
+_LOAD_BASIS_FACTOR = {
+    "total_to_total": 1.0,
+    "total_to_per_hand": 0.5,
+    "per_hand_to_total": 2.0,
+    "per_hand_to_per_hand": 1.0,
+}
+
+
+def ignore_calibration_transfer(
+    source_exercise_name: str, target_exercise_name: str, *, db: DatabaseHandler
+) -> None:
+    """Suppress one related source-target pair without deleting exact evidence."""
+    source = (source_exercise_name or "").strip()
+    target = (target_exercise_name or "").strip()
+    if not source or not target:
+        return
+    db.execute_query(
+        """
+        INSERT INTO ignored_calibration_transfers (
+            source_exercise_name, target_exercise_name, created_at
+        )
+        VALUES (?, ?, CURRENT_TIMESTAMP)
+        ON CONFLICT(source_exercise_name, target_exercise_name) DO NOTHING
+        """,
+        (source, target),
+    )
+
+
+def get_related_calibration_candidate(
+    target_exercise_row: dict[str, Any],
+    *,
+    db: DatabaseHandler,
+    now: Optional[datetime] = None,
+) -> Optional[dict[str, Any]]:
+    """Return the strongest eligible related calibration for a target exercise.
+
+    Phase 2A is intentionally read-only and ratio-gated: no explicit
+    ``exercise_transfer_ratios`` row means no related suggestion, even when a
+    plausible source calibration exists.
+    """
+    if not related_exercise_learning_enabled(db=db):
+        return None
+    if not target_exercise_row or classify_tier(target_exercise_row) == "excluded":
+        return None
+
+    target_name = (target_exercise_row.get("exercise_name") or "").strip()
+    if not target_name:
+        return None
+
+    now = now or _utcnow()
+    target_lift_key = match_direct_lift_key(target_name)
+    rows = db.fetch_all(
+        """
+        SELECT
+            c.exercise_name AS source_exercise_name,
+            c.lift_key AS source_lift_key,
+            c.primary_muscle AS source_primary_muscle,
+            c.estimated_1rm AS source_estimated_1rm,
+            c.suggested_weight AS source_suggested_weight,
+            c.suggested_min_reps AS source_suggested_min_reps,
+            c.suggested_max_reps AS source_suggested_max_reps,
+            c.confidence AS source_confidence,
+            c.sample_count AS source_sample_count,
+            c.last_observed_at AS source_last_observed_at,
+            r.id AS transfer_ratio_id,
+            r.source_lift_key AS ratio_source_lift_key,
+            r.target_lift_key AS ratio_target_lift_key,
+            r.ratio AS transfer_ratio,
+            r.load_basis,
+            r.relationship_type,
+            r.confidence AS transfer_confidence,
+            r.notes AS transfer_notes
+        FROM exercise_transfer_ratios r
+        JOIN learned_strength_calibrations c
+          ON c.exercise_name = r.source_exercise_name COLLATE NOCASE
+        LEFT JOIN ignored_calibration_transfers ignored
+          ON ignored.source_exercise_name = r.source_exercise_name COLLATE NOCASE
+         AND ignored.target_exercise_name = r.target_exercise_name COLLATE NOCASE
+        WHERE r.target_exercise_name = ? COLLATE NOCASE
+          AND c.exercise_name <> ? COLLATE NOCASE
+          AND ignored.id IS NULL
+        """,
+        (target_name, target_name),
+    )
+
+    candidates: list[dict[str, Any]] = []
+    for row in rows:
+        if row.get("source_confidence") not in USABLE_SUGGEST_CONFIDENCES:
+            continue
+        if int(row.get("source_sample_count") or 0) < MIN_RELATED_LOGS:
+            continue
+        observed_at = _parse_dt(row.get("source_last_observed_at"))
+        if observed_at is not None and _age_days(now, observed_at) > STALE_AFTER_DAYS:
+            continue
+        if row.get("transfer_confidence") not in USABLE_SUGGEST_CONFIDENCES:
+            continue
+        basis_factor = _LOAD_BASIS_FACTOR.get(row.get("load_basis"))
+        if basis_factor is None:
+            continue
+        try:
+            source_e1rm = float(row["source_estimated_1rm"])
+            transfer_ratio = float(row["transfer_ratio"])
+        except (TypeError, ValueError):
+            continue
+        if source_e1rm <= 0 or transfer_ratio <= 0:
+            continue
+        ratio_source_key = row.get("ratio_source_lift_key")
+        ratio_target_key = row.get("ratio_target_lift_key")
+        if ratio_source_key and row.get("source_lift_key") and ratio_source_key != row.get("source_lift_key"):
+            continue
+        if ratio_target_key and target_lift_key and ratio_target_key != target_lift_key:
+            continue
+
+        target_e1rm = source_e1rm * transfer_ratio * basis_factor
+        candidate = dict(row)
+        candidate.update({
+            "target_exercise_name": target_name,
+            "target_lift_key": target_lift_key,
+            "target_estimated_1rm": target_e1rm,
+            "load_basis_factor": basis_factor,
+        })
+        candidates.append(candidate)
+
+    if not candidates:
+        return None
+
+    def sort_key(row: dict[str, Any]) -> tuple[int, datetime, int]:
+        observed = _parse_dt(row.get("source_last_observed_at")) or datetime.min
+        return (
+            _CONFIDENCE_RANK.get(row.get("source_confidence"), 0),
+            observed,
+            int(row.get("source_sample_count") or 0),
+        )
+
+    return max(candidates, key=sort_key)
 
 
 def _utcnow() -> datetime:
@@ -324,7 +520,6 @@ def update_calibration_for_exercise(
             str(latest["created_at"]) if latest.get("created_at") is not None else None
         ),
         "source": CALIBRATION_SOURCE,
-        "progression_status": decision["status"],
     }
     _upsert_calibration(payload, db=db)
     return payload


### PR DESCRIPTION
## Summary

Phase 2A of learned calibration: **read-only, ratio-gated related-exercise transfer**. When a target exercise has no usable exact learned calibration and no exact last-log fallback, the estimator can surface a suggestion derived from a *related* source exercise's learned calibration — but only via an explicit `exercise_transfer_ratios` row. Ships with **zero seeded ratios and no behavior change** (per the plan's acceptance criteria).

Includes a prep refactor (`a1aa8ae`) that extracts `match_direct_lift_key()` / `DIRECT_LIFT_MATCHERS` into `utils/lift_matching.py` so both the estimator and `strength_calibration` share them without reaching for a private symbol (pure move + re-export, no behavior change).

## Backend
- Additive idempotent tables `exercise_transfer_ratios` + `ignored_calibration_transfers` — created at startup, cleaned in `conftest` + `/erase-data`.
- Settings gain `allow_related_exercise_learning` (default `0`); related transfer requires `mode == 'suggest'` **AND** the flag.
- `get_related_calibration_candidate()` — confidence/staleness/sample/basis gates, directional ratio + load-basis conversion, highest-confidence pick (recency then sample-count tie-break).
- `ignore_calibration_transfer()` + `POST .../calibration/ignore_transfer`.
- Estimator priority: exact learned → exact log → **related learned** → Profile → cold-start → default. Related trace names source, ratio, load basis, and fallback reason.

## UI
- Profile related-suggestions toggle (gated behind learned suggestions).
- Workout Controls related-source badge, trace details, and **Ignore** action.

## Tests
Settings round-trip + validation, related on/off/no-ratio, exact-log suppression, ignore-pair scoping, numeric transfer assertion (source e1RM × 0.72 × 0.5 → target weight 39.0); E2E coverage in `e2e/learned-calibration.spec.ts`.

## Migration note
Estimator priority changes **only** when both switches are on and a transfer ratio exists. Default-off and no-ratio paths are byte-for-byte unchanged from shipped MVP behavior.

## Verification
- [ ] Full pytest (running locally; CI gate authoritative)
- [ ] Chromium Playwright relevant specs

Design: `docs/user_profile/RELATED_EXERCISE_TRANSFER_DESIGN.md`, `docs/user_profile/LEARNED_CALIBRATION_PLAN.md` §Phase 2A.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
