### PR TITLE
fix(progression): experienced lifters get +5 kg below 20 kg (Track B WPB.5 / OD5)

### DIFF
--- a/static/js/modules/progression-plan.js
+++ b/static/js/modules/progression-plan.js
@@ -190,9 +190,9 @@ export function initializeProgressionPlan() {
                                 targetValueInput.value = currentValue + 2;
                                 break;
                             case 'weight':
-                                // Use same increment logic as suggestion cards: 2.5kg if < 20, else 5kg
-                                const weightIncrement = currentValue < 20 ? 2.5 : 5;
-                                targetValueInput.value = currentValue + weightIncrement;
+                                // Match the server's novice default (is_novice=True): always +2.5kg.
+                                // Increment tiers live in _calculate_weight_increment (utils/progression_plan.py).
+                                targetValueInput.value = currentValue + 2.5;
                                 break;
                             case 'sets':
                                 // Suggest adding 1 set

--- a/tests/test_double_progression.py
+++ b/tests/test_double_progression.py
@@ -257,11 +257,37 @@ class TestProgressionSuggestions:
         ]
         
         suggestions = generate_progression_suggestions(history)
-        
+
         # Should have a reduce_weight suggestion
         reduce_suggestions = [s for s in suggestions if s["type"] == "reduce_weight"]
         assert len(reduce_suggestions) == 1
-    
+
+    def test_reduce_weight_decrement_experienced_below_20kg(self):
+        """OD5 side effect: the reduce-weight DECREMENT is also 5kg for
+        experienced lifters below 20kg (novice stays 2.5kg)."""
+        def make_history():
+            return [
+                {
+                    "exercise": "Lateral Raise",
+                    "scored_max_reps": 5,
+                    "planned_min_reps": 8,
+                    "planned_max_reps": 12,
+                    "scored_weight": 10.0,
+                    "planned_sets": 3,
+                }
+                for _ in range(2)
+            ]
+
+        experienced = generate_progression_suggestions(make_history(), is_novice=False)
+        reduce_exp = [s for s in experienced if s["type"] == "reduce_weight"]
+        assert len(reduce_exp) == 1
+        assert reduce_exp[0]["suggested_weight"] == 5.0  # 10 - 5.0 (was 7.5 pre-OD5)
+
+        novice = generate_progression_suggestions(make_history(), is_novice=True)
+        reduce_nov = [s for s in novice if s["type"] == "reduce_weight"]
+        assert len(reduce_nov) == 1
+        assert reduce_nov[0]["suggested_weight"] == 7.5  # 10 - 2.5, unchanged
+
     def test_empty_history(self):
         """Should return empty list for empty history."""
         suggestions = generate_progression_suggestions([])

--- a/tests/test_double_progression.py
+++ b/tests/test_double_progression.py
@@ -27,6 +27,28 @@ class TestWeightIncrement:
         assert _calculate_weight_increment(20.0, is_novice=True) == 2.5
         assert _calculate_weight_increment(50.0, is_novice=True) == 2.5
 
+    def test_light_weight_increment_experienced(self):
+        """Experienced lifters get +5kg below 20kg too (OD5)."""
+        assert _calculate_weight_increment(15.0, is_novice=False) == 5.0
+        assert _calculate_weight_increment(10.0, is_novice=False) == 5.0
+        assert _calculate_weight_increment(19.9, is_novice=False) == 5.0
+
+    def test_light_weight_increment_novice_unchanged(self):
+        """Novice behavior below 20kg is unchanged by OD5."""
+        assert _calculate_weight_increment(15.0, is_novice=True) == 2.5
+        assert _calculate_weight_increment(19.9, is_novice=True) == 2.5
+
+    def test_weight_increment_boundary_20kg_both_experience_levels(self):
+        """At the 20kg boundary, both experience levels keep existing behavior."""
+        assert _calculate_weight_increment(20.0, is_novice=False) == 5.0
+        assert _calculate_weight_increment(20.0, is_novice=True) == 2.5
+
+    def test_weight_increment_just_below_and_above_20kg_experienced(self):
+        """Experienced lifters get 5kg on both sides of the 20kg boundary now."""
+        assert _calculate_weight_increment(19.9, is_novice=False) == 5.0
+        assert _calculate_weight_increment(20.0, is_novice=False) == 5.0
+        assert _calculate_weight_increment(20.1, is_novice=False) == 5.0
+
 
 class TestAcceptableEffort:
     """Tests for effort acceptability check."""

