### PR TITLE
chore(docs): archive completed CLEANUP_V2_DEAD_CODE_AUDIT.md

### DIFF
--- a/docs/archive/CLEANUP_V2_DEAD_CODE_AUDIT.md
+++ b/docs/archive/CLEANUP_V2_DEAD_CODE_AUDIT.md
@@ -3,7 +3,7 @@
 **Date:** 2026-06-11
 **Author:** Claude (Opus 4.8) — deep scan, parallel agents + manual grep verification
 **For:** Codex review + execution
-**Status:** Findings verified, awaiting cleanup decision
+**Status:** CLOSED 2026-06-12 — all tiers (1/2/3) + both HOLD items shipped to `main` (PRs #81, #82). See the Execution Records at the foot of this file. Archived.
 
 ---
 


### PR DESCRIPTION
The cleanup-v2 dead-code audit is fully closed — all tiers (1/2/3) + both HOLD items shipped to `main` (PRs #81, #82).

- `git mv docs/CLEANUP_V2_DEAD_CODE_AUDIT.md docs/archive/` — matches the existing convention for completed one-off audit/plan docs (DOCS_AUDIT_PLAN, PUPPETEER_TEST_FINDINGS, etc.).
- Updated the stale `Status:` header (was "awaiting cleanup decision") to CLOSED.
- Reference-safe: the doc is linked from no code or other docs (unlike `CLAUDE_MD_AUDIT.md`, which stays top-level because `CLAUDE.md` points to it).

Docs-only move; no code impact.

🤖 Generated with [Claude Code](https://claude.com/claude-code)