### PR TITLE
fix(errors): repair route failure rendering contracts

### DIFF
--- a/routes/body_composition.py
+++ b/routes/body_composition.py
@@ -189,7 +189,12 @@ def body_composition():
         )
     except Exception:
         logger.exception("Error rendering body composition page")
-        return render_template("error.html", message="Unable to load Body Composition."), 500
+        return render_template(
+            "error.html",
+            error_title="Server Error",
+            error_code=500,
+            error_message="Unable to load Body Composition.",
+        ), 500
 
 
 @body_composition_bp.route("/api/body_composition/snapshot", methods=["POST"])

--- a/routes/fatigue.py
+++ b/routes/fatigue.py
@@ -23,7 +23,12 @@ def fatigue_page():
         context = build_fatigue_page_context(period)
     except Exception:
         logger.exception("Error building /fatigue context")
-        if is_xhr_request(request):
+        if is_xhr_request():
             return error_response("INTERNAL_ERROR", "Failed to load fatigue page", 500)
-        return render_template('error.html', error_message="Unable to load fatigue page"), 500
+        return render_template(
+            'error.html',
+            error_title="Server Error",
+            error_code=500,
+            error_message="Unable to load fatigue page",
+        ), 500
     return render_template('fatigue.html', **context)

--- a/routes/program_backup.py
+++ b/routes/program_backup.py
@@ -41,7 +41,12 @@ def backup_center():
         )
     except Exception:
         logger.exception("Error loading backup center page")
-        return render_template("error.html", message="Unable to load backup center."), 500
+        return render_template(
+            "error.html",
+            error_title="Server Error",
+            error_code=500,
+            error_message="Unable to load backup center.",
+        ), 500
 
 
 @program_backup_bp.route('/api/backups', methods=['GET'])

--- a/routes/progression_plan.py
+++ b/routes/progression_plan.py
@@ -130,7 +130,12 @@ def progression_plan():
         )
     except Exception as e:
         logger.exception("Error in progression_plan: %s", str(e))
-        return render_template("error.html", message="Unable to load progression plan."), 500
+        return render_template(
+            "error.html",
+            error_title="Server Error",
+            error_code=500,
+            error_message="Unable to load progression plan.",
+        ), 500
 
 
 @progression_plan_bp.route("/get_exercise_suggestions", methods=["POST"])

--- a/routes/session_summary.py
+++ b/routes/session_summary.py
@@ -143,4 +143,9 @@ def session_summary():
         logger.exception("Error in session_summary: %s", e)
         if is_xhr_request():
             return error_response("INTERNAL_ERROR", "Unable to fetch session summary", 500)
-        return render_template("error.html", message="Unable to load session summary."), 500 
+        return render_template(
+            "error.html",
+            error_title="Server Error",
+            error_code=500,
+            error_message="Unable to load session summary.",
+        ), 500

--- a/routes/user_profile.py
+++ b/routes/user_profile.py
@@ -466,7 +466,12 @@ def user_profile():
         return render_template("user_profile.html", **context)
     except Exception:
         logger.exception("Error rendering user profile")
-        return render_template("error.html", message="Unable to load user profile."), 500
+        return render_template(
+            "error.html",
+            error_title="Server Error",
+            error_code=500,
+            error_message="Unable to load user profile.",
+        ), 500
 
 
 @user_profile_bp.route("/api/user_profile", methods=["POST"])

--- a/routes/weekly_summary.py
+++ b/routes/weekly_summary.py
@@ -126,7 +126,12 @@ def weekly_summary():
         logger.exception("Error in weekly_summary: %s", e)
         if is_xhr_request():
             return error_response("INTERNAL_ERROR", "Unable to fetch weekly summary", 500)
-        return render_template("error.html", message="Unable to load weekly summary."), 500
+        return render_template(
+            "error.html",
+            error_title="Server Error",
+            error_code=500,
+            error_message="Unable to load weekly summary.",
+        ), 500
 
 
 @weekly_summary_bp.route("/api/pattern_coverage")