--- a/tests/test_progression_plan_utils.py
+++ b/tests/test_progression_plan_utils.py
@@ -47,6 +47,30 @@ class TestCalculateWeightIncrement:
         assert _calculate_weight_increment(20.0, is_novice=True) == 2.5
         assert _calculate_weight_increment(50.0, is_novice=True) == 2.5
 
+    def test_experienced_under_20kg_returns_5(self):
+        """Experienced (non-novice) lifters under 20kg now get +5kg (OD5)."""
+        assert _calculate_weight_increment(5.0, is_novice=False) == 5.0
+        assert _calculate_weight_increment(15.0, is_novice=False) == 5.0
+        assert _calculate_weight_increment(19.9, is_novice=False) == 5.0
+
+    def test_novice_under_20kg_still_returns_2_5(self):
+        """Novice behavior under 20kg is unchanged by OD5."""
+        assert _calculate_weight_increment(5.0, is_novice=True) == 2.5
+        assert _calculate_weight_increment(15.0, is_novice=True) == 2.5
+        assert _calculate_weight_increment(19.9, is_novice=True) == 2.5
+
+    def test_boundary_around_20kg_experienced_vs_novice(self):
+        """Regression across the 20kg boundary for both experience levels."""
+        # Just below 20kg
+        assert _calculate_weight_increment(19.9, is_novice=False) == 5.0
+        assert _calculate_weight_increment(19.9, is_novice=True) == 2.5
+        # At 20kg
+        assert _calculate_weight_increment(20.0, is_novice=False) == 5.0
+        assert _calculate_weight_increment(20.0, is_novice=True) == 2.5
+        # Just above 20kg
+        assert _calculate_weight_increment(20.1, is_novice=False) == 5.0
+        assert _calculate_weight_increment(20.1, is_novice=True) == 2.5
+
 
 class TestCheckAcceptableEffort:
     """Tests for effort acceptability check (RIR/RPE)."""

--- a/utils/progression_plan.py
+++ b/utils/progression_plan.py
@@ -39,16 +39,14 @@ def get_exercise_plan_defaults(exercise: str) -> Optional[Dict[str, Any]]:
 def _calculate_weight_increment(current_weight: float, is_novice: bool = True) -> float:
     """
     Calculate appropriate weight increment based on double progression rules.
-    
+
     Rules:
-    - Under 20kg: +2.5kg
-    - 20kg and above: +5kg
-    - Novices get smaller increments for safety
+    - Novices: always +2.5kg, regardless of weight (safety).
+    - Experienced lifters: +5kg at every weight, including under 20kg (OD5).
     """
-    if current_weight < 20:
-        return 2.5 if not is_novice else 2.5
-    else:
-        return 5.0 if not is_novice else 2.5
+    if is_novice:
+        return 2.5
+    return 5.0
 
 
 def _check_acceptable_effort(scored_rir: Optional[int], scored_rpe: Optional[float]) -> bool:


### PR DESCRIPTION
## Summary
- Track B item WPB.5 (owner decision OD5) from `docs/REFACTOR_PLAN.md`.
- `_calculate_weight_increment` (`utils/progression_plan.py:39`) was a de-facto no-op differentiator below 20 kg: experienced (`is_novice=False`) lifters received the same +2.5 kg increment as novices there, despite the docstring implying a novice/experienced split applied everywhere.
- Per owner decision OD5: below 20 kg, experienced lifters now get **+5 kg**. Novice behavior is unchanged at every weight. Experienced behavior at >= 20 kg is unchanged.
- **Scope**: OD5 is function+API scope only — the progression UI posts only `{exercise}` and the route defaults to novice, so the experienced path is reachable only via API until a separate WP wires the Profile experience tier into `is_novice`.

## Before / after increment table

| current_weight | is_novice | Before | After | Changed? |
|---|---|---|---|---|
| < 20 kg | `True` (novice) | 2.5 kg | 2.5 kg | No |
| < 20 kg | `False` (experienced) | 2.5 kg | **5.0 kg** | **Yes** |
| == 20 kg | `True` (novice) | 2.5 kg | 2.5 kg | No |
| == 20 kg | `False` (experienced) | 5.0 kg | 5.0 kg | No |
| > 20 kg | `True` (novice) | 2.5 kg | 2.5 kg | No |
| > 20 kg | `False` (experienced) | 5.0 kg | 5.0 kg | No |

