### PR TITLE
fix(toast): correct reversed showToast argument order in app.js (Track A1)

### DIFF
--- a/e2e/workout-plan.spec.ts
+++ b/e2e/workout-plan.spec.ts
@@ -624,6 +624,73 @@ test.describe('Plan Generator v1.5.0 Features', () => {
 });
 
 // ============================================================================
+// Toast severity contract (Track A1) — app.js's generateStarterPlan() previously
+// called showToast(message, type) instead of showToast(type, message). toast.js's
+// legacy-signature fallback (modules/toast.js:14-27) treats any non-boolean 2nd
+// arg as a falsy legacyIsError, so both the client-side validation warning and
+// the server-error path silently rendered as a green "success" toast. These
+// tests pin the correct severity class (bg-warning / bg-danger) as well as the
+// message, so a regression back to the reversed argument order fails loudly.
+// ============================================================================
+
+test.describe('Starter plan toast severity contract', () => {
+  test.beforeEach(async ({ page, consoleErrors }) => {
+    consoleErrors.startCollecting();
+    await page.goto(ROUTES.WORKOUT_PLAN);
+    await waitForPageReady(page);
+  });
+
+  test.afterEach(async ({ consoleErrors }) => {
+    consoleErrors.assertNoErrors();
+  });
+
+  test('no-equipment-selected guard renders a warning toast, not success', async ({ page }) => {
+    await page.locator('#generate-plan-btn').click();
+    const modal = page.locator('#generatePlanModal');
+    await expect(modal).toBeVisible({ timeout: 5000 });
+
+    // Uncheck every equipment box via the modal's own "None" shortcut so
+    // generateStarterPlan() hits the client-side equipment-required guard
+    // (app.js: showToast('warning', 'Please select at least one equipment type.'))
+    // instead of reaching the API.
+    await page.locator('button[onclick*="checked = false"]').click();
+
+    await page.locator('#generatePlanSubmit').click();
+
+    const toast = page.locator('#liveToast');
+    await expect(toast).toBeVisible({ timeout: 5000 });
+    await expect(toast).toHaveClass(/bg-warning/);
+    await expect(toast).not.toHaveClass(/bg-success/);
+    await expect(page.locator('#toast-body')).toContainText('Please select at least one equipment type.');
+
+    // Submission was blocked client-side, so the modal stays open.
+    await expect(modal).toBeVisible();
+  });
+
+  test('server-rejected generation renders an error toast with the server message, not success', async ({ page }) => {
+    await page.route('**/generate_starter_plan', async route => {
+      await route.fulfill({
+        status: 400,
+        contentType: 'application/json',
+        body: JSON.stringify({ message: 'No exercises available for the selected filters.' }),
+      });
+    });
+
+    await page.locator('#generate-plan-btn').click();
+    const modal = page.locator('#generatePlanModal');
+    await expect(modal).toBeVisible({ timeout: 5000 });
+
+    await page.locator('#generatePlanSubmit').click();
+
+    const toast = page.locator('#liveToast');
+    await expect(toast).toBeVisible({ timeout: 5000 });
+    await expect(toast).toHaveClass(/bg-danger/);
+    await expect(toast).not.toHaveClass(/bg-success/);
+    await expect(page.locator('#toast-body')).toContainText('No exercises available for the selected filters.');
+  });
+});
+
+// ============================================================================
 // Muscle selector — single MuscleMap body map
 //
 // One MuscleMap anatomy figure (id="body-{anterior,posterior}-hypertrophy-advanced")

