### PR TITLE
fix(plan): accept weight 0 and order 0 as valid values (Track B WPB.1 / OD1)

### DIFF
--- a/routes/workout_plan.py
+++ b/routes/workout_plan.py
@@ -698,11 +698,15 @@ def update_exercise_order():
         
         with DatabaseHandler() as db:
             for entry in data:
-                if not entry.get("id") or not entry.get("order"):
+                entry_id = entry.get("id")
+                entry_order = entry.get("order")
+                # order == 0 is a valid position; only None/absent/empty-string
+                # counts as missing.
+                if not entry_id or entry_order is None or entry_order == "":
                     return error_response("VALIDATION_ERROR", "Invalid entry data", 400)
                 db.execute_query(
                     "UPDATE user_selection SET exercise_order = ? WHERE id = ?",
-                    (entry["order"], entry["id"])
+                    (entry_order, entry_id)
                 )
                 
         return jsonify(success_response(message="Exercise order updated successfully"))
@@ -1034,7 +1038,7 @@ def _perform_exercise_swap(db: DatabaseHandler, exercise_id: int, new_exercise: 
             "SELECT exercise_order FROM user_selection WHERE id = ?",
             (exercise_id,)
         )
-        if order_row and order_row.get('exercise_order'):
+        if order_row and order_row.get('exercise_order') is not None:
             updated_row['exercise_order'] = order_row['exercise_order']
             
     return updated_row

--- a/tests/test_exercise_manager.py
+++ b/tests/test_exercise_manager.py
@@ -202,11 +202,28 @@ class TestAddExercise:
             
             assert "Error" in result
     
+    def test_add_exercise_accepts_zero_weight(self, app, exercise_factory, clean_db):
+        """weight=0 is valid for bodyweight/assisted exercises and must be accepted."""
+        with app.app_context():
+            exercise_factory("Pull Up")
+
+            result = ExerciseManager.add_exercise(
+                routine="Workout A",
+                exercise="Pull Up",
+                sets=3,
+                min_rep_range=6,
+                max_rep_range=8,
+                rir=2,
+                weight=0
+            )
+
+            assert result == "Exercise added successfully."
+
     def test_add_exercise_missing_weight(self, app, exercise_factory):
-        """Should return error when weight is missing/zero."""
+        """Should return error when weight is None (missing/absent)."""
         with app.app_context():
             exercise_factory("Bench Press")
-            
+
             result = ExerciseManager.add_exercise(
                 routine="Workout A",
                 exercise="Bench Press",
@@ -214,9 +231,9 @@ class TestAddExercise:
                 min_rep_range=6,
                 max_rep_range=8,
                 rir=2,
-                weight=0  # Missing/zero
+                weight=None  # Missing/absent
             )
-            
+
             assert "Error" in result
     
     def test_add_exercise_optional_rir(self, app, exercise_factory, clean_db):

--- a/tests/test_replace_exercise.py
+++ b/tests/test_replace_exercise.py
@@ -178,6 +178,40 @@ class TestReplaceExerciseEndpoint:
         assert updated_row['exercise'] == "Front Squat"
         assert updated_row['routine'] == "Leg Day"
     
+    def test_replace_exercise_preserves_exercise_order_zero(self, client, exercise_factory, workout_plan_factory):
+        """exercise_order=0 (the first position) must survive a replace/swap, not be dropped as missing."""
+        from utils.database import DatabaseHandler
+
+        exercise1 = exercise_factory(
+            "Deadlift",
+            primary_muscle_group="Back",
+            equipment="Barbell"
+        )
+        exercise_factory(
+            "Romanian Deadlift",
+            primary_muscle_group="Back",
+            equipment="Barbell"
+        )
+
+        plan_id = workout_plan_factory(exercise_name=exercise1, routine="Pull Day")
+
+        with DatabaseHandler() as db:
+            db.execute_query(
+                "UPDATE user_selection SET exercise_order = 0 WHERE id = ?",
+                (plan_id,)
+            )
+
+        response = client.post('/replace_exercise', json={
+            "id": plan_id
+        })
+
+        assert response.status_code == 200
+        data = response.get_json()
+
+        assert data['ok'] is True
+        updated_row = data['data']['updated_row']
+        assert updated_row['exercise_order'] == 0
+
     def test_replace_exercise_ai_strategy(self, client, exercise_factory, workout_plan_factory):
         """Test replacement with AI strategy specified."""
         exercise1 = exercise_factory(

--- a/tests/test_workout_plan_routes.py
+++ b/tests/test_workout_plan_routes.py
@@ -75,6 +75,40 @@ class TestAddExercise:
         })
         assert resp.status_code == 200
 
