### PR TITLE
feat(calibration): promote learned rows to Profile references (Phase 2C)

### DIFF
--- a/docs/user_profile/LEARNED_CALIBRATION_PLAN.md
+++ b/docs/user_profile/LEARNED_CALIBRATION_PLAN.md
@@ -2,13 +2,14 @@
 
 ## Status
 
-MVP + Phase 2A learned calibration are shipped on `main`:
+MVP + Phase 2A + Phase 2B learned calibration are shipped on `main`:
 
 - PR #37 / `fd2e2f5`: exact-exercise learned calibration backend, settings, estimator integration, Profile controls, Workout Controls source UI/actions, workout-log notifications, tests, and E2E.
 - PR #39 / `62db541`: separate profile-estimator dumbbell/total-load reference fix.
 - PR #53 / `0f8b4b7`: Phase 2A read-only, ratio-gated related-exercise transfer — `utils/lift_matching.py`, additive `exercise_transfer_ratios` + `ignored_calibration_transfers` tables, `allow_related_exercise_learning` settings flag (default `0`), estimator priority (exact learned → exact log → related learned → Profile → cold-start → default), Profile toggle, Workout Controls related-source badge/trace/ignore. Ships with **zero** seeded ratios, so no behavior change until learned mode + related mode + a ratio row all exist.
+- PR #54 / `bad70c6`: Phase 2B read/control-only review surface on `/user_profile` — learned-calibration list, ignored related-transfer list with per-row unignore, confirmed bulk reset-all / clear-ignored. No estimator math or priority change, no `calibration_events` table, transfer ratios remain internal. Verified: full pytest `1509 passed`; scoped Playwright (`user-profile.spec.ts` + `learned-calibration.spec.ts`) `30 passed`; CI all 8 jobs green.
 
-**Phase 2A is complete.** The next implementation slice is **Phase 2B** (review and control surface) — see §"Phase 2B Review and Control Surface" below. This document remains the planning source for Phases 2B–2D; 2C (promote to Profile) and 2D (fatigue/volume-aware) still need design review before coding.
+**Phases 2A and 2B are complete.** The next implementation slice is **Phase 2C** (promote to Profile) — see §"Phase 2C Promote-to-Profile Plan" below, with decisions locked 2026-06-06. This document remains the planning source for Phases 2C–2D; 2D (fatigue/volume-aware) still needs design review before coding.
 
 ## Goal
 
@@ -97,7 +98,7 @@ Phase 2 should be split into reviewable stages:
 3. **Phase 2C - promote to Profile.** Add manual promote-to-Profile as its own explicit action with route tests, response-contract tests, and clear copy that it changes the user's declared baseline.
 4. **Phase 2D - fatigue/volume-aware suggestions.** Keep this separate from strength transfer so fatigue logic does not become a hidden modifier inside Workout Controls.
 
-Phase 2A is shipped (PR #53). **Phase 2B is the next implementation slice** — see below.
+Phase 2A is shipped (PR #53). Phase 2B is shipped (PR #54). **Phase 2C is the next implementation slice** — see §"Phase 2C Promote-to-Profile Plan" below.
 
 ## Phase 2B Review and Control Surface
 
@@ -149,6 +150,123 @@ New routes in `routes/user_profile.py` (all `success_response()` / `error_respon
 ### Out of scope for 2B
 
 Promote-to-Profile (2C), Profile/plan-row writes, auto-apply, fatigue/volume-aware suggestions (2D), user-visible/seeded transfer ratios, and `calibration_events` history.
+
+## Phase 2C Promote-to-Profile Plan
+
+### Goal
+
+Give the user one explicit action to **graduate** an exact learned calibration into their **declared Profile reference lift** — the only Phase 2 step that writes into user-declared baseline data. This is the first Phase 2 surface that mutates `user_profile_lifts`, so it is gated, confirmed, and never silent.
+
+### Why this is not a no-op (and not the estimator change)
+
+Estimator priority is unchanged: `exact learned → exact log → related learned → Profile → cold-start → default`. While learned mode is on and the row is usable, Workout Controls still serves the **learned** suggestion, not the promoted Profile value. Promotion's effect surfaces elsewhere:
+
+- It becomes the **declared baseline** used when learned data and exact log fallback are unavailable (for example learned mode off or row reset/stale, with no exact target log taking priority).
+- It feeds the **cross-muscle fallback chain**, **accuracy band**, **cohort bars/donut**, and **cold-start replacement** on `/user_profile`, none of which read learned-calibration rows.
+- It is idempotent and reversible via backup/restore.
+
+So promotion is "save this measured number as my permanent baseline," distinct from the live learned suggestion. UI copy must make that distinction explicit.
+
+### Zero new schema
+
+Both endpoints of the write already exist: source `learned_strength_calibrations` (keyed by `exercise_name`) and sink `user_profile_lifts` (keyed by `lift_key`, columns `weight_kg` + `reps`, `upsert_user_profile_lift()` in `utils/database.py`). Phase 2C adds **no table and no column** — so no `tests/conftest.py` table-list change, no `/erase-data` change (`user_profile_lifts` is already wiped), and no backup/restore snapshot-compatibility concern. This is the single biggest risk reducer for the phase.
+
+### Locked decisions (Opus review, 2026-06-06)
+
+1. **What gets written** — the user's **measured top set**: `scored_weight × scored_max_reps` from the source log (`learned_strength_calibrations.last_log_id` → `workout_log`), basis-converted into the target `lift_key`'s load basis (see §"Load basis"). Keeps reference-lift semantics ("what I actually lifted", run through Epley) intact and round-trips: the estimator re-derives the same e1RM. Not the progression `suggested_weight` (forward-looking) and not a 1-rep e1RM entry (loses rep context).
+2. **Placement** — a per-row **"Promote to reference lift"** action in the Phase 2B learned-calibration review table on `/user_profile` only. Not on the Workout Controls trace (keeps a Profile-mutating action on the Profile page, off the fast-moving plan flow, and testable in isolation).
+3. **Promotable sources** — **exact learned rows only**, with usable confidence (`medium`/`high`) and an `exercise_name` that resolves to a known `KEY_LIFTS` slug via `match_direct_lift_key()`. Not related-transfer, not exact-last-log, not Profile/cold-start/default, not `low` confidence.
+4. **Overwrite policy** — **never silent**. If a reference lift already exists for the slug, the UI shows a confirm with current → new before writing. **No preservation table** in 2C (keeps it additive-minimal, consistent with the 2B deferral of `calibration_events`); the prior value stays recoverable via backup/restore. Server enforces a no-silent-overwrite guard as a backstop.
+
+### Eligibility (a learned row is promotable only when all hold)
+
+- A `learned_strength_calibrations` row exists for the exercise with confidence in `USABLE_SUGGEST_CONFIDENCES` (`medium`/`high`).
+- `match_direct_lift_key(exercise_name)` resolves to a slug in `KEY_LIFTS` (the questionnaire vocabulary). Exercises with no direct reference-lift slug are **not** promotable.
+- The source log (`last_log_id`) still exists and carries a usable `scored_weight` + `scored_max_reps`.
+- The exercise is not `excluded` by `classify_tier()`.
+
+### Load basis
+
+Reference-lift slugs in `DUMBBELL_LIFT_KEYS` are stored **per hand**; everything else is **total/system load**. The source exercise's `scored_weight` is in the *exercise's* basis (per hand iff its equipment normalizes to `Dumbbells`). Convert source→target explicitly (same "two dumbbells = one barbell" model as `_load_basis_factor()`, but source side is the exercise, not a lift_key):
+
+- `exercise_per_hand == lift_key_per_hand` → ×1.0
+- per-hand exercise → total-load slug → ×2.0
+- total-load exercise → per-hand slug → ÷2.0
+
+Store `weight_kg = round(converted, 2)`; **no** equipment increment-rounding (reference lifts hold raw user-entered values). Store `reps = int(scored_max_reps)` (truthful measured reps; `epley_1rm` caps at 12 internally, so no pre-cap needed).
+
+### Backend (additive, no schema change)
+
+New helpers in `utils/strength_calibration.py` (reuse the caller's `DatabaseHandler`):
+
+- `resolve_promotion_target(exercise_name, *, db) -> Optional[dict]` — returns the full promotion plan or `None` when not promotable: `{exercise_name, lift_key, weight_kg, reps, confidence, existing_reference}` where `existing_reference` is `{weight_kg, reps}` or `None`. Encapsulates the eligibility gates, the `last_log_id` lookup, and the basis conversion.
+- `promote_calibration_to_profile(exercise_name, *, db, overwrite=False) -> dict` — resolves, enforces the no-silent-overwrite guard, writes via `upsert_user_profile_lift()`, and returns `{lift_key, weight_kg, reps, overwrote, previous}`. **Does not delete the learned row** (promotion graduates, it does not consume) and touches nothing but `user_profile_lifts`.
+
+### Route contract (`routes/user_profile.py`, thin; `success_response()` / `error_response()`)
+
+1. **Enrich** existing `GET /api/user_profile/calibration/dashboard` — each `learned[]` row additionally carries `lift_key`, `lift_label`, `promotable` (bool), `existing_reference` (`{weight_kg, reps}` | null), `promote_weight_kg`, `promote_reps`. Additive keys only; `ignored_transfers` unchanged; still read-only. Lets the table render the correct button label and confirm copy without a per-click round-trip.
+2. **New** `POST /api/user_profile/calibration/promote` — body `{exercise: <name>, overwrite?: bool}`.
+   - Missing/blank `exercise` → `error_response("VALIDATION_ERROR", ..., 400)`.
+   - Not promotable (no usable learned row / unresolvable slug / missing source log) → `error_response("NOT_PROMOTABLE", ..., 400)`.
+   - Existing reference present and `overwrite` falsy → `error_response("REFERENCE_LIFT_EXISTS", ..., 400)` (guard backstop; UI confirms before sending `overwrite: true`).
+   - Otherwise write → `success_response(data={lift_key, lift_label, weight_kg, reps, overwrote, previous}, message="Promoted to Profile reference lift")`.
+
+### UI copy (Profile review table)
+
+- Button: **"Promote to reference lift"**. When not promotable, render **disabled with a tooltip**: "No matching Profile reference lift for this exercise." (discoverable + explains the gate).
+- No existing value — lightweight confirm: "Save **{w} kg × {reps}** as your declared Profile reference lift for **{lift_label}**? This sets your saved baseline (separate from the live learned suggestion)."
+- Overwrite — confirm shows old → new: "Replace your declared Profile reference lift for **{lift_label}**? This changes your saved baseline. Current: {old_w} kg × {old_reps}. New (from your logged set): {new_w} kg × {new_reps}. Your learned suggestion already drives Workout Controls — this only updates the baseline used when learned data is unavailable."
+- Success toast: "Promoted to Profile reference lift: {lift_label} {w} kg × {reps}."
+- Copy must keep "**learned suggestion**" and "**declared Profile reference**" visibly distinct.
+
+### Data lifecycle
+
+- Writes **only** `user_profile_lifts`. No plan-row (`user_selection`) writes, no `workout_log` rewrites, no learned-calibration deletion, no settings/transfer-ratio changes.
+- No new table → `/erase-data`, `tests/conftest.py` cleanup lists, and backup/restore are unchanged and already correct.
+- The learned row persists after promotion and continues to win in estimator priority while usable; promotion is idempotent.
+
+### Estimator priority
+
+**Unchanged.** Phase 2C does not touch the estimator chain. Migration note for the PR: promotion can change *future* suggestions only through the pre-existing Profile/cold-start fallback path and the accuracy/cohort displays — there is no priority or formula change.
+
+### Tests
+
+Unit (`tests/` calibration suite):
+- `resolve_promotion_target` returns `None` for: no learned row; `low` confidence; `exercise_name` with no `KEY_LIFTS` slug; missing source log.
+- Correct `weight_kg`/`reps` for same-basis (barbell exercise → barbell slug).
+- Per-hand → total conversion (×2) and total → per-hand conversion (÷2).
+- `existing_reference` populated when a reference lift already exists for the slug.
+- `promote_calibration_to_profile` writes the converted value; is idempotent; **does not** delete the learned row; **does not** touch other reference lifts, settings, or transfer ratios.
+
+Route:
+- Promote success with no existing value → 200 `ok`, `user_profile_lifts` written.
+- Existing + `overwrite=false` → `REFERENCE_LIFT_EXISTS`, no write.
+- Existing + `overwrite=true` → overwrites, `previous` returned.
+- Missing `exercise` → `VALIDATION_ERROR` 400.
+- Not promotable (low confidence / unresolvable slug) → `NOT_PROMOTABLE` 400.
+- Dashboard returns the new `promotable` / `existing_reference` annotations.
+- All responses use `success_response()` / `error_response()` (response-contract test).
+
+Integration (estimator priority proof):
+- Log → usable learned row → promote → `user_profile_lifts` holds the measured (basis-converted) set.
+- With learned mode **on**, post-promotion estimate still serves the **learned** source (priority unchanged).
+- With learned mode **off** (or learned row reset) and no exact-log fallback, post-promotion estimate now serves the **promoted Profile** value (baseline took effect).
+- Regression guard: non-promote actions (dashboard GET, ignore/unignore, clear-ignored, reset-all, settings) do **not** mutate `user_profile_lifts`.
+
+E2E (after implementation, focused Chromium):
+- Enable learned → log a set → open Profile review table → Promote → confirm → reference lift populated + success toast.
+- Promote over an existing value shows the old → new confirm.
+
+### Out of scope for 2C
+
+Auto-apply, plan-row (`user_selection`) writes, promoting related/last-log/cold-start sources, an in-app preserved-history table, fatigue/volume-aware suggestions (2D), and any estimator priority/formula change.
+
+### Open (non-blocking) defaults — proceed unless owner objects
+
+- Non-promotable rows: **disabled button + tooltip** (vs hide). Chosen for discoverability.
+- `REFERENCE_LIFT_EXISTS` guard returns **HTTP 400** (vs 200 + `reason`): the UI confirms before sending `overwrite: true`, so reaching the server without it is a true error, not the normal confirm flow.
+- Store **raw measured reps** (no pre-cap at 12; `epley_1rm` caps internally).
+- **No** `promoted_at`/source marker on the reference lift (no schema change; consistent with the no-preservation-table decision).
 
 ## Phase 2A Related-Exercise Transfer Plan
 

--- a/e2e/learned-calibration.spec.ts
+++ b/e2e/learned-calibration.spec.ts
@@ -15,6 +15,8 @@ import { test, expect, ROUTES, SELECTORS, waitForPageReady } from './fixtures';
 import type { Page } from '@playwright/test';
 
 const CALIBRATION_SETTINGS = '/api/user_profile/calibration_settings';
+const CALIBRATION_DASHBOARD = '/api/user_profile/calibration/dashboard';
+const CALIBRATION_PROMOTE = '/api/user_profile/calibration/promote';
 const CALIBRATION_RESET = '/api/user_profile/calibration/reset';
 const CALIBRATION_IGNORE = '/api/user_profile/calibration/ignore_transfer';
 const ESTIMATE = '/api/user_profile/estimate';
@@ -91,6 +93,157 @@ test.describe('Learned Calibration — Profile settings', () => {
       page.locator('input[name="calibration_mode"][value="suggest"]'),
     ).toBeChecked();
     await expect(page.locator('input[name="allow_related_exercise_learning"]')).toBeChecked();
+  });
+
+  test('promotes a learned row to a Profile reference lift', async ({ page, consoleErrors }) => {
+    consoleErrors.startCollecting();
+    await page.route(`**${CALIBRATION_DASHBOARD}`, async (route) => {
+      await route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify({
+          ok: true,
+          status: 'success',
+          data: {
+            learned: [
+              {
+                exercise_name: 'Barbell Bench Press',
+                confidence: 'medium',
+                sample_count: 1,
+                estimated_1rm: 126.67,
+                suggested_weight: 102.5,
+                suggested_min_reps: 6,
+                suggested_max_reps: 8,
+                last_observed_at: '2026-06-06 10:00:00',
+                promotable: true,
+                lift_key: 'barbell_bench_press',
+                lift_label: 'Barbell Bench Press',
+                existing_reference: null,
+                promote_weight_kg: 100,
+                promote_reps: 8,
+              },
+            ],
+            ignored_transfers: [],
+          },
+        }),
+      });
+    });
+    await page.route(`**${CALIBRATION_PROMOTE}`, async (route) => {
+      expect(route.request().postDataJSON()).toEqual({
+        exercise: 'Barbell Bench Press',
+        overwrite: false,
+      });
+      await route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify({
+          ok: true,
+          status: 'success',
+          data: {
+            lift_key: 'barbell_bench_press',
+            lift_label: 'Barbell Bench Press',
+            weight_kg: 100,
+            reps: 8,
+            overwrote: false,
+            previous: null,
+          },
+        }),
+      });
+    });
+
+    await page.goto(ROUTES.USER_PROFILE);
+    await waitForPageReady(page);
+
+    const review = page.locator('[data-calibration-review]');
+    await expect(review.locator('[data-learned-table]')).toBeVisible();
+    await expect(review).toContainText('Barbell Bench Press');
+    const button = review.locator('[data-promote-exercise="Barbell Bench Press"]');
+    await expect(button).toBeVisible();
+
+    page.once('dialog', async (dialog) => {
+      expect(dialog.message()).toContain('Save 100 kg × 8');
+      expect(dialog.message()).toContain('declared Profile reference lift');
+      await dialog.accept();
+    });
+    await button.click();
+    await expect(page.locator(SELECTORS.TOAST_BODY)).toContainText(
+      'Promoted to Profile reference lift: Barbell Bench Press 100 kg × 8',
+    );
+
+    consoleErrors.assertNoErrors();
+  });
+
+  test('promote overwrite confirm shows old and new reference values', async ({ page, consoleErrors }) => {
+    consoleErrors.startCollecting();
+    await page.route(`**${CALIBRATION_DASHBOARD}`, async (route) => {
+      await route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify({
+          ok: true,
+          status: 'success',
+          data: {
+            learned: [
+              {
+                exercise_name: 'Barbell Bench Press',
+                confidence: 'medium',
+                sample_count: 1,
+                estimated_1rm: 126.67,
+                suggested_weight: 102.5,
+                suggested_min_reps: 6,
+                suggested_max_reps: 8,
+                last_observed_at: '2026-06-06 10:00:00',
+                promotable: true,
+                lift_key: 'barbell_bench_press',
+                lift_label: 'Barbell Bench Press',
+                existing_reference: { weight_kg: 90, reps: 5 },
+                promote_weight_kg: 100,
+                promote_reps: 8,
+              },
+            ],
+            ignored_transfers: [],
+          },
+        }),
+      });
+    });
+    await page.route(`**${CALIBRATION_PROMOTE}`, async (route) => {
+      expect(route.request().postDataJSON()).toEqual({
+        exercise: 'Barbell Bench Press',
+        overwrite: true,
+      });
+      await route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify({
+          ok: true,
+          status: 'success',
+          data: {
+            lift_key: 'barbell_bench_press',
+            lift_label: 'Barbell Bench Press',
+            weight_kg: 100,
+            reps: 8,
+            overwrote: true,
+            previous: { weight_kg: 90, reps: 5 },
+          },
+        }),
+      });
+    });
+
+    await page.goto(ROUTES.USER_PROFILE);
+    await waitForPageReady(page);
+
+    const button = page.locator('[data-promote-exercise="Barbell Bench Press"]');
+    page.once('dialog', async (dialog) => {
+      expect(dialog.message()).toContain('Current: 90 kg × 5');
+      expect(dialog.message()).toContain('New (from your logged set): 100 kg × 8');
+      await dialog.accept();
+    });
+    await button.click();
+    await expect(page.locator(SELECTORS.TOAST_BODY)).toContainText(
+      'Promoted to Profile reference lift: Barbell Bench Press 100 kg × 8',
+    );
+
+    consoleErrors.assertNoErrors();
   });
 });
 

--- a/routes/user_profile.py
+++ b/routes/user_profile.py
@@ -16,10 +16,10 @@ from utils.logger import get_logger
 from utils.strength_calibration import (
     VALID_CALIBRATION_MODES,
     clear_ignored_transfers,
+    get_calibration_dashboard,
     get_calibration_settings,
     ignore_calibration_transfer,
-    list_ignored_transfers,
-    list_learned_calibrations,
+    promote_calibration_to_profile,
     reset_all_calibrations,
     reset_calibration_for_exercise,
     set_calibration_settings,
@@ -605,22 +605,79 @@ def ignore_calibration_transfer_route():
 
 @user_profile_bp.route("/api/user_profile/calibration/dashboard")
 def calibration_dashboard():
-    """Read-only calibration review surface (Phase 2B).
+    """Read-only calibration review surface (Phase 2B + 2C annotations).
 
-    Returns the learned-calibration rows and ignored related pairs the Profile
-    page renders. Never mutates state and never exposes internal transfer-ratio
-    tuning data. See ``docs/user_profile/LEARNED_CALIBRATION_PLAN.md``.
+    Returns the learned-calibration rows (each annotated with Phase 2C
+    promotion state: ``promotable`` / ``lift_key`` / ``lift_label`` /
+    ``existing_reference`` / ``promote_weight_kg`` / ``promote_reps``) and the
+    ignored related pairs the Profile page renders. Never mutates state and
+    never exposes internal transfer-ratio tuning data. See
+    ``docs/user_profile/LEARNED_CALIBRATION_PLAN.md``.
     """
     try:
         with DatabaseHandler() as db:
-            data = {
-                "learned": list_learned_calibrations(db=db),
-                "ignored_transfers": list_ignored_transfers(db=db),
-            }
+            data = get_calibration_dashboard(db=db)
         return jsonify(success_response(data=data))
     except Exception:
         logger.exception("Failed to load calibration dashboard")
         return error_response("INTERNAL_ERROR", "Failed to load calibration dashboard", 500)
+
+
+@user_profile_bp.route("/api/user_profile/calibration/promote", methods=["POST"])
+def promote_calibration_route():
+    """Promote an exact learned calibration into a declared Profile reference lift.
+
+    Writes the measured top set (basis-converted) into ``user_profile_lifts``.
+    Never silent: an existing reference lift requires ``overwrite=true`` (the UI
+    confirms old→new first). Does not change estimator priority. See
+    ``docs/user_profile/LEARNED_CALIBRATION_PLAN.md`` §"Phase 2C".
+    """
+    data = None
+    try:
+        data = _get_json_payload("promote_calibration")
+        if not isinstance(data, dict):
+            raise ValueError("Invalid JSON data")
+        exercise = _nullable_text(data.get("exercise"))
+        if exercise is None:
+            raise ValueError("exercise is required")
+        overwrite = bool(_optional_bool(data, "overwrite"))
+
+        with DatabaseHandler() as db:
+            result = promote_calibration_to_profile(exercise, db=db, overwrite=overwrite)
+
+        status = result.get("status")
+        if status == "not_promotable":
+            return error_response(
+                "NOT_PROMOTABLE",
+                "This learned calibration can't be promoted to a Profile reference lift.",
+                400,
+            )
+        if status == "exists":
+            return error_response(
+                "REFERENCE_LIFT_EXISTS",
+                "A Profile reference lift already exists for this lift; confirm to overwrite it.",
+                400,
+            )
+        return jsonify(
+            success_response(
+                data={
+                    "exercise": exercise,
+                    "lift_key": result["lift_key"],
+                    "lift_label": result["lift_label"],
+                    "weight_kg": result["weight_kg"],
+                    "reps": result["reps"],
+                    "overwrote": result["overwrote"],
+                    "previous": result["previous"],
+                },
+                message="Promoted to Profile reference lift",
+            )
+        )
+    except ValueError as exc:
+        logger.warning("Validation error promoting calibration", extra={"error": str(exc)})
+        return error_response("VALIDATION_ERROR", str(exc), 400)
+    except Exception:
+        logger.exception("Failed to promote calibration", extra={"payload": data})
+        return error_response("INTERNAL_ERROR", "Failed to promote calibration", 500)
 
 
 @user_profile_bp.route("/api/user_profile/calibration/unignore_transfer", methods=["POST"])

--- a/static/js/modules/user-profile.js
+++ b/static/js/modules/user-profile.js
@@ -1208,8 +1208,42 @@ function renderLearnedCalibrations(review, rows) {
             td.textContent = text;
             tr.appendChild(td);
         }
+        tr.appendChild(buildPromoteCell(row));
         body.appendChild(tr);
     }
+}
+
+// Phase 2C — per-row "Promote to reference lift". Promotable rows carry the
+// proposed (basis-converted) weight/reps and any existing reference value as
+// data-* attributes so the click handler can build the confirm copy without a
+// per-click round-trip. Non-promotable rows show a disabled button + tooltip.
+function buildPromoteCell(row) {
+    const td = document.createElement('td');
+    const button = document.createElement('button');
+    button.type = 'button';
+    button.className = 'btn btn-outline-primary btn-sm';
+    button.textContent = 'Promote to reference lift';
+
+    if (!row.promotable) {
+        button.disabled = true;
+        button.title = 'No matching Profile reference lift for this exercise';
+        td.appendChild(button);
+        return td;
+    }
+
+    button.dataset.promoteExercise = row.exercise_name || '';
+    button.dataset.promoteLiftLabel = row.lift_label || row.lift_key || 'this lift';
+    button.dataset.promoteWeight = row.promote_weight_kg != null ? String(row.promote_weight_kg) : '';
+    button.dataset.promoteReps = row.promote_reps != null ? String(row.promote_reps) : '';
+    if (row.existing_reference) {
+        button.dataset.promoteHasExisting = '1';
+        button.dataset.promoteExistingWeight =
+            row.existing_reference.weight_kg != null ? String(row.existing_reference.weight_kg) : '—';
+        button.dataset.promoteExistingReps =
+            row.existing_reference.reps != null ? String(row.existing_reference.reps) : '—';
+    }
+    td.appendChild(button);
+    return td;
 }
 
 function renderIgnoredTransfers(review, rows) {
@@ -1286,6 +1320,37 @@ function bindCalibrationReview() {
     review.addEventListener('click', (event) => {
         const target = event.target;
         if (!(target instanceof HTMLElement)) return;
+
+        const promote = target.closest('[data-promote-exercise]');
+        if (promote) {
+            const label = promote.dataset.promoteLiftLabel || 'this lift';
+            const weight = promote.dataset.promoteWeight;
+            const reps = promote.dataset.promoteReps;
+            let overwrite = false;
+            if (promote.dataset.promoteHasExisting === '1') {
+                const ok = window.confirm(
+                    `Replace your declared Profile reference lift for ${label}? `
+                    + 'This changes your saved baseline.\n\n'
+                    + `Current: ${promote.dataset.promoteExistingWeight} kg × ${promote.dataset.promoteExistingReps}\n`
+                    + `New (from your logged set): ${weight} kg × ${reps}\n\n`
+                    + 'Your learned suggestion already drives Workout Controls — this only '
+                    + 'updates the baseline used when learned data is unavailable.',
+                );
+                if (!ok) return;
+                overwrite = true;
+            } else if (!window.confirm(
+                `Save ${weight} kg × ${reps} as your declared Profile reference lift for ${label}? `
+                + 'This sets your saved baseline (separate from the live learned suggestion).',
+            )) {
+                return;
+            }
+            runAction(
+                '/api/user_profile/calibration/promote',
+                { exercise: promote.dataset.promoteExercise, overwrite },
+                `Promoted to Profile reference lift: ${label} ${weight} kg × ${reps}`,
+            );
+            return;
+        }
 
         const unignore = target.closest('[data-unignore-source]');
         if (unignore) {

--- a/templates/user_profile.html
+++ b/templates/user_profile.html
@@ -548,6 +548,7 @@
                                         <th scope="col">Est. 1RM</th>
                                         <th scope="col">Suggested</th>
                                         <th scope="col">Last observed</th>
+                                        <th scope="col">Action</th>
                                     </tr>
                                 </thead>
                                 <tbody data-learned-rows></tbody>

--- a/tests/test_calibration_integration.py
+++ b/tests/test_calibration_integration.py
@@ -522,3 +522,215 @@ def test_reset_all_endpoint_clears_learned_but_keeps_ratios_and_settings(
         "SELECT COUNT(*) AS n FROM exercise_transfer_ratios"
     )["n"] == 1
     assert get_calibration_settings(db=clean_db)["mode"] == "suggest"
+
+
+# --------------------------------------------------------------------------- #
+# Phase 2C — promote learned calibration to Profile reference lift
+# --------------------------------------------------------------------------- #
+
+def test_dashboard_endpoint_includes_promotion_annotations(
+    client, clean_db, exercise_factory, workout_plan_factory, workout_log_factory
+):
+    exercise_factory(BENCH, primary_muscle_group="Chest", equipment="Barbell")
+    plan_id = workout_plan_factory(exercise_name=BENCH)
+    workout_log_factory(
+        plan_id=plan_id,
+        exercise=BENCH,
+        scored_weight=100.0,
+        scored_min_reps=8,
+        scored_max_reps=8,
+    )
+    update_calibration_for_exercise(BENCH, db=clean_db)
+
+    resp = client.get("/api/user_profile/calibration/dashboard")
+    assert resp.status_code == 200
+    row = resp.get_json()["data"]["learned"][0]
+    assert row["promotable"] is True
+    assert row["lift_key"] == "barbell_bench_press"
+    assert row["lift_label"] == "Barbell Bench Press"
+    assert row["promote_weight_kg"] == 100.0
+    assert row["promote_reps"] == 8
+    assert row["existing_reference"] is None
+
+
+def test_promote_endpoint_writes_reference_without_deleting_calibration(
+    client, clean_db, exercise_factory, workout_plan_factory, workout_log_factory
+):
+    exercise_factory(BENCH, primary_muscle_group="Chest", equipment="Barbell")
+    plan_id = workout_plan_factory(exercise_name=BENCH)
+    workout_log_factory(
+        plan_id=plan_id,
+        exercise=BENCH,
+        scored_weight=102.5,
+        scored_min_reps=7,
+        scored_max_reps=7,
+    )
+    update_calibration_for_exercise(BENCH, db=clean_db)
+
+    resp = client.post(
+        "/api/user_profile/calibration/promote",
+        json={"exercise": BENCH},
+    )
+    assert resp.status_code == 200
+    body = resp.get_json()
+    assert body["ok"] is True
+    assert body["data"]["lift_key"] == "barbell_bench_press"
+    assert body["data"]["weight_kg"] == 102.5
+    assert body["data"]["reps"] == 7
+    assert body["data"]["overwrote"] is False
+    assert clean_db.fetch_one(
+        "SELECT 1 FROM learned_strength_calibrations WHERE exercise_name = ?",
+        (BENCH,),
+    ) is not None
+    saved = clean_db.fetch_one(
+        "SELECT weight_kg, reps FROM user_profile_lifts WHERE lift_key = ?",
+        ("barbell_bench_press",),
+    )
+    assert saved["weight_kg"] == 102.5
+    assert saved["reps"] == 7
+
+
+def test_promote_endpoint_requires_overwrite_for_existing_reference(
+    client, clean_db, exercise_factory, workout_plan_factory, workout_log_factory
+):
+    exercise_factory(BENCH, primary_muscle_group="Chest", equipment="Barbell")
+    plan_id = workout_plan_factory(exercise_name=BENCH)
+    workout_log_factory(
+        plan_id=plan_id,
+        exercise=BENCH,
+        scored_weight=110.0,
+        scored_min_reps=6,
+        scored_max_reps=6,
+    )
+    update_calibration_for_exercise(BENCH, db=clean_db)
+    clean_db.execute_query(
+        """
+        INSERT INTO user_profile_lifts (lift_key, weight_kg, reps, updated_at)
+        VALUES ('barbell_bench_press', 90.0, 5, CURRENT_TIMESTAMP)
+        """
+    )
+
+    blocked = client.post(
+        "/api/user_profile/calibration/promote",
+        json={"exercise": BENCH},
+    )
+    assert blocked.status_code == 400
+    assert blocked.get_json()["error"]["code"] == "REFERENCE_LIFT_EXISTS"
+    saved = clean_db.fetch_one(
+        "SELECT weight_kg, reps FROM user_profile_lifts WHERE lift_key = ?",
+        ("barbell_bench_press",),
+    )
+    assert saved["weight_kg"] == 90.0
+    assert saved["reps"] == 5
+
+    overwritten = client.post(
+        "/api/user_profile/calibration/promote",
+        json={"exercise": BENCH, "overwrite": True},
+    )
+    assert overwritten.status_code == 200
+    data = overwritten.get_json()["data"]
+    assert data["overwrote"] is True
+    assert data["previous"] == {"weight_kg": 90.0, "reps": 5}
+    saved = clean_db.fetch_one(
+        "SELECT weight_kg, reps FROM user_profile_lifts WHERE lift_key = ?",
+        ("barbell_bench_press",),
+    )
+    assert saved["weight_kg"] == 110.0
+    assert saved["reps"] == 6
+
+
+def test_promote_endpoint_rejects_missing_or_non_promotable_exercise(
+    client, clean_db, exercise_factory, workout_plan_factory, workout_log_factory
+):
+    missing = client.post("/api/user_profile/calibration/promote", json={})
+    assert missing.status_code == 400
+    assert missing.get_json()["error"]["code"] == "VALIDATION_ERROR"
+
+    exercise_factory("Pec Deck", primary_muscle_group="Chest", equipment="Machine")
+    plan_id = workout_plan_factory(exercise_name="Pec Deck")
+    workout_log_factory(
+        plan_id=plan_id,
+        exercise="Pec Deck",
+        scored_weight=70.0,
+        scored_min_reps=10,
+        scored_max_reps=10,
+    )
+    update_calibration_for_exercise("Pec Deck", db=clean_db)
+
+    non_promotable = client.post(
+        "/api/user_profile/calibration/promote",
+        json={"exercise": "Pec Deck"},
+    )
+    assert non_promotable.status_code == 400
+    assert non_promotable.get_json()["error"]["code"] == "NOT_PROMOTABLE"
+    assert clean_db.fetch_one(
+        "SELECT COUNT(*) AS n FROM user_profile_lifts"
+    )["n"] == 0
+
+
+def test_promotion_does_not_change_learned_priority_when_mode_is_on(
+    client, clean_db, exercise_factory, workout_plan_factory, workout_log_factory
+):
+    exercise_factory(SQUAT, primary_muscle_group="Quadriceps", equipment="Barbell")
+    plan_id = workout_plan_factory(exercise_name=SQUAT)
+    workout_log_factory(
+        plan_id=plan_id,
+        exercise=SQUAT,
+        scored_weight=120.0,
+        scored_min_reps=8,
+        scored_max_reps=8,
+        scored_rir=2,
+    )
+    calibration = update_calibration_for_exercise(SQUAT, db=clean_db)
+    set_calibration_mode("suggest", db=clean_db)
+
+    promote = client.post(
+        "/api/user_profile/calibration/promote",
+        json={"exercise": SQUAT},
+    )
+    assert promote.status_code == 200
+
+    estimate = client.get(
+        "/api/user_profile/estimate", query_string={"exercise": SQUAT}
+    ).get_json()["data"]
+    assert estimate["source"] == "learned"
+    assert estimate["weight"] == calibration["suggested_weight"]
+
+
+def test_promoted_reference_takes_effect_without_learned_or_exact_log_fallback(
+    client, clean_db, exercise_factory, workout_plan_factory, workout_log_factory
+):
+    exercise_factory(BENCH, primary_muscle_group="Chest", equipment="Barbell")
+    plan_id = workout_plan_factory(exercise_name=BENCH)
+    workout_log_factory(
+        plan_id=plan_id,
+        exercise=BENCH,
+        scored_weight=100.0,
+        scored_min_reps=8,
+        scored_max_reps=8,
+        scored_rir=2,
+    )
+    update_calibration_for_exercise(BENCH, db=clean_db)
+    set_calibration_mode("suggest", db=clean_db)
+    client.post(
+        "/api/user_profile/calibration/promote",
+        json={"exercise": BENCH},
+    )
+
+    reset = client.post(
+        "/api/user_profile/calibration/reset", json={"exercise": BENCH}
+    )
+    assert reset.status_code == 200
+    clean_db.execute_query("DELETE FROM workout_log WHERE exercise = ?", (BENCH,))
+
+    estimate = client.get(
+        "/api/user_profile/estimate", query_string={"exercise": BENCH}
+    ).get_json()["data"]
+    assert estimate["source"] == "profile"
+    assert estimate["reason"] == "profile"
+    saved = clean_db.fetch_one(
+        "SELECT weight_kg, reps FROM user_profile_lifts WHERE lift_key = ?",
+        ("barbell_bench_press",),
+    )
+    assert saved["weight_kg"] == 100.0
+    assert saved["reps"] == 8

--- a/tests/test_strength_calibration.py
+++ b/tests/test_strength_calibration.py
@@ -18,12 +18,15 @@ from utils.strength_calibration import (
     _utcnow,
     _variance_within_high_band,
     clear_ignored_transfers,
+    get_calibration_dashboard,
     get_calibration_mode,
     ignore_calibration_transfer,
     list_ignored_transfers,
     list_learned_calibrations,
+    promote_calibration_to_profile,
     reset_all_calibrations,
     reset_calibration_for_exercise,
+    resolve_promotion_target,
     unignore_calibration_transfer,
     update_calibration_for_exercise,
 )
@@ -383,3 +386,177 @@ def test_reset_all_calibrations_clears_rows_only(
     assert list_learned_calibrations(db=clean_db) == []
     # Ignored transfers are a separate concern — left untouched by reset-all.
     assert len(list_ignored_transfers(db=clean_db)) == 1
+
+
+# --------------------------------------------------------------------------- #
+# Phase 2C — promote learned calibration to Profile reference lift
+# --------------------------------------------------------------------------- #
+
+def test_resolve_promotion_target_uses_measured_top_set(
+    clean_db, exercise_factory, workout_plan_factory
+):
+    ex = exercise_factory("Barbell Bench Press", equipment="Barbell")
+    plan = workout_plan_factory(exercise_name=ex)
+    _log(clean_db, plan, ex, scored_weight=100.0, scored_max_reps=14)
+    update_calibration_for_exercise(ex, db=clean_db)
+
+    target = resolve_promotion_target(ex, db=clean_db)
+    assert target["lift_key"] == "barbell_bench_press"
+    assert target["weight_kg"] == 100.0
+    assert target["reps"] == 14
+    assert target["existing_reference"] is None
+
+
+def test_resolve_promotion_target_converts_dumbbell_to_total_lift_basis(
+    clean_db, exercise_factory, workout_plan_factory
+):
+    ex = exercise_factory("Incline Dumbbell Bench Press", equipment="Dumbbells")
+    plan = workout_plan_factory(exercise_name=ex)
+    _log(clean_db, plan, ex, scored_weight=36.0, scored_max_reps=8)
+    update_calibration_for_exercise(ex, db=clean_db)
+
+    target = resolve_promotion_target(ex, db=clean_db)
+    assert target["lift_key"] == "incline_bench_press"
+    assert target["weight_kg"] == 72.0
+    assert target["reps"] == 8
+
+
+def test_resolve_promotion_target_converts_total_to_dumbbell_lift_basis(
+    clean_db, exercise_factory, workout_plan_factory
+):
+    ex = exercise_factory("Machine Dumbbell Bench Press", equipment="Machine")
+    plan = workout_plan_factory(exercise_name=ex)
+    _log(clean_db, plan, ex, scored_weight=80.0, scored_max_reps=8)
+    update_calibration_for_exercise(ex, db=clean_db)
+
+    target = resolve_promotion_target(ex, db=clean_db)
+    assert target["lift_key"] == "dumbbell_bench_press"
+    assert target["weight_kg"] == 40.0
+    assert target["reps"] == 8
+
+
+def test_resolve_promotion_target_blocks_low_confidence_and_unmapped_exercises(
+    clean_db, exercise_factory, workout_plan_factory
+):
+    low = exercise_factory("Barbell Bench Press", equipment="Barbell")
+    plan = workout_plan_factory(exercise_name=low)
+    _log(clean_db, plan, low, scored_weight=100.0, scored_max_reps=8)
+    update_calibration_for_exercise(low, db=clean_db)
+    clean_db.execute_query(
+        "UPDATE learned_strength_calibrations SET confidence = 'low' WHERE exercise_name = ?",
+        (low,),
+    )
+    assert resolve_promotion_target(low, db=clean_db) is None
+
+    unmapped = exercise_factory("Pec Deck", equipment="Machine")
+    unmapped_plan = workout_plan_factory(exercise_name=unmapped)
+    _log(clean_db, unmapped_plan, unmapped, scored_weight=60.0, scored_max_reps=10)
+    update_calibration_for_exercise(unmapped, db=clean_db)
+    assert resolve_promotion_target(unmapped, db=clean_db) is None
+
+
+def test_resolve_promotion_target_blocks_excluded_exercise_even_with_lift_key(
+    clean_db, exercise_factory, workout_plan_factory
+):
+    ex = exercise_factory("Weighted Pull-Up With Band", equipment="Band")
+    plan = workout_plan_factory(exercise_name=ex)
+    log_id = _log(clean_db, plan, ex, scored_weight=20.0, scored_max_reps=6)
+    clean_db.execute_query(
+        """
+        INSERT INTO learned_strength_calibrations (
+            exercise_name, lift_key, estimated_1rm, suggested_weight,
+            confidence, sample_count, last_log_id, source, created_at, updated_at
+        ) VALUES (?, 'weighted_pullups', 24.0, 20.0, 'medium', 1, ?,
+                  'exact_logs', CURRENT_TIMESTAMP, CURRENT_TIMESTAMP)
+        """,
+        (ex, log_id),
+    )
+
+    assert resolve_promotion_target(ex, db=clean_db) is None
+
+
+def test_resolve_promotion_target_requires_source_log(
+    clean_db, exercise_factory, workout_plan_factory
+):
+    ex = exercise_factory("Barbell Bench Press", equipment="Barbell")
+    plan = workout_plan_factory(exercise_name=ex)
+    log_id = _log(clean_db, plan, ex, scored_weight=100.0, scored_max_reps=8)
+    update_calibration_for_exercise(ex, db=clean_db)
+    clean_db.execute_query("DELETE FROM workout_log WHERE id = ?", (log_id,))
+
+    assert resolve_promotion_target(ex, db=clean_db) is None
+
+
+def test_promote_calibration_to_profile_writes_reference_and_keeps_learned_row(
+    clean_db, exercise_factory, workout_plan_factory
+):
+    ex = exercise_factory("Barbell Bench Press", equipment="Barbell")
+    plan = workout_plan_factory(exercise_name=ex)
+    _log(clean_db, plan, ex, scored_weight=102.5, scored_max_reps=7)
+    update_calibration_for_exercise(ex, db=clean_db)
+
+    result = promote_calibration_to_profile(ex, db=clean_db)
+    assert result["status"] == "promoted"
+    assert result["lift_key"] == "barbell_bench_press"
+    assert result["weight_kg"] == 102.5
+    assert result["reps"] == 7
+    assert result["overwrote"] is False
+    assert _calibration_row(clean_db, ex) is not None
+    saved = clean_db.fetch_one(
+        "SELECT weight_kg, reps FROM user_profile_lifts WHERE lift_key = ?",
+        ("barbell_bench_press",),
+    )
+    assert saved["weight_kg"] == 102.5
+    assert saved["reps"] == 7
+
+
+def test_promote_calibration_to_profile_requires_overwrite_for_existing_reference(
+    clean_db, exercise_factory, workout_plan_factory
+):
+    ex = exercise_factory("Barbell Bench Press", equipment="Barbell")
+    plan = workout_plan_factory(exercise_name=ex)
+    _log(clean_db, plan, ex, scored_weight=110.0, scored_max_reps=6)
+    update_calibration_for_exercise(ex, db=clean_db)
+    clean_db.execute_query(
+        """
+        INSERT INTO user_profile_lifts (lift_key, weight_kg, reps, updated_at)
+        VALUES ('barbell_bench_press', 90.0, 5, CURRENT_TIMESTAMP)
+        """
+    )
+
+    blocked = promote_calibration_to_profile(ex, db=clean_db)
+    assert blocked["status"] == "exists"
+    saved = clean_db.fetch_one(
+        "SELECT weight_kg, reps FROM user_profile_lifts WHERE lift_key = ?",
+        ("barbell_bench_press",),
+    )
+    assert saved["weight_kg"] == 90.0
+    assert saved["reps"] == 5
+
+    overwritten = promote_calibration_to_profile(ex, db=clean_db, overwrite=True)
+    assert overwritten["status"] == "promoted"
+    assert overwritten["overwrote"] is True
+    assert overwritten["previous"] == {"weight_kg": 90.0, "reps": 5}
+    saved = clean_db.fetch_one(
+        "SELECT weight_kg, reps FROM user_profile_lifts WHERE lift_key = ?",
+        ("barbell_bench_press",),
+    )
+    assert saved["weight_kg"] == 110.0
+    assert saved["reps"] == 6
+
+
+def test_calibration_dashboard_adds_promotion_annotations(
+    clean_db, exercise_factory, workout_plan_factory
+):
+    ex = exercise_factory("Barbell Bench Press", equipment="Barbell")
+    plan = workout_plan_factory(exercise_name=ex)
+    _log(clean_db, plan, ex, scored_weight=100.0, scored_max_reps=8)
+    update_calibration_for_exercise(ex, db=clean_db)
+
+    dashboard = get_calibration_dashboard(db=clean_db)
+    row = dashboard["learned"][0]
+    assert row["promotable"] is True
+    assert row["lift_key"] == "barbell_bench_press"
+    assert row["lift_label"] == "Barbell Bench Press"
+    assert row["promote_weight_kg"] == 100.0
+    assert row["promote_reps"] == 8

--- a/utils/strength_calibration.py
+++ b/utils/strength_calibration.py
@@ -23,12 +23,15 @@ from __future__ import annotations
 from datetime import datetime, timezone
 from typing import Any, Optional
 
-from utils.database import DatabaseHandler
+from utils.database import DatabaseHandler, upsert_user_profile_lift
 from utils.logger import get_logger
-from utils.normalization import normalize_muscle
+from utils.normalization import normalize_equipment, normalize_muscle
 from utils.lift_matching import match_direct_lift_key
 from utils.profile_estimator import (
     DEFAULT_ESTIMATE,
+    DUMBBELL_LIFT_KEYS,
+    KEY_LIFT_LABELS,
+    KEY_LIFTS,
     classify_tier,
     epley_1rm,
 )
@@ -504,6 +507,180 @@ def reset_all_calibrations(*, db: DatabaseHandler) -> None:
     transfer ratios are left intact, and rows recompute on the next scored log.
     """
     db.execute_query("DELETE FROM learned_strength_calibrations")
+
+
+# -- Phase 2C: promote learned calibration → declared Profile reference lift --
+#
+# The only Phase 2 path that writes user-declared baseline data. It graduates a
+# *measured* learned result into ``user_profile_lifts`` so it survives learned
+# mode being off/stale once exact log fallback is unavailable, and feeds the
+# Profile/cold-start/cohort surfaces that never read learned rows. Estimator
+# priority is unchanged: while learned mode is on and the row is usable, Workout
+# Controls still serves the learned suggestion, not the promoted Profile value
+# (plan §"Phase 2C").
+
+
+def _promotion_basis_factor(source_is_per_hand: bool, target_is_per_hand: bool) -> float:
+    """Convert a measured load from the *exercise* basis to the *lift_key* basis.
+
+    Dumbbell loads are per hand; everything else is a single total/system load
+    (same "two dumbbells = one barbell" model as
+    :func:`profile_estimator._load_basis_factor`, but the source side here is
+    the exercise, not a reference lift_key).
+    """
+    if source_is_per_hand == target_is_per_hand:
+        return 1.0
+    return 2.0 if source_is_per_hand else 0.5
+
+
+def resolve_promotion_target(
+    exercise_name: str, *, db: DatabaseHandler
+) -> Optional[dict[str, Any]]:
+    """Return the promotion plan for one exact learned calibration, or ``None``.
+
+    Promotable only when (plan §"Phase 2C / Eligibility"): a learned row exists
+    with usable (``medium``/``high``) confidence; ``exercise_name`` resolves to a
+    known ``KEY_LIFTS`` reference-lift slug; and the source log
+    (``last_log_id``) still carries a usable scored top set. The measured top
+    set is basis-converted into the slug's load basis — no estimator math and no
+    rounding to equipment increments (reference lifts hold raw user values).
+    """
+    if not exercise_name or not exercise_name.strip():
+        return None
+    row = get_learned_calibration(exercise_name.strip(), db=db)
+    if not row or row.get("confidence") not in USABLE_SUGGEST_CONFIDENCES:
+        return None
+
+    canonical_name = row.get("exercise_name") or exercise_name.strip()
+    lift_key = match_direct_lift_key(canonical_name)
+    if not lift_key or lift_key not in KEY_LIFTS:
+        return None
+
+    last_log_id = row.get("last_log_id")
+    if last_log_id is None:
+        return None
+    log = db.fetch_one(
+        "SELECT scored_weight, scored_max_reps FROM workout_log WHERE id = ?",
+        (last_log_id,),
+    )
+    if not log:
+        return None
+    scored_weight = log.get("scored_weight")
+    scored_reps = log.get("scored_max_reps")
+    if scored_weight is None or scored_reps is None:
+        return None
+    try:
+        scored_weight = float(scored_weight)
+        scored_reps = int(scored_reps)
+    except (TypeError, ValueError):
+        return None
+    if scored_weight <= 0 or scored_reps <= 0:
+        return None
+
+    exercise_row = db.fetch_one(
+        """
+        SELECT exercise_name, primary_muscle_group, equipment, mechanic, movement_pattern
+        FROM exercises
+        WHERE exercise_name = ? COLLATE NOCASE
+        """,
+        (canonical_name,),
+    )
+    if not exercise_row or classify_tier(exercise_row) == "excluded":
+        return None
+    source_is_per_hand = (
+        normalize_equipment((exercise_row or {}).get("equipment")) == "Dumbbells"
+    )
+    factor = _promotion_basis_factor(source_is_per_hand, lift_key in DUMBBELL_LIFT_KEYS)
+    weight_kg = round(scored_weight * factor, 2)
+
+    existing = db.fetch_one(
+        "SELECT weight_kg, reps FROM user_profile_lifts WHERE lift_key = ?",
+        (lift_key,),
+    )
+    existing_reference = None
+    if existing and (
+        existing.get("weight_kg") is not None or existing.get("reps") is not None
+    ):
+        existing_reference = {
+            "weight_kg": existing.get("weight_kg"),
+            "reps": existing.get("reps"),
+        }
+
+    return {
+        "exercise_name": canonical_name,
+        "lift_key": lift_key,
+        "lift_label": KEY_LIFT_LABELS.get(lift_key, lift_key),
+        "weight_kg": weight_kg,
+        "reps": scored_reps,
+        "confidence": row.get("confidence"),
+        "existing_reference": existing_reference,
+    }
+
+
+def promote_calibration_to_profile(
+    exercise_name: str, *, db: DatabaseHandler, overwrite: bool = False
+) -> dict[str, Any]:
+    """Promote an exact learned calibration into the Profile reference lift.
+
+    Returns a status dict the route maps to a response:
+
+    - ``not_promotable`` — no usable learned row / unresolvable slug / no source
+      log (route → ``NOT_PROMOTABLE`` 400).
+    - ``exists`` — a reference lift already exists and ``overwrite`` is false; no
+      write (route → ``REFERENCE_LIFT_EXISTS`` 400 guard; the UI confirms first).
+    - ``promoted`` — written. Graduates the row; does **not** delete it, and
+      touches nothing but ``user_profile_lifts``.
+    """
+    target = resolve_promotion_target(exercise_name, db=db)
+    if target is None:
+        return {"status": "not_promotable"}
+    if target["existing_reference"] is not None and not overwrite:
+        return {"status": "exists", "target": target}
+
+    upsert_user_profile_lift(
+        target["lift_key"], target["weight_kg"], target["reps"], db=db
+    )
+    return {
+        "status": "promoted",
+        "lift_key": target["lift_key"],
+        "lift_label": target["lift_label"],
+        "weight_kg": target["weight_kg"],
+        "reps": target["reps"],
+        "overwrote": target["existing_reference"] is not None,
+        "previous": target["existing_reference"],
+    }
+
+
+def get_calibration_dashboard(*, db: DatabaseHandler) -> dict[str, Any]:
+    """Learned + ignored review payload, with per-row promotion annotations.
+
+    Read-only. Each learned row gains ``lift_key`` / ``lift_label`` /
+    ``promotable`` / ``existing_reference`` / ``promote_weight_kg`` /
+    ``promote_reps`` so the Profile review table can render the right button
+    label and confirm copy without a per-click round-trip (plan §"Phase 2C /
+    Route contract"). Never mutates state.
+    """
+    learned = list_learned_calibrations(db=db)
+    for row in learned:
+        target = resolve_promotion_target(row.get("exercise_name"), db=db)
+        if target is None:
+            row["promotable"] = False
+            row["lift_key"] = None
+            row["lift_label"] = None
+            row["existing_reference"] = None
+            row["promote_weight_kg"] = None
+            row["promote_reps"] = None
+        else:
+            row["promotable"] = True
+            row["lift_key"] = target["lift_key"]
+            row["lift_label"] = target["lift_label"]
+            row["existing_reference"] = target["existing_reference"]
+            row["promote_weight_kg"] = target["weight_kg"]
+            row["promote_reps"] = target["reps"]
+    return {
+        "learned": learned,
+        "ignored_transfers": list_ignored_transfers(db=db),
+    }
 
 
 def update_calibration_for_exercise(


### PR DESCRIPTION
## Phase 2C — Promote learned calibration to Profile reference lift

Adds one explicit, gated, confirmed action that **graduates** an exact learned calibration into the user's **declared Profile reference lift** — the first and only Phase 2 path that writes user-declared baseline data (`user_profile_lifts`).

### What it does
A per-row **"Promote to reference lift"** button on the Phase 2B learned-calibration review table (`/user_profile`). It writes the user's **measured top set** (`scored_weight × scored_max_reps` from the source `workout_log` row via `last_log_id`), basis-converted between dumbbell per-hand and total/system load, into `user_profile_lifts`.

### Eligibility (all must hold)
- Exact learned row exists with `medium`/`high` confidence
- `match_direct_lift_key()` resolves to a known `KEY_LIFTS` slug
- Source log still exists with usable scored weight + reps
- Source exercise is not `excluded` by `classify_tier()`

### Guarantees
- **No schema change** — both endpoints of the write already exist; no `conftest`/`/erase-data`/backup changes.
- **No silent overwrite** — existing reference requires UI confirm (old → new); server enforces a `REFERENCE_LIFT_EXISTS` backstop.
- **No estimator priority change** — `exact learned → exact log → related learned → Profile → cold-start → default` is unchanged. While learned mode is on and the row is usable, Workout Controls still serves the learned suggestion; the promoted Profile value only surfaces via the pre-existing Profile/cold-start fallback and cohort/accuracy displays.
- **Learned row is not deleted** by promotion (graduates, doesn't consume); idempotent.
- No `calibration_events`, no plan-row (`user_selection`) writes, no workout-log rewrites.

### Migration note
Promotion can change *future* suggestions only through the pre-existing Profile/cold-start fallback path and the accuracy/cohort displays — there is no priority or formula change.

### Changes
- `utils/strength_calibration.py` — `_promotion_basis_factor`, `resolve_promotion_target`, `promote_calibration_to_profile`, dashboard promotion annotations
- `routes/user_profile.py` — `POST /api/user_profile/calibration/promote` (`VALIDATION_ERROR` / `NOT_PROMOTABLE` / `REFERENCE_LIFT_EXISTS`); dashboard now uses `get_calibration_dashboard`
- `templates/user_profile.html` + `static/js/modules/user-profile.js` — promote button, confirm copy, success toast
- `docs/user_profile/LEARNED_CALIBRATION_PLAN.md` — Phase 2C plan
- tests + e2e — resolver/basis/guard unit, route contract, estimator-priority integration, mocked promote flow

### Verification
- Full pytest: **1524 passed** (~218s)
- Focused calibration suites locally: 64 passed
- Playwright Chromium: `learned-calibration.spec.ts` 8 passed, `user-profile.spec.ts` 24 passed
- `git diff --check`: clean (CRLF warnings only)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
