### PR TITLE
ci(pyright): align pythonVersion to 3.11 to match CI runtime (A12)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -369,7 +369,8 @@ jobs:
   #                   job only on NET-NEW diagnostics. Existing errors never red
   #                   the build; a regression does.
   # The recorded pyright count is 1.1.410 under the committed pyrightconfig.json
-  # (py3.12 + Windows platform). The baseline-diff keys on file+rule+message+
+  # (py3.11 + Windows platform — pythonVersion aligned to the CI runtime, A12).
+  # The baseline-diff keys on file+rule+message+
   # severity (repo-relative POSIX path), counted as a multiset, so it reproduces
   # across Windows/Linux. Regenerate the baseline with --write-baseline when an
   # intentional, reviewed change shifts the backlog.
@@ -389,7 +390,10 @@ jobs:
     - name: Set up Python
       uses: actions/setup-python@v5
       with:
-        python-version: '3.12'
+        # Aligned to the CI runtime python (3.11) so pyright type-checks against
+        # the version the tests actually run on (A12 reconcile). Diagnostic set is
+        # identical under 3.11 vs the prior 3.12 (verified: 190 diags, 0 delta).
+        python-version: '3.11'
         cache: 'pip'
 
     - name: Set up Node.js
@@ -414,10 +418,10 @@ jobs:
       run: |
         npx pyright@1.1.410 --outputjson > pyright.json 2> pyright.stderr.txt || true
         COUNT=$(python -c "import json; print(json.load(open('pyright.json'))['summary']['errorCount'])" 2>/dev/null || echo "unknown")
-        echo "::notice title=pyright (measure-only count)::pyright 1.1.410 reported $COUNT errors (py3.12 config); the baseline-diff step gates NET-NEW errors only"
+        echo "::notice title=pyright (measure-only count)::pyright 1.1.410 reported $COUNT errors (py3.11 config); the baseline-diff step gates NET-NEW errors only"
         {
           echo "### pyright (measure-only count + baseline-gated)"
-          echo "- **total errors**: $COUNT (pyright 1.1.410, py3.12 + Windows-platform config)"
+          echo "- **total errors**: $COUNT (pyright 1.1.410, py3.11 + Windows-platform config)"
           echo "- Blocking gate: net-new vs docs/ci_cd_phase3/pyright-baseline.json (next step)."
         } >> "$GITHUB_STEP_SUMMARY"
 

--- a/docs/ci_cd_phase3/pyright-baseline.json
+++ b/docs/ci_cd_phase3/pyright-baseline.json
@@ -1,7 +1,7 @@
 {
   "_meta": {
     "tool": "pyright",
-    "note": "Baseline-allowlist for the typecheck CI gate (leftovers A9). Generated under the committed pyrightconfig.json (pythonVersion 3.12, pythonPlatform Windows). Regenerate with scripts/pyright_baseline_diff.py --write-baseline. Do NOT edit by hand to silence a real regression.",
+    "note": "Baseline-allowlist for the typecheck CI gate (leftovers A9). Generated under the committed pyrightconfig.json (pythonVersion 3.11, pythonPlatform Windows). Regenerate with scripts/pyright_baseline_diff.py --write-baseline. Do NOT edit by hand to silence a real regression.",
     "total_diagnostics": 190,
     "distinct_keys": 58
   },

--- a/pyrightconfig.json
+++ b/pyrightconfig.json
@@ -1,7 +1,7 @@
 {
   "venvPath": ".",
   "venv": ".venv",
-  "pythonVersion": "3.12",
+  "pythonVersion": "3.11",
   "pythonPlatform": "Windows",
   "executionEnvironments": [
     {

--- a/scripts/pyright_baseline_diff.py
+++ b/scripts/pyright_baseline_diff.py
@@ -113,7 +113,7 @@ def counts_to_baseline(counter: Counter) -> dict:
             "note": (
                 "Baseline-allowlist for the typecheck CI gate (leftovers A9). "
                 "Generated under the committed pyrightconfig.json "
-                "(pythonVersion 3.12, pythonPlatform Windows). Regenerate with "
+                "(pythonVersion 3.11, pythonPlatform Windows). Regenerate with "
                 "scripts/pyright_baseline_diff.py --write-baseline. Do NOT edit "
                 "by hand to silence a real regression."
             ),


### PR DESCRIPTION
Closes the pyright Python-version mismatch (A12 misc, leftovers P2).

## Problem
The `typecheck` job ran pyright under **pythonVersion 3.12** while every other CI job (Run Tests, Code Linting, E2E, Frontend Build, Security Audit) runs **Python 3.11** — so the type gate validated the code against a Python version the tests never execute on.

## Change (narrow, reversible)
- `pyrightconfig.json`: `pythonVersion` 3.12 → **3.11**.
- `.github/workflows/ci.yml` `typecheck` job: `setup-python` 3.12 → 3.11 + the py3.12 notice/summary/comment text → py3.11. **Job `name:` unchanged** — the required branch-protection context `Type Check (tsc blocking + pyright measure-only)` is preserved byte-for-byte.
- `scripts/pyright_baseline_diff.py`: the hardcoded regenerate-note string 3.12 → 3.11 (so `--write-baseline` stays truthful).
- `docs/ci_cd_phase3/pyright-baseline.json`: regenerated under 3.11.

## Measurement (why this is safe)
Diagnostic set is **identical** under 3.11 vs 3.12: **190 diagnostics / 58 distinct keys, symmetric difference = 0** (no net-new, no removals, no swaps). `reportMissingImports = 0` (intrinsic diagnostics, venv- and platform-independent — same property that let the 3.12 baseline reproduce on CI's Linux runner in A9). The only content change to the baseline JSON is the `_meta.note` version string.

## Validation
- `pyright_baseline_diff.py` gate: **PASS, 0 net-new** (baseline 190, current 190).
- `pytest tests/test_pyright_baseline_diff.py` → **13 passed**.
- CI `typecheck` job expected to reproduce the regenerated baseline on the Linux 3.11 runner and stay green.

## Guardrails honored
No branch-protection change; no required-job rename; no fatigue/calibration code touched; `data/database.db` not staged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)