+    def test_add_exercise_weight_zero_accepted(self, client, clean_db, exercise_factory):
+        """weight=0 is valid for bodyweight/assisted exercises."""
+        exercise_factory("Pull Up")
+
+        resp = client.post("/add_exercise", json={
+            "routine": "Pull",
+            "exercise": "Pull Up",
+            "sets": 3,
+            "min_rep_range": 8,
+            "max_rep_range": 12,
+            "rir": 2,
+            "weight": 0
+        })
+        assert resp.status_code == 200
+        data = resp.get_json()
+        assert data["ok"] is True
+
+    def test_add_exercise_weight_absent_rejected(self, client, clean_db, exercise_factory):
+        """A missing weight key (None) is still rejected as a required field."""
+        exercise_factory("Bench Press")
+
+        resp = client.post("/add_exercise", json={
+            "routine": "Push",
+            "exercise": "Bench Press",
+            "sets": 3,
+            "min_rep_range": 8,
+            "max_rep_range": 12,
+            "rir": 2
+            # weight intentionally omitted
+        })
+        assert resp.status_code == 400
+        data = resp.get_json()
+        assert data["ok"] is False
+
     def test_add_exercise_duplicate_returns_400(self, client, clean_db, exercise_factory):
         """Duplicate exercise in same routine should return validation error."""
         exercise_factory("Bench Press")
@@ -385,6 +419,38 @@ class TestUpdateExercise:
             "updates": {"sets": 5}
         })
         assert resp.status_code == 400
+
+
+class TestUpdateExerciseOrder:
+    """Tests for POST /update_exercise_order endpoint."""
+
+    def test_update_exercise_order_zero_accepted(self, client, clean_db, workout_plan_fixture):
+        """order=0 is a valid position and must be accepted, not treated as missing."""
+        from utils.database import DatabaseHandler
+
+        resp = client.post("/update_exercise_order", json=[
+            {"id": workout_plan_fixture["id"], "order": 0}
+        ])
+        assert resp.status_code == 200
+        data = resp.get_json()
+        assert data["ok"] is True
+
+        with DatabaseHandler() as db:
+            row = db.fetch_one(
+                "SELECT exercise_order FROM user_selection WHERE id = ?",
+                (workout_plan_fixture["id"],)
+            )
+        assert row is not None
+        assert row["exercise_order"] == 0
+
+    def test_update_exercise_order_missing_order_rejected(self, client, clean_db, workout_plan_fixture):
+        """A missing/None order value is still rejected."""
+        resp = client.post("/update_exercise_order", json=[
+            {"id": workout_plan_fixture["id"]}
+        ])
+        assert resp.status_code == 400
+        data = resp.get_json()
+        assert data["ok"] is False
 
 
 class TestSupersetLink:

--- a/utils/exercise_manager.py
+++ b/utils/exercise_manager.py
@@ -25,11 +25,14 @@ class ExerciseManager:
         min_rep_range: int,
         max_rep_range: int,
         rir: Optional[int],
-        weight: float,
+        weight: Optional[float],
         rpe: Optional[float] = None,
     ) -> str:
         """Add a selection entry, preventing duplicate routine/exercise pairs."""
-        if not all([routine, exercise, sets, min_rep_range, max_rep_range, weight]):
+        # weight == 0 is a valid value (bodyweight/assisted exercises); only
+        # None/absent/empty-string weight counts as missing. The other required
+        # fields keep their existing truthiness check.
+        if not all([routine, exercise, sets, min_rep_range, max_rep_range]) or weight is None or weight == "":
             logger.warning("Rejecting add_exercise due to missing fields")
             return "Error: Missing required fields."
 


