### PR TITLE
docs: archive procedure — grep code/tests/workflows, not just docs

### DIFF
--- a/docs/ai_workflow/DOC_RETENTION.md
+++ b/docs/ai_workflow/DOC_RETENTION.md
@@ -28,8 +28,9 @@ Archive a document only when all of these are true:
 
 1. Create `docs/archive/<year>/<feature>/` if it does not already exist.
 2. Move the stale document there with its filename preserved unless the old name is misleading.
-3. Update links in `docs/README.md`, `docs/ai_workflow/INDEX.md`, and any affected feature docs.
-4. Add a short changelog or handover note if the archived document was previously part of an active workstream.
+3. Grep the **whole repo** for the filename, not just docs — `*.py`/`*.ts`/`*.json`/`.github/workflows/*.yml` can hardcode a doc path (e.g. a test asserting an audit doc exists, or a CI step reading a baseline file). A doc-only link sweep misses these and the move reds CI. Fix every code/workflow reference, or keep the file in place if a build/test depends on its path.
+4. Update links in `docs/README.md`, `docs/ai_workflow/INDEX.md`, and any affected feature docs.
+5. Add a short changelog or handover note if the archived document was previously part of an active workstream.
 
 ## Keep Active Procedure
 


### PR DESCRIPTION
## What
One step added to the [DOC_RETENTION.md](docs/ai_workflow/DOC_RETENTION.md) **Archive Procedure**: before moving a doc, grep the whole repo (`*.py`/`*.ts`/`*.json`/`.github/workflows/*.yml`) for the filename — not just docs — because code/CI can hardcode a doc path.

## Why
In PR #84, archiving `VOLUME_TAXONOMY_AUDIT.md` reded CI: `tests/test_volume_taxonomy.py::test_blank_pst_audit_section_present` asserts the audit doc exists at a hardcoded path. A docs-only link sweep missed it. This step prevents that class of failure.

Docs-only change. No code/schema/API/CI-logic impact.

🤖 Generated with [Claude Code](https://claude.com/claude-code)