### PR TITLE
ci: add fatigue-context E2E as new non-required context (Track B WPB.9 step 1 / OD9)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -322,6 +322,62 @@ jobs:
         path: artifacts/playwright
         retention-days: 7
 
+  # Track B WPB.9 (OD9, docs/REFACTOR_PLAN.md) step 1: land fatigue-context.spec.ts
+  # in CI as a NEW, NON-required job so it starts accumulating green runs on PRs.
+  # Mirrors the e2e-backup idiom above (an isolated single-spec job with its own
+  # fresh server + throwaway DB via playwright.config.ts's webServer command) rather
+  # than the e2e-functional-shard matrix idiom: adding a spec to that matrix's list
+  # feeds the "E2E Functional (Chromium)" fan-in gate, which IS a required
+  # branch-protection context — that would promote this spec to required
+  # immediately, skipping the green-run observation window OD9 calls for. This job
+  # is intentionally NOT added to branch protection's required_status_checks; step
+  # 2 (later, separate PR) promotes it only after several consecutive green runs.
+  e2e-fatigue-context:
+    name: E2E Fatigue Context (Chromium, non-required)
+    runs-on: ubuntu-latest
+    needs: frontend-build
+
+    steps:
+    - name: Checkout code
+      uses: actions/checkout@v4
+
+    - name: Set up Python
+      uses: actions/setup-python@v5
+      with:
+        python-version: '3.11'
+        cache: 'pip'
+
+    - name: Set up Node.js
+      uses: actions/setup-node@v4
+      with:
+        node-version: '20'
+        cache: 'npm'
+
+    - name: Install Python dependencies
+      run: |
+        python -m pip install --upgrade pip
+        pip install -r requirements.txt
+
+    - name: Install npm dependencies
+      run: npm ci
+
+    - name: Build Bootstrap-customized CSS
+      run: npm run build:css
+
+    - name: Install Playwright Chromium
+      run: npx playwright install --with-deps chromium
+
+    - name: Run fatigue-context spec
+      run: npx playwright test e2e/fatigue-context.spec.ts --project=chromium --reporter=line
+
+    - name: Upload Playwright artifacts
+      if: failure()
+      uses: actions/upload-artifact@v4
+      with:
+        name: playwright-fatigue-context
+        path: artifacts/playwright
+        retention-days: 7
+
   test:
     name: Run Tests
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Summary
- Step 1 of Track B WPB.9 (OD9, `docs/REFACTOR_PLAN.md`): adds a **new, non-required** CI job, `e2e-fatigue-context` (job name `"E2E Fatigue Context (Chromium, non-required)"`), that runs `e2e/fatigue-context.spec.ts` on every PR/push to `main`/`develop`.
- Verified before making this change that `fatigue-context.spec.ts` was **not already covered anywhere** in `.github/workflows/ci.yml` (grepped the workflow directory for the spec name and for the functional-shard spec list — no match), matching the plan's premise.
- Purely additive: one new job block appended after `e2e-backup`. No existing job's `name:`, steps, or the required-status-checks list were touched (confirmed via `git diff` — only insertions, zero deletions/modifications).

## Idiom chosen and why
Two existing e2e idioms were considered:
1. **`e2e-functional-shard` matrix** — add the spec to the shared spec list, sharded across the matrix.
2. **Isolated single-spec job** (`e2e-smoke`, `e2e-backup`) — its own job, own fresh server + throwaway DB via `playwright.config.ts`'s `webServer` command.

Chose **(2), mirroring `e2e-backup`** (including its artifact-upload-on-failure step), because the functional-shard matrix feeds the `e2e-functional` fan-in job, and `"E2E Functional (Chromium)"` **is** a required branch-protection context (confirmed via `gh api repos/:owner/:repo/branches/main/protection`). Adding the spec to that list would make it required immediately, skipping the green-run observation window that OD9 explicitly calls for. An isolated job lets it run and report status without being in `required_status_checks` at all.

Current required contexts (unchanged by this PR): `Run Tests`, `E2E Functional (Chromium)`, `E2E Backup (Chromium, isolated)`, `E2E Smoke (Chromium)`, `Type Check (tsc blocking + pyright measure-only)`, `Code Linting`, `Frontend Build (npm ci + SCSS)`, `Security Audit`. `E2E Fatigue Context (Chromium, non-required)` is **not** in this list and this PR does not modify branch protection.

## Promotion criteria (for step 2, later, separate PR)
Per `docs/REFACTOR_PLAN.md` WPB.9 gate: promote only after the new context has run **green on several consecutive PRs** as observed in this repo's Actions history — then a separate PR/branch-protection settings change adds `"E2E Fatigue Context (Chromium, non-required)"` to `required_status_checks` (a reversible settings change, not a workflow rename).

## Test plan
- [x] `python -c "import yaml,sys;yaml.safe_load(open('.github/workflows/ci.yml'))"` — YAML parses; job keys enumerate cleanly including the new `e2e-fatigue-context` key.
- [x] `git diff` reviewed — insertions only, no existing job/step modified.
- [ ] Observe this PR's own CI run: new job appears, is not blocking, and (ideally) goes green.
- [ ] (Later) accumulate consecutive green runs before the step-2 promotion PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)