### PR TITLE
fix(workout-log): prevent duplicate scored updates

### DIFF
--- a/e2e/learned-calibration.spec.ts
+++ b/e2e/learned-calibration.spec.ts
@@ -12,7 +12,7 @@
  * docs/user_profile/LEARNED_CALIBRATION_PLAN.md.
  */
 import { test, expect, ROUTES, SELECTORS, waitForPageReady } from './fixtures';
-import type { Page } from '@playwright/test';
+import type { Locator, Page } from '@playwright/test';
 
 const CALIBRATION_SETTINGS = '/api/user_profile/calibration_settings';
 const CALIBRATION_DASHBOARD = '/api/user_profile/calibration/dashboard';
@@ -549,25 +549,53 @@ test.describe('Learned Calibration — Golden Path (Real Data)', () => {
     await page.waitForSelector('.workout-log-table tbody tr');
     const row = page.locator('.workout-log-table tbody tr').first();
 
+    const editScoredField = async (cell: Locator, value: string) => {
+      const responseDone = page.waitForResponse(
+        (response) => response.url().includes('/update_workout_log')
+          && response.request().method() === 'POST',
+      );
+      await cell.locator('.editable-text').click();
+      await cell.locator('input').fill(value);
+      await cell.locator('input').blur();
+      expect((await responseDone).ok()).toBeTruthy();
+      // Let any competing delayed submission surface before the next edit.
+      await page.waitForTimeout(650);
+    };
+
     // Weight
     const weightCell = row.locator('td[data-field="scored_weight"]');
-    await weightCell.locator('.editable-text').click();
-    await weightCell.locator('input').fill('140');
-    await weightCell.locator('input').blur();
+    await editScoredField(weightCell, '140');
 
     // Min Reps
     const minRepsCell = row.locator('td[data-field="scored_min_reps"]');
-    await minRepsCell.locator('.editable-text').click();
-    await minRepsCell.locator('input').fill('6');
-    await minRepsCell.locator('input').blur();
+    await editScoredField(minRepsCell, '6');
 
     // Max Reps
     const maxRepsCell = row.locator('td[data-field="scored_max_reps"]');
-    await maxRepsCell.locator('.editable-text').click();
-    await maxRepsCell.locator('input').fill('6');
-    await maxRepsCell.locator('input').blur();
+    await editScoredField(maxRepsCell, '6');
 
-    // RIR
+    // RIR — one browser edit must produce one write and one calibration update.
+    let updatePostCount = 0;
+    const calibrationResponseChecks: Promise<boolean>[] = [];
+    page.on('request', (request) => {
+      if (
+        new URL(request.url()).pathname === '/update_workout_log'
+        && request.method() === 'POST'
+      ) {
+        updatePostCount += 1;
+      }
+    });
+    page.on('response', (response) => {
+      if (
+        new URL(response.url()).pathname === '/update_workout_log'
+        && response.request().method() === 'POST'
+      ) {
+        calibrationResponseChecks.push(
+          response.json().then((body) => body?.data?.calibration?.status === 'updated'),
+        );
+      }
+    });
+
     const rirCell = row.locator('td[data-field="scored_rir"]');
     await rirCell.locator('.editable-text').click();
     await rirCell.locator('input').fill('2');
@@ -575,6 +603,11 @@ test.describe('Learned Calibration — Golden Path (Real Data)', () => {
     const updateResponse = page.waitForResponse((r) => r.url().includes('/update_workout_log') && r.request().method() === 'POST');
     await rirCell.locator('input').blur();
     expect((await updateResponse).ok()).toBeTruthy();
+    await page.waitForTimeout(650);
+
+    expect(updatePostCount).toBe(1);
+    const calibrationUpdateCount = (await Promise.all(calibrationResponseChecks)).filter(Boolean).length;
+    expect(calibrationUpdateCount).toBe(1);
 
     await page.waitForSelector(SELECTORS.TOAST_CONTAINER + ' .toast.show');
     await page.locator(SELECTORS.TOAST_CONTAINER).locator('.btn-close').first().click();

--- a/templates/workout_log.html
+++ b/templates/workout_log.html
@@ -128,7 +128,6 @@
                                 <input type="number" 
                                        class="editable-input number-input form-control input-calm-inset"
                                        value="{{ log.scored_min_reps if log.scored_min_reps and log.scored_min_reps != 'None' else '' }}"
-                                       onchange="updateScoredValue('{{ log.id }}', 'scored_min_reps', this.value)"
                                        min="0"
                                        style="display: none;">
                                 <span class="editable-text">{{ log.scored_min_reps if log.scored_min_reps and log.scored_min_reps != 'None' else '--' }}</span>
@@ -148,7 +147,6 @@
                                 <input type="number" 
                                        class="editable-input number-input form-control input-calm-inset"
                                        value="{{ log.scored_max_reps if log.scored_max_reps and log.scored_max_reps != 'None' else '' }}"
-                                       onchange="updateScoredValue('{{ log.id }}', 'scored_max_reps', this.value)"
                                        min="0"
                                        style="display: none;">
                                 <span class="editable-text">{{ log.scored_max_reps if log.scored_max_reps and log.scored_max_reps != 'None' else '--' }}</span>
@@ -169,7 +167,6 @@
                                        class="editable-input number-input form-control input-calm-inset"
                                        value="{{ log.scored_rir if log.scored_rir and log.scored_rir != 'None' else '' }}"
                                        min="0"
-                                       onchange="updateScoredValue('{{ log.id }}', 'scored_rir', this.value)"
                                        style="display: none;">
                                 <span class="editable-text">{{ log.scored_rir if log.scored_rir and log.scored_rir != 'None' else '--' }}</span>
                                 {# For RIR, LOWER is BETTER (means you pushed harder) #}
@@ -190,7 +187,6 @@
                                        class="editable-input number-input form-control input-calm-inset"
                                        value="{{ log.scored_rpe if log.scored_rpe and log.scored_rpe != 'None' else '' }}"
                                        min="0"
-                                       onchange="updateScoredValue('{{ log.id }}', 'scored_rpe', this.value)"
                                        style="display: none;">
                                 <span class="editable-text">{{ log.scored_rpe if log.scored_rpe and log.scored_rpe != 'None' else '--' }}</span>
                                 {# For RPE, HIGHER means you pushed harder - it's a measure of effort #}
@@ -212,7 +208,6 @@
                                        value="{{ log.scored_weight if log.scored_weight is not none and log.scored_weight != 'None' else '' }}"
                                        step="0.5"
                                        min="0"
-                                       onchange="updateScoredValue('{{ log.id }}', 'scored_weight', this.value)"
                                        style="display: none;">
                                 <span class="editable-text">{{ log.scored_weight if log.scored_weight is not none and log.scored_weight != 'None' else '--' }}</span>
                                 {% if log.scored_weight is not none and log.scored_weight != 'None' and log.planned_weight is not none %}


### PR DESCRIPTION
## Summary
- remove the five inline scored-input `onchange` submissions from the workout-log template
- retain the shared 500 ms debounced input handler as the single scored-edit save path
- strengthen the real learned-calibration golden path to prove one edit sends exactly one `/update_workout_log` POST and produces exactly one `status: updated` calibration response

## Track
Track A2 — workout-log duplicate submission from `docs/REFACTOR_PLAN.md`.

## Migration notes
- No database schema or API response-shape migration.
- No calibration formula or workout-log persistence semantics change.
- Browser behavior changes only by removing a duplicate write: a scored edit now reaches the existing endpoint once after the existing debounce instead of once on blur plus once when the debounce expires.

## Test evidence
- Focused workout-log/calibration pytest: **81 passed**
- Chromium `workout-log.spec.ts` + `learned-calibration.spec.ts`: **30 passed**
- `npx tsc --noEmit`: passed
- Regression assertion: final scored edit = **1 POST** and **1 updated calibration response**