### PR TITLE
fix(workout-log): keep progression badge decisions aligned

### DIFF
--- a/e2e/workout-log.spec.ts
+++ b/e2e/workout-log.spec.ts
@@ -321,6 +321,81 @@ test.describe('Workout Log with Data', () => {
       expect(hasIndicators !== null).toBeTruthy();
     }
   });
+
+  test('assisted progression stays achieved after changing its date', async ({ page }) => {
+    await page.request.post('/clear_workout_log');
+    await page.request.post('/clear_workout_plan');
+
+    try {
+      const addResponse = await page.request.post('/add_exercise', {
+        data: {
+          routine: 'GYM - Full Body - Workout A',
+          exercise: 'Machine Assisted Chin Up',
+          sets: 3,
+          min_rep_range: 6,
+          max_rep_range: 10,
+          rir: 2,
+          rpe: 8,
+          weight: 65,
+        },
+      });
+      expect(addResponse.ok()).toBeTruthy();
+
+      const exportResponse = await page.request.post('/export_to_workout_log');
+      expect(exportResponse.ok()).toBeTruthy();
+
+      await page.goto(ROUTES.WORKOUT_LOG);
+      await waitForPageReady(page);
+
+      const row = page.locator('tr[data-assisted-bodyweight="true"]', {
+        hasText: 'Machine Assisted Chin Up',
+      });
+      await expect(row).toHaveCount(1);
+
+      const badge = row.locator('td[data-label="Progressive Overload"] .badge');
+      await expect(badge).toHaveText('Pending');
+
+      const weightCell = row.locator('td[data-field="scored_weight"]');
+      const weightInput = weightCell.locator('input');
+      await weightCell.locator('.editable-text').click();
+      const weightUpdate = page.waitForResponse((response) =>
+        new URL(response.url()).pathname === '/update_workout_log'
+          && response.request().method() === 'POST',
+      );
+      await weightInput.fill('60');
+      expect((await weightUpdate).ok()).toBeTruthy();
+      await expect(badge).toHaveText('Achieved');
+
+      let datePostCount = 0;
+      page.on('request', (request) => {
+        if (
+          new URL(request.url()).pathname === '/update_progression_date'
+          && request.method() === 'POST'
+        ) {
+          datePostCount += 1;
+        }
+      });
+
+      const dateCell = row.locator('td[data-field="last_progression_date"]');
+      const dateInput = dateCell.locator('input[type="date"]');
+      await dateCell.click();
+      await expect(dateInput).toBeVisible();
+
+      const dateUpdate = page.waitForResponse((response) =>
+        new URL(response.url()).pathname === '/update_progression_date'
+          && response.request().method() === 'POST',
+      );
+      await dateInput.fill('2026-07-04');
+      expect((await dateUpdate).ok()).toBeTruthy();
+
+      await expect(dateCell.locator('.date-display')).toHaveText('04-07-26');
+      await expect(badge).toHaveText('Achieved');
+      expect(datePostCount).toBe(1);
+    } finally {
+      await page.request.post('/clear_workout_log');
+      await page.request.post('/clear_workout_plan');
+    }
+  });
 });
 
 test.describe('Workout Log Date Filter', () => {

--- a/static/js/modules/workout-log.js
+++ b/static/js/modules/workout-log.js
@@ -36,6 +36,37 @@ function parseOptionalNumber(text) {
     return Number.isFinite(parsed) ? parsed : null;
 }
 
+function computeProgressionState(row) {
+    const plannedRir = parseFloat(row.querySelector('[data-field="planned_rir"]')?.textContent) || 0;
+    const plannedRpe = parseFloat(row.querySelector('[data-field="planned_rpe"]')?.textContent) || 0;
+    const plannedMinReps = parseFloat(row.querySelector('[data-field="planned_min_reps"]')?.textContent) || 0;
+    const plannedMaxReps = parseFloat(row.querySelector('[data-field="planned_max_reps"]')?.textContent) || 0;
+    const plannedWeight = parseOptionalNumber(row.querySelector('[data-field="planned_weight"]')?.textContent);
+
+    const scoredRir = parseFloat(row.querySelector('[data-field="scored_rir"] .editable-text')?.textContent) || 0;
+    const scoredRpe = parseFloat(row.querySelector('[data-field="scored_rpe"] .editable-text')?.textContent) || 0;
+    const scoredMinReps = parseFloat(row.querySelector('[data-field="scored_min_reps"] .editable-text')?.textContent) || 0;
+    const scoredMaxReps = parseFloat(row.querySelector('[data-field="scored_max_reps"] .editable-text')?.textContent) || 0;
+    const scoredWeight = parseOptionalNumber(row.querySelector('[data-field="scored_weight"] .editable-text')?.textContent);
+
+    return Boolean(
+        (scoredRir && plannedRir && scoredRir < plannedRir) ||
+        (scoredRpe && plannedRpe && scoredRpe > plannedRpe) ||
+        (scoredMinReps && plannedMinReps && scoredMinReps > plannedMinReps) ||
+        (scoredMaxReps && plannedMaxReps && scoredMaxReps > plannedMaxReps) ||
+        isWeightProgression(row, plannedWeight, scoredWeight)
+    );
+}
+
+function updateProgressionBadge(row) {
+    const badge = row?.querySelector('.badge');
+    if (!badge) return;
+
+    const isProgressive = computeProgressionState(row);
+    badge.className = `badge ${isProgressive ? 'bg-success' : 'bg-warning'}`;
+    badge.textContent = isProgressive ? 'Achieved' : 'Pending';
+}
+
 export function initializeWorkoutLog() {
     console.log('Initializing workout log');
 
@@ -370,33 +401,7 @@ export async function updateScoredValue(logId, field, value) {
             updateProgressionIndicator(row, field, value);
         }
 
-        // Update badge status
-        const badge = row.querySelector('.badge');
-        if (badge) {
-            // Get all the values
-            const planned_rir = parseFloat(row.querySelector('[data-field="planned_rir"]')?.textContent) || 0;
-            const planned_rpe = parseFloat(row.querySelector('[data-field="planned_rpe"]')?.textContent) || 0;
-            const planned_min_reps = parseFloat(row.querySelector('[data-field="planned_min_reps"]')?.textContent) || 0;
-            const planned_max_reps = parseFloat(row.querySelector('[data-field="planned_max_reps"]')?.textContent) || 0;
-            const planned_weight = parseOptionalNumber(row.querySelector('[data-field="planned_weight"]')?.textContent);
-
-            const scored_rir = parseFloat(row.querySelector('[data-field="scored_rir"] .editable-text')?.textContent) || 0;
-            const scored_rpe = parseFloat(row.querySelector('[data-field="scored_rpe"] .editable-text')?.textContent) || 0;
-            const scored_min_reps = parseFloat(row.querySelector('[data-field="scored_min_reps"] .editable-text')?.textContent) || 0;
-            const scored_max_reps = parseFloat(row.querySelector('[data-field="scored_max_reps"] .editable-text')?.textContent) || 0;
-            const scored_weight = parseOptionalNumber(row.querySelector('[data-field="scored_weight"] .editable-text')?.textContent);
-
-            const isProgressive = (
-                (scored_rir && planned_rir && scored_rir < planned_rir) ||
-                (scored_rpe && planned_rpe && scored_rpe > planned_rpe) ||
-                (scored_min_reps && planned_min_reps && scored_min_reps > planned_min_reps) ||
-                (scored_max_reps && planned_max_reps && scored_max_reps > planned_max_reps) ||
-                isWeightProgression(row, planned_weight, scored_weight)
-            );
-
-            badge.className = `badge ${isProgressive ? 'bg-success' : 'bg-warning'}`;
-            badge.textContent = isProgressive ? 'Achieved' : 'Pending';
-        }
+        updateProgressionBadge(row);
 
         notifyCalibrationOutcome(response?.data?.calibration);
     } catch (error) {
@@ -563,33 +568,7 @@ function checkProgressiveOverload(logId) {
         return;
     }
 
-    // Get planned values
-    const planned_rir = parseFloat(row.querySelector('[data-field="planned_rir"]')?.textContent) || 0;
-    const planned_rpe = parseFloat(row.querySelector('[data-field="planned_rpe"]')?.textContent) || 0;
-    const planned_min_reps = parseFloat(row.querySelector('[data-field="planned_min_reps"]')?.textContent) || 0;
-    const planned_max_reps = parseFloat(row.querySelector('[data-field="planned_max_reps"]')?.textContent) || 0;
-    const planned_weight = parseOptionalNumber(row.querySelector('[data-field="planned_weight"]')?.textContent);
-
-    // Get scored values
-    const scored_rir = parseFloat(row.querySelector('[data-field="scored_rir"] .editable-text')?.textContent) || 0;
-    const scored_rpe = parseFloat(row.querySelector('[data-field="scored_rpe"] .editable-text')?.textContent) || 0;
-    const scored_min_reps = parseFloat(row.querySelector('[data-field="scored_min_reps"] .editable-text')?.textContent) || 0;
-    const scored_max_reps = parseFloat(row.querySelector('[data-field="scored_max_reps"] .editable-text')?.textContent) || 0;
-    const scored_weight = parseOptionalNumber(row.querySelector('[data-field="scored_weight"] .editable-text')?.textContent);
-
-    const isProgressive = (
-        (scored_rir && planned_rir && scored_rir < planned_rir) ||
-        (scored_rpe && planned_rpe && scored_rpe > planned_rpe) ||
-        (scored_min_reps && planned_min_reps && scored_min_reps > planned_min_reps) ||
-        (scored_max_reps && planned_max_reps && scored_max_reps > planned_max_reps) ||
-        isWeightProgression(row, planned_weight, scored_weight)
-    );
-
-    const badge = row.querySelector('.badge');
-    if (badge) {
-        badge.className = `badge ${isProgressive ? 'bg-success' : 'bg-warning'}`;
-        badge.textContent = isProgressive ? 'Achieved' : 'Pending';
-    }
+    updateProgressionBadge(row);
 }
 
 function initializeEditableCells() {
@@ -781,34 +760,10 @@ export async function handleDateChange(event, logId) {
         // Hide the input after successful update
         input.style.display = 'none';
 
-        // Get the row and update badge status
+        // Changing the date does not affect progression, but repaint from the
+        // same shared decision used by initial load and scored-value updates.
         const row = document.querySelector(`tr[data-log-id="${id}"]`);
-        const badge = row?.querySelector('.badge');
-        if (badge) {
-            // Get all the values
-            const planned_rir = parseFloat(row.querySelector('[data-field="planned_rir"]')?.textContent) || 0;
-            const planned_rpe = parseFloat(row.querySelector('[data-field="planned_rpe"]')?.textContent) || 0;
-            const planned_min_reps = parseFloat(row.querySelector('[data-field="planned_min_reps"]')?.textContent) || 0;
-            const planned_max_reps = parseFloat(row.querySelector('[data-field="planned_max_reps"]')?.textContent) || 0;
-            const planned_weight = parseFloat(row.querySelector('[data-field="planned_weight"]')?.textContent) || 0;
-
-            const scored_rir = parseFloat(row.querySelector('[data-field="scored_rir"] .editable-text')?.textContent) || 0;
-            const scored_rpe = parseFloat(row.querySelector('[data-field="scored_rpe"] .editable-text')?.textContent) || 0;
-            const scored_min_reps = parseFloat(row.querySelector('[data-field="scored_min_reps"] .editable-text')?.textContent) || 0;
-            const scored_max_reps = parseFloat(row.querySelector('[data-field="scored_max_reps"] .editable-text')?.textContent) || 0;
-            const scored_weight = parseFloat(row.querySelector('[data-field="scored_weight"] .editable-text')?.textContent) || 0;
-
-            const isProgressive = (
-                (scored_rir && planned_rir && scored_rir < planned_rir) ||
-                (scored_rpe && planned_rpe && scored_rpe > planned_rpe) ||
-                (scored_min_reps && planned_min_reps && scored_min_reps > planned_min_reps) ||
-                (scored_max_reps && planned_max_reps && scored_max_reps > planned_max_reps) ||
-                (scored_weight && planned_weight && scored_weight > planned_weight)
-            );
-
-            badge.className = `badge ${isProgressive ? 'bg-success' : 'bg-warning'}`;
-            badge.textContent = isProgressive ? 'Achieved' : 'Pending';
-        }
+        updateProgressionBadge(row);
 
         showToast('success', 'Progression date updated successfully');
     } catch (error) {


### PR DESCRIPTION
## Summary
- extract one client-side progression-state calculation and badge painter for initial load, scored-value updates, and progression-date changes
- preserve the server-rendered `data-assisted-bodyweight` flag as the first-choice assisted-exercise decision
- keep reduced machine assistance marked `Achieved` after a date-only edit
- add a real-browser regression covering the assisted scored update, date display, badge stability, and single date POST

## Migration notes
No database schema, stored-data, API-response, or route migration is required. The `/update_workout_log` and `/update_progression_date` requests, persistence behavior, date formatting, and toast timing are unchanged. The intentional UI behavior correction is that changing only `last_progression_date` no longer reclassifies an assisted-bodyweight improvement with the ordinary `scored_weight > planned_weight` rule; all three client repaint paths now use the same assisted-aware decision already used by server rendering and scored edits.

## Verification
- `npx playwright test e2e/workout-log.spec.ts e2e/progression.spec.ts --project=chromium --reporter=line` — **49 passed**
- `node_modules/.bin/tsc.cmd --noEmit` — **passed** before and after rebase
- rebased by replaying only the A3 commit onto `origin/main` after A2 merged; `origin/main...HEAD` contains exactly:
  - `static/js/modules/workout-log.js`
  - `e2e/workout-log.spec.ts`