--- a/tests/test_error_page_contract.py
+++ b/tests/test_error_page_contract.py
@@ -1,0 +1,82 @@
+"""Contract tests for route-level renders of the shared error page."""
+
+import pytest
+
+import routes.body_composition as body_composition_route
+import routes.fatigue as fatigue_route
+import routes.program_backup as program_backup_route
+import routes.progression_plan as progression_plan_route
+import routes.session_summary as session_summary_route
+import routes.user_profile as user_profile_route
+import routes.weekly_summary as weekly_summary_route
+
+
+def _raise(*_args, **_kwargs):
+    raise RuntimeError("forced route failure")
+
+
+@pytest.mark.parametrize(
+    ("route_module", "failure_target", "url", "expected_message"),
+    [
+        (
+            weekly_summary_route,
+            "calculate_weekly_summary",
+            "/weekly_summary",
+            "Unable to load weekly summary.",
+        ),
+        (
+            session_summary_route,
+            "calculate_session_summary",
+            "/session_summary",
+            "Unable to load session summary.",
+        ),
+        (
+            progression_plan_route,
+            "DatabaseHandler",
+            "/progression",
+            "Unable to load progression plan.",
+        ),
+        (
+            program_backup_route,
+            "list_backups",
+            "/backup",
+            "Unable to load backup center.",
+        ),
+        (
+            body_composition_route,
+            "DatabaseHandler",
+            "/body_composition",
+            "Unable to load Body Composition.",
+        ),
+        (
+            user_profile_route,
+            "DatabaseHandler",
+            "/user_profile",
+            "Unable to load user profile.",
+        ),
+        (
+            fatigue_route,
+            "build_fatigue_page_context",
+            "/fatigue",
+            "Unable to load fatigue page",
+        ),
+    ],
+)
+def test_route_error_page_uses_shared_template_contract(
+    client,
+    monkeypatch,
+    route_module,
+    failure_target,
+    url,
+    expected_message,
+):
+    """Every route supplies the title, status code, and message expected by error.html."""
+    monkeypatch.setattr(route_module, failure_target, _raise)
+
+    response = client.get(url)
+
+    assert response.status_code == 500
+    assert b"<title>Server Error - Hypertrophy Toolbox</title>" in response.data
+    assert b'<h1 class="error-status-code">500</h1>' in response.data
+    assert b'<h2 class="error-title">Server Error</h2>' in response.data
+    assert expected_message.encode() in response.data

--- a/tests/test_fatigue_routes.py
+++ b/tests/test_fatigue_routes.py
@@ -1,5 +1,30 @@
 """Integration tests for GET /fatigue (Phase 2 Stage 2)."""
+import routes.fatigue as fatigue_route
 from utils.fatigue_data import build_fatigue_page_context
+
+
+class TestFatigueRouteExceptionPath:
+    """Regression: the except-branch of /fatigue must not crash on its own error handling."""
+
+    def _raise(self, *args, **kwargs):
+        raise RuntimeError("boom")
+
+    def test_xhr_request_gets_json_error_not_a_crash(self, client, monkeypatch):
+        # is_xhr_request() takes zero arguments; the route previously called
+        # is_xhr_request(request), which raised TypeError inside the except
+        # block and masked the intended error_response with an unhandled 500.
+        monkeypatch.setattr(fatigue_route, "build_fatigue_page_context", self._raise)
+        response = client.get('/fatigue', headers={'Accept': 'application/json'})
+        assert response.status_code == 500
+        data = response.get_json()
+        assert data['ok'] is False
+        assert data['error']['code'] == 'INTERNAL_ERROR'
+
+    def test_non_xhr_request_gets_error_page(self, client, monkeypatch):
+        monkeypatch.setattr(fatigue_route, "build_fatigue_page_context", self._raise)
+        response = client.get('/fatigue')
+        assert response.status_code == 500
+        assert b'Unable to load fatigue page' in response.data
 
 
 class TestFatigueRouteBasic:


### PR DESCRIPTION
## Summary
- fix `/fatigue` exception handling to call the zero-argument `is_xhr_request()` contract instead of raising a second `TypeError`
- align all seven route-level `error.html` renderers with the template's `error_title`, `error_code`, and `error_message` context contract
- add forced-failure regression coverage for the fatigue JSON path and every shared error-page renderer

## Track
Track A4 — error-path correctness from `docs/REFACTOR_PLAN.md`.

## Migration notes
- No database schema migration.
- No successful-path calculation or response-shape changes.
- Error-path behavior is corrected: `/fatigue` JSON clients receive the existing standardized `INTERNAL_ERROR` envelope, while browser failures across affected page routes render the intended Server Error title, HTTP 500 code, and route-specific message instead of blank template fields.

## Test evidence
- Focused affected route suites after rebase: **191 passed**
- Initial fatigue regression suite during handoff: **14 passed**