### PR TITLE
fix(backup): make backup creation atomic

### DIFF
--- a/tests/test_program_backup.py
+++ b/tests/test_program_backup.py
@@ -94,6 +94,75 @@ class TestProgramBackup:
         with pytest.raises(ValueError, match="Backup name is required"):
             create_backup(name="   ")
     
+    def test_create_backup_rollback_leaves_no_partial_backup_on_failure(
+        self,
+        clean_db,
+        exercise_factory,
+        workout_plan_factory,
+        monkeypatch,
+    ):
+        """Test that a crash mid-item-insert leaves no partial header or items.
+
+        Forces the second `program_backup_items` insert to raise, mirroring the
+        restore-path rollback test above. Before the atomic-transaction fix, the
+        header insert and each item insert committed individually, so a crash
+        here would leave a header row overstating item_count with only the
+        already-committed items present.
+        """
+        ex1 = exercise_factory("Exercise A", primary_muscle_group="Chest")
+        ex2 = exercise_factory("Exercise B", primary_muscle_group="Back")
+        ex3 = exercise_factory("Exercise C", primary_muscle_group="Legs")
+
+        workout_plan_factory(exercise_name=ex1, routine="Workout A", sets=3, weight=100.0)
+        workout_plan_factory(exercise_name=ex2, routine="Workout A", sets=4, weight=110.0)
+        workout_plan_factory(exercise_name=ex3, routine="Workout A", sets=5, weight=120.0)
+
+        original_execute_query = DatabaseHandler.execute_query
+        insert_calls = {"count": 0}
+
+        def flaky_execute_query(self, query, params=None, *, commit=True):
+            if "INSERT INTO program_backup_items" in query:
+                insert_calls["count"] += 1
+                if insert_calls["count"] == 2:
+                    raise sqlite3.Error("forced")
+            return original_execute_query(self, query, params, commit=commit)
+
+        monkeypatch.setattr(DatabaseHandler, "execute_query", flaky_execute_query)
+
+        with pytest.raises(sqlite3.Error, match="forced"):
+            create_backup(name="Doomed Backup")
+
+        with DatabaseHandler() as db:
+            headers = db.fetch_all(
+                "SELECT id FROM program_backups WHERE name = ?", ("Doomed Backup",)
+            )
+            assert headers == []
+
+            items = db.fetch_all("SELECT id FROM program_backup_items")
+            assert items == []
+
+    def test_create_backup_item_count_matches_inserted_rows(
+        self, clean_db, exercise_factory, workout_plan_factory
+    ):
+        """The header's item_count must always equal the actual number of
+        program_backup_items rows written for that backup — the invariant the
+        non-atomic N+1-commit bug could silently violate on a mid-loop crash."""
+        ex1 = exercise_factory("Exercise A", primary_muscle_group="Chest")
+        ex2 = exercise_factory("Exercise B", primary_muscle_group="Back")
+
+        workout_plan_factory(exercise_name=ex1, routine="Workout A", sets=3, weight=100.0)
+        workout_plan_factory(exercise_name=ex2, routine="Workout A", sets=4, weight=110.0)
+
+        backup = create_backup(name="Invariant Backup")
+
+        with DatabaseHandler() as db:
+            row = db.fetch_one(
+                "SELECT COUNT(*) as cnt FROM program_backup_items WHERE backup_id = ?",
+                (backup["id"],),
+            )
+            assert row["cnt"] == backup["item_count"]
+            assert row["cnt"] == 2
+
     def test_list_backups_returns_all_backups(self, clean_db, exercise_factory, workout_plan_factory):
         """Test that list_backups returns all created backups."""
         exercise_factory("Test Exercise")

--- a/tests/test_program_backup.py
+++ b/tests/test_program_backup.py
@@ -160,6 +160,7 @@ class TestProgramBackup:
                 "SELECT COUNT(*) as cnt FROM program_backup_items WHERE backup_id = ?",
                 (backup["id"],),
             )
+            assert row is not None
             assert row["cnt"] == backup["item_count"]
             assert row["cnt"] == 2
 

--- a/utils/program_backup.py
+++ b/utils/program_backup.py
@@ -149,9 +149,18 @@ def create_backup(
         db.__enter__()
         should_close = True
 
-    commit_writes = should_close
+    # When we own the connection, wrap the header insert and all item inserts
+    # in a single transaction (mirrors restore_backup's BEGIN IMMEDIATE /
+    # commit / rollback shape) so a crash mid-insert leaves no partial
+    # backup. When a caller supplies its own `db`, that caller owns the
+    # transaction (e.g. create_auto_backup_before_erase already holds a
+    # BEGIN IMMEDIATE), so we just write uncommitted and let it commit.
+    own_transaction = should_close
 
     try:
+        if own_transaction:
+            db.execute_query("BEGIN IMMEDIATE", commit=False)
+
         # Check if user_selection table exists
         table_check = db.fetch_one(
             "SELECT name FROM sqlite_master WHERE type='table' AND name='user_selection'"
@@ -188,7 +197,7 @@ def create_backup(
         db.execute_query("""
             INSERT INTO program_backups (name, note, backup_type, schema_version, item_count, created_at)
             VALUES (?, ?, ?, ?, ?, ?)
-        """, (name, note, backup_type, BACKUP_SCHEMA_VERSION, item_count, datetime.now()), commit=commit_writes)
+        """, (name, note, backup_type, BACKUP_SCHEMA_VERSION, item_count, datetime.now()), commit=False)
         
         # Get the newly created backup ID
         result = db.fetch_one("SELECT last_insert_rowid() as id")
@@ -216,8 +225,11 @@ def create_backup(
                     item.get('weight'),
                     item.get('exercise_order'),  # Will be None if column doesn't exist
                     item.get('superset_group')   # Will be None if column doesn't exist
-                ), commit=commit_writes)
-        
+                ), commit=False)
+
+        if own_transaction:
+            db.connection.commit()
+
         logger.info(
             "Backup created successfully",
             extra={
@@ -238,6 +250,8 @@ def create_backup(
             'created_at': datetime.now().isoformat()
         }
     except BaseException as exc:
+        if own_transaction:
+            db.connection.rollback()
         if should_close:
             db.__exit__(type(exc), exc, exc.__traceback__)
             should_close = False


### PR DESCRIPTION
## Summary
- make standalone program-backup creation atomic with one `BEGIN IMMEDIATE` transaction
- keep shared `DatabaseHandler` callers transaction-owned, preserving the pre-erase backup + prune transaction
- roll back the backup header and all items when any item insert fails
- add regression coverage for mid-insert rollback and the header/item-count invariant

## Track
Track A5 — backup atomicity from `docs/REFACTOR_PLAN.md`.

## Migration notes
- No database schema migration.
- No API response-shape or calculation changes.
- Behavioral hardening only: a failed backup creation no longer leaves a partial `program_backups` header or item rows. Successful backups retain the existing metadata contract.

## Test evidence
- `pytest tests/test_program_backup.py -q` — **43 passed** after rebase onto current `origin/main`
- Full suite from the preserved A5 worktree before handoff — **1589 passed**
- Regression test was confirmed to fail before the transaction fix and pass afterward.