Concrete example: an experienced lifter (`is_novice=False`) progressing on an exercise currently loaded at 15 kg who hits the top of their rep range with good effort previously got a suggested weight of 15 + 2.5 = **17.5 kg**. After this change, the same lifter gets 15 + 5.0 = **20.0 kg**.

### Diff
```python
def _calculate_weight_increment(current_weight: float, is_novice: bool = True) -> float:
    """
    Calculate appropriate weight increment based on double progression rules.

    Rules:
    - Novices: always +2.5kg, regardless of weight (safety).
    - Experienced lifters: +5kg at every weight, including under 20kg (OD5).
    """
    if is_novice:
        return 2.5
    return 5.0
```
(Previously: `if current_weight < 20: return 2.5 if not is_novice else 2.5` / `else: return 5.0 if not is_novice else 2.5` — the `< 20` branch ignored `is_novice` entirely.)

## Migration notes
- **Behavior change (increment)**: progression suggestions for experienced lifters (`is_novice=False`) below 20 kg change from **+2.5 kg** to **+5 kg** per double-progression cycle.
- Example: an experienced lifter on Cable Lateral Raise loaded at 7.5 kg who clears the top of their rep range at acceptable effort previously got a suggested next weight of 10.0 kg; now gets 12.5 kg.
- **Behavior change (decrement side effect)**: `_build_primary_rep_suggestion` subtracts the same increment when suggesting a weight reduction after repeated below-range sessions, so the reduce-weight **decrement** for experienced lifters below 20 kg also changes from **−2.5 kg** to **−5 kg**. Example: an experienced lifter stuck below range at 10 kg previously got "reduce to 7.5 kg"; now gets "reduce to 5.0 kg". Novice decrements are unchanged; the existing `scored_weight > 5` guard still applies. Pinned by a dedicated regression test (`test_reduce_weight_decrement_experienced_below_20kg`).
- **Frontend fallback aligned**: the goal-modal weight fallback in `static/js/modules/progression-plan.js` hardcoded `currentValue < 20 ? 2.5 : 5`, which matched neither experience tier post-OD5. It now always suggests +2.5 kg (the server's `is_novice=True` default) with a corrected comment.
- Novice suggestions are byte-for-byte unchanged at every weight.
- Experienced suggestions at >= 20 kg are byte-for-byte unchanged.
- No DB schema change, no API response shape change — pure calculation-constant change inside `_calculate_weight_increment`, consumed by `generate_progression_suggestions` and the other call sites in `utils/progression_plan.py`.
- `utils/strength_calibration.py::decide_progression_target` has its own independent increment logic (not this function) and is unaffected — confirmed no shared code path.

## Test plan
- Added regression tests in `tests/test_double_progression.py` and `tests/test_progression_plan_utils.py` covering both experience levels around the 20 kg boundary (just below at 19.9, at 20.0, just above at 20.1), plus below-20kg values for both novice and experienced.
- Verified the 4 new experienced/below-20kg assertions **fail against pre-fix code** (`assert 2.5 == 5.0`) before applying the fix, confirming they exercise the changed behavior.
- Added `test_reduce_weight_decrement_experienced_below_20kg` pinning the decrement side effect (experienced at 10 kg → 5.0 kg suggested; novice → 7.5 kg unchanged).
- `pytest tests/ -q -k "progression"`: 128 passed.
- Full suite: `pytest tests/ -q` → **1637 passed** (baseline 1629 + 8 new tests).
- `flake8 --select=F401,F811,E711,E712` on changed files: clean.
- `pyright` on `utils/progression_plan.py`: 1 pre-existing `reportReturnType` diagnostic at line 479 (unrelated function, already in `docs/ci_cd_phase3/pyright-baseline.json`), zero new diagnostics from this change.
- No local E2E run per task instructions; CI will run `progression.spec.ts` — the only UI-visible change is the goal-modal fallback increment (2.5 for all weights), which no E2E assertion pins to the old `< 20 ? 2.5 : 5` split.

## Review note
This is a behavior-change PR on a protected calculation zone. Product-risk review verdict: **APPROVE-WITH-NOTES** — the three conditional fixes (decrement regression test + disclosure, JS fallback alignment, scope sentence) are applied in commit `47c3b0a`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)