--- a/static/js/app.js
+++ b/static/js/app.js
@@ -96,7 +96,7 @@ window.generateStarterPlan = async function() {
         
         // Validate at least one equipment is selected
         if (equipmentWhitelist.length === 0) {
-            showToast('Please select at least one equipment type.', 'warning');
+            showToast('warning', 'Please select at least one equipment type.');
             submitBtn.disabled = false;
             submitBtn.innerHTML = originalText;
             return;
@@ -108,7 +108,7 @@ window.generateStarterPlan = async function() {
             priorityMuscles = window.muscleSelector.getSelectedMusclesForBackend();
             // Limit to 2 priority muscles
             if (priorityMuscles.length > 2) {
-                showToast('Maximum 2 priority muscles allowed. Using first 2 selected.', 'warning');
+                showToast('warning', 'Maximum 2 priority muscles allowed. Using first 2 selected.');
                 priorityMuscles = priorityMuscles.slice(0, 2);
             }
         }
@@ -143,7 +143,7 @@ window.generateStarterPlan = async function() {
             // Show success message
             const routines = Object.keys(result.data.routines).join(', ');
             const totalExercises = result.data.total_exercises;
-            showToast(`Plan generated successfully! Created routines: ${routines} with ${totalExercises} exercises.`, 'success');
+            showToast('success', `Plan generated successfully! Created routines: ${routines} with ${totalExercises} exercises.`);
             
             // Refresh the workout plan table
             if (typeof fetchWorkoutPlan === 'function') {
@@ -155,11 +155,11 @@ window.generateStarterPlan = async function() {
             }
         } else {
             const errorMsg = result.message || 'Failed to generate plan';
-            showToast(errorMsg, 'error');
+            showToast('error', errorMsg);
         }
     } catch (error) {
         console.error('Error generating plan:', error);
-        showToast('Error generating plan. Please try again.', 'error');
+        showToast('error', 'Error generating plan. Please try again.');
     } finally {
         // Restore button state
         submitBtn.disabled = false;


### PR DESCRIPTION
## Summary

`static/js/app.js`'s `generateStarterPlan()` called the standardized `showToast(type, message)` API with the arguments **reversed**, as `showToast(message, type)`, at all five call sites in the function. `toast.js`'s legacy-signature backward-compat branch (`static/js/modules/toast.js:14-27`) treats any non-boolean 2nd argument as a falsy `legacyIsError`, so these calls silently rendered as a green **success** toast regardless of the intended severity — the message text was still correct, only the color/class was wrong (or, for the one call whose intended severity happened to be `'success'`, coincidentally correct).

Fixed call sites (all in `static/js/app.js`, `window.generateStarterPlan`):
- `app.js:99` — equipment-required guard: `showToast('...', 'warning')` → `showToast('warning', '...')`
- `app.js:111` — priority-muscles-limit guard: `showToast('...', 'warning')` → `showToast('warning', '...')`
- `app.js:146` — success path: `showToast('...', 'success')` → `showToast('success', '...')`
- `app.js:158` — server-rejected generation: `showToast(errorMsg, 'error')` → `showToast('error', errorMsg)`
- `app.js:162` — fetch/exception catch: `showToast('...', 'error')` → `showToast('error', '...')`

**Count note:** the refactor plan (`docs/REFACTOR_PLAN.md` A1) and the scan findings (`docs/SCAN_FINDINGS.md` Phase 12/17, `docs/scan/PHASE_12.md`, `docs/scan/PHASE_17.md`) call out **four** risk sites (`app.js:99,111,158,162`) because those are the ones with an observable severity-color bug (warning/error rendering green). Re-grepping `app.js` against current `main` turns up a **fifth** call using the same reversed-argument pattern at line 146 (the success-path toast) — it doesn't produce a visibly wrong color today only because the fallback for a non-boolean `legacyIsError` happens to be `'success'`, which is what that call intended anyway. Fixed all five for consistency and to remove the latent footgun (any future edit to that line's intended severity would silently reintroduce the bug).

Other files (`workout-plan.js`, `exercises.js`, `charts.js`, `summary.js`, `filters.js`, `progression-plan.js`) use `showToast(message, true/false)` with a real boolean — that's the legacy signature working as designed, not this bug, and is out of scope here (legacy API removal is explicitly deferred per the plan).

## Migration notes (behavior change)

Toasts fired from `generateStarterPlan()` in `static/js/app.js` now render with the correct Bootstrap background class instead of always green:
- "Please select at least one equipment type." → now `bg-warning` (was `bg-success`)
- "Maximum 2 priority muscles allowed. Using first 2 selected." → now `bg-warning` (was `bg-success`)
- "Plan generated successfully! ..." → still `bg-success` (unchanged in effect; call now uses the correct signature)
- Server-rejected generation error message → now `bg-danger` (was `bg-success`)
- "Error generating plan. Please try again." (fetch/exception path) → now `bg-danger` (was `bg-success`)

No DB schema, API response shape, or calculation-logic changes. The legacy `showToast(message, isError?, duration?)` signature in `toast.js` is untouched and still supported — no warning added for legacy misuse (optional per plan, deferred).

## Test plan

- Added `test.describe('Starter plan toast severity contract', ...)` in `e2e/workout-plan.spec.ts` with two cases:
  - **Warning path**: opens the Generate Starter Plan modal, clicks the modal's "None" equipment shortcut, submits, and asserts `#liveToast` has class `bg-warning` (and NOT `bg-success`) with the exact guard message.
  - **Error path**: mocks `**/generate_starter_plan` to return HTTP 400 with a `message`, submits, and asserts `#liveToast` has class `bg-danger` (and NOT `bg-success`) with the server message.
- **Verified these fail pre-fix by code trace** (did not run Playwright locally — instructed to avoid starting a server on port 5000 while other agents run in parallel against the same repo): with the original `showToast(message, 'warning')` / `showToast(errorMsg, 'error')` call shape, `toast.js`'s legacy branch sees a string (not a boolean) as the 2nd positional arg, so `legacyIsError` evaluates `false` and `type` falls back to `'success'` — both new assertions (`toHaveClass(/bg-warning|bg-danger/)` and `not.toHaveClass(/bg-success/)`) would fail against that pre-fix code path. Post-fix, `showToast('warning'|'error', message)` hits the standard (non-legacy) branch and sets the class correctly.
- [x] `npx tsc --noEmit -p tsconfig.json` — passes with no errors (confirms the new spec compiles).
- [ ] CI Playwright `e2e/workout-plan.spec.ts` (Chromium) — will run in the PR's required checks.
- Python tests unaffected (JS/E2E-only change) — pytest not run for this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)