### PR DESCRIPTION
## Summary

Implements Track B WPB.1 (owner decision OD1) from `docs/REFACTOR_PLAN.md`: fixes the falsy-check family in `utils/exercise_manager.py` and `routes/workout_plan.py` that treated `weight == 0` and `order`/`exercise_order == 0` as missing values.

- `utils/exercise_manager.py::ExerciseManager.add_exercise` — the `if not all([routine, exercise, sets, min_rep_range, max_rep_range, weight])` guard rejected `weight=0` (a valid load for bodyweight/assisted exercises like pull-ups). Split `weight` out of the truthiness check; only `None`/absent/empty-string now counts as missing. Widened the `weight` parameter type hint to `Optional[float]` to match what the route caller (`data.get('weight')`) actually passes at runtime.
- `routes/workout_plan.py::update_exercise_order` — `if not entry.get("id") or not entry.get("order")` rejected `order=0` (a valid first position). Now only `None`/empty-string `order` is treated as missing.
- `routes/workout_plan.py::_perform_exercise_swap` — `if order_row and order_row.get('exercise_order'):` silently dropped `exercise_order=0` from the `/replace_exercise` response's `updated_row`. Now checks `is not None`.

Swept the rest of `exercise_manager.py` and its route callers in `routes/workout_plan.py` for the same bug family on these two fields; no other instances found. `exercise_id`/primary-key truthiness checks (`remove_exercise`, `update_exercise`, `replace_exercise`, execution-style validation) were deliberately left untouched — they validate row IDs, not weight/order fields, and are out of scope per the WP.

## Migration notes

- **weight=0**: previously rejected by `ExerciseManager.add_exercise` / `POST /add_exercise` with `"Error: Missing required fields."` (400 `VALIDATION_ERROR`). Now accepted — bodyweight/assisted exercises can be added with `weight: 0`. `sets`/`min_rep_range`/`max_rep_range` == 0 remain rejected (unchanged; out of scope for this WP, see WPB.2).
- **order/exercise_order=0**: previously rejected by `POST /update_exercise_order` (400 `VALIDATION_ERROR`) and silently dropped from `POST /replace_exercise`'s `updated_row.exercise_order`. Now accepted/preserved as the first position.
- No response shapes or status codes changed beyond accepting these newly-valid values.

## Test plan

- Rewrote `test_add_exercise_missing_weight` to assert `weight=None` is rejected (it previously asserted `weight=0` was rejected — that assertion was the bug).
- Added regression tests, verified to **fail against the pre-fix code** (confirmed via `git stash` on the source files only) and pass after the fix:
  - `tests/test_exercise_manager.py::TestAddExercise::test_add_exercise_accepts_zero_weight`
  - `tests/test_workout_plan_routes.py::TestAddExercise::test_add_exercise_weight_zero_accepted` (+ `test_add_exercise_weight_absent_rejected`)
  - `tests/test_workout_plan_routes.py::TestUpdateExerciseOrder::test_update_exercise_order_zero_accepted` (+ `test_update_exercise_order_missing_order_rejected`)
  - `tests/test_replace_exercise.py::TestReplaceExerciseEndpoint::test_replace_exercise_preserves_exercise_order_zero`
- [x] `pytest tests/ -q -k "exercise or workout_plan"` — 301 passed (was 296 before this PR's new tests)
- [x] Full `pytest tests/ -q` — **1635 passed** (baseline 1629 + 6 new/rewritten tests, exact match)
- [x] `flake8 --select=F401` on changed files and full repo — clean
- [x] `scripts/pyright_baseline_diff.py` — **PASS, 0 net-new diagnostics** (baseline 189 → current 187; one test-file diagnostic introduced by a new test was fixed with a `None`-guard before an indexed access, so the count actually dropped)
- [ ] CI `workout-plan.spec.ts` E2E (not run locally per instructions; CI will run it)

## Notes for reviewers

An identical task appears to have been dispatched to a second parallel worktree (`fix/wpb1-zero-semantics`) with uncommitted local changes at the time this PR was prepared; that worktree was left untouched, no PR exists for it, and this PR was implemented and verified independently in its own worktree off `main` @ `62e03d1`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)