### PR TITLE
chore(mcp): drop puppeteer server, keep context7

### DIFF
--- a/.mcp.json
+++ b/.mcp.json
@@ -3,11 +3,6 @@
     "context7": {
       "type": "http",
       "url": "https://mcp.context7.com/mcp"
-    },
-    "puppeteer": {
-      "type": "stdio",
-      "command": "cmd",
-      "args": ["/c", "npx", "-y", "@modelcontextprotocol/server-puppeteer"]
     }
   }
 }


### PR DESCRIPTION
Removes the `puppeteer` MCP server from the checked-in `.mcp.json`.

Browser automation is consolidated on the **Playwright MCP** (pinned to `@playwright/mcp@0.0.74` = Playwright 1.60.0, matching the E2E suite's `@playwright/test` version so it reuses the existing `chromium-1223` browser). The Playwright + markitdown MCP servers are configured at user scope, not in this file.

No code or test impact — config-only change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)