### PR TITLE
feat(backup): show auto-backup banner after erase (Track B WPB.8 / OD8)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -378,6 +378,60 @@ jobs:
         path: artifacts/playwright
         retention-days: 7
 
+  # Track B WPB.8 (OD8, docs/REFACTOR_PLAN.md): erase-flow.spec.ts drives the
+  # POST /erase-data full reset, which wipes the live DB mid-run — the same
+  # destructive-mutation reason program-backup.spec.ts runs isolated in
+  # e2e-backup above. It must therefore NEVER join the e2e-functional-shard
+  # spec lists. Mirrors the e2e-fatigue-context idiom: an isolated single-spec
+  # job with its own fresh server + throwaway DB (playwright.config.ts
+  # webServer command), intentionally NOT added to branch protection's
+  # required_status_checks.
+  e2e-erase-flow:
+    name: E2E Erase Flow (Chromium, isolated, non-required)
+    runs-on: ubuntu-latest
+    needs: frontend-build
+
+    steps:
+    - name: Checkout code
+      uses: actions/checkout@v4
+
+    - name: Set up Python
+      uses: actions/setup-python@v5
+      with:
+        python-version: '3.11'
+        cache: 'pip'
+
+    - name: Set up Node.js
+      uses: actions/setup-node@v4
+      with:
+        node-version: '20'
+        cache: 'npm'
+
+    - name: Install Python dependencies
+      run: |
+        python -m pip install --upgrade pip
+        pip install -r requirements.txt
+
+    - name: Install npm dependencies
+      run: npm ci
+
+    - name: Build Bootstrap-customized CSS
+      run: npm run build:css
+
+    - name: Install Playwright Chromium
+      run: npx playwright install --with-deps chromium
+
+    - name: Run erase-flow spec
+      run: npx playwright test e2e/erase-flow.spec.ts --project=chromium --reporter=line
+
+    - name: Upload Playwright artifacts
+      if: failure()
+      uses: actions/upload-artifact@v4
+      with:
+        name: playwright-erase-flow
+        path: artifacts/playwright
+        retention-days: 7
+
   test:
     name: Run Tests
     runs-on: ubuntu-latest

--- a/app.py
+++ b/app.py
@@ -10,7 +10,7 @@ from utils.database import (
     add_user_profile_tables,
     add_volume_tracking_tables,
 )
-from utils.auto_backup import create_startup_backup
+from utils.auto_backup import create_startup_backup, describe_snapshot
 from routes.workout_log import workout_log_bp
 from routes.weekly_summary import weekly_summary_bp
 from routes.session_summary import session_summary_bp
@@ -173,7 +173,7 @@ def erase_data():
         )
     try:
         # Snapshot before wiping so the nuke is recoverable from data/auto_backup/.
-        create_startup_backup()
+        snapshot_path = create_startup_backup()
         # Drop ALL tables including backup tables (full reset)
         with DatabaseHandler() as db:
             tables = [
@@ -220,11 +220,11 @@ def erase_data():
         init_backup_tables()
         
         from utils.errors import success_response
-        
+
         response_message = 'All data has been erased and tables reinitialized successfully.'
-        
+
         return jsonify(success_response(
-            data=None,
+            data={"auto_backup": describe_snapshot(snapshot_path)},
             message=response_message
         ))
     except Exception as e:

--- a/docs/program_backups.md
+++ b/docs/program_backups.md
@@ -63,6 +63,7 @@ There are two backup mechanisms:
 
 - **Program auto-backup support**: `utils/program_backup.py` can create `program_backups` rows with `backup_type='auto'` and prune them to the latest 10. The Backup Center displays these separately when they exist. The current `/erase-data` full-reset route does not call this utility because it drops and recreates the backup tables.
 - **Startup database snapshots**: `utils/auto_backup.py` copies the live SQLite file to `data/auto_backup/database_<timestamp>.db` when the app starts and immediately before `/erase-data`. These are disaster-recovery files outside the Backup Center UI and rotate to the latest 7 files.
+- **Erase-flow banner**: `/erase-data`'s JSON response includes `data.auto_backup` — `{"filename": "database_<timestamp>.db"}` from `utils.auto_backup.describe_snapshot()`, or `null` if no snapshot was taken. The welcome page's confirm-erase handler passes this to `showAutoBackupBanner()` (`static/js/modules/program-backup.js`) so the user sees where the pre-erase file-copy landed. This is informational only — there is no in-app restore action for the raw file snapshot.
 
 ## Key Files
 
@@ -73,4 +74,6 @@ There are two backup mechanisms:
 - `utils/program_backup.py`
 - `utils/auto_backup.py`
 - `tests/test_program_backup.py`
+- `tests/test_auto_backup.py`
 - `e2e/program-backup.spec.ts`
+- `e2e/erase-flow.spec.ts`

--- a/e2e/erase-flow.spec.ts
+++ b/e2e/erase-flow.spec.ts
@@ -1,0 +1,38 @@
+/**
+ * E2E Test: Erase-data flow surfaces the auto-backup banner
+ *
+ * Track B WPB.8 (OD8) — /erase-data snapshots the live DB to
+ * data/auto_backup/ before wiping it (utils/auto_backup.py::create_startup_backup).
+ * The welcome page's confirm-erase handler must pass that snapshot's filename
+ * to `showAutoBackupBanner()` so the user sees where the recoverable copy
+ * landed. This spec fails without the wiring: the banner never appears.
+ */
+import { test, expect, ROUTES, waitForPageReady } from './fixtures';
+
+const AUTO_BACKUP_BANNER = '[data-testid="auto-backup-banner"]';
+const SNAPSHOT_FILENAME_PATTERN = /database_\d{8}_\d{6}\.db/;
+
+test.describe('Erase flow — auto-backup banner', () => {
+  test.beforeEach(async ({ page, consoleErrors }) => {
+    consoleErrors.startCollecting();
+    await page.goto(ROUTES.HOME);
+    await waitForPageReady(page);
+  });
+
+  test('no banner is present before erase is confirmed', async ({ page }) => {
+    await expect(page.locator(AUTO_BACKUP_BANNER)).toHaveCount(0);
+  });
+
+  test('confirming erase shows a banner referencing the data/auto_backup/ snapshot', async ({ page }) => {
+    await page.locator('#eraseDataBtn').click();
+    await expect(page.locator('#eraseDataModal')).toBeVisible();
+
+    await page.locator('#confirmEraseBtn').click();
+
+    const banner = page.locator(AUTO_BACKUP_BANNER);
+    await expect(banner).toBeVisible();
+    await expect(banner).toContainText('Auto-backup created');
+    await expect(banner).toContainText('data/auto_backup/');
+    await expect(banner).toContainText(SNAPSHOT_FILENAME_PATTERN);
+  });
+});

--- a/static/js/modules/program-backup.js
+++ b/static/js/modules/program-backup.js
@@ -1,9 +1,7 @@
 /**
  * Program backup utilities shared by the Backup Center and auto-recovery flows.
  */
-import { showToast } from './toast.js';
 import { api } from './fetch-wrapper.js';
-import { notifyVolumeAffectingPlanChange } from './workout-plan-events.js';
 
 /**
  * Fetch all backups from the API
@@ -102,62 +100,39 @@ export async function deleteBackup(backupId) {
 }
 
 /**
- * Show auto-backup restore banner after erase
- * @param {Object} autoBackup - Auto-backup info from erase response
+ * Show a banner referencing the pre-erase file-copy snapshot written to
+ * data/auto_backup/ (see utils/auto_backup.py). This is informational only —
+ * there is no in-app restore action for this raw file snapshot; recovery is a
+ * manual file-copy operation, distinct from the Backup Center's DB-table
+ * backups (see restoreBackup() above).
+ * @param {Object|null} autoBackup - Snapshot info from the /erase-data response,
+ *   e.g. `{ filename: "database_20260704_153012.db" }`. No-op if falsy (the
+ *   erase route returns null when no snapshot was taken).
  */
 export function showAutoBackupBanner(autoBackup) {
-    if (!autoBackup || !autoBackup.id) return;
-    
+    if (!autoBackup || !autoBackup.filename) return;
+
     // Remove any existing banner
     const existingBanner = document.getElementById('auto-backup-banner');
     if (existingBanner) existingBanner.remove();
-    
+
     const banner = document.createElement('div');
     banner.id = 'auto-backup-banner';
+    banner.setAttribute('data-testid', 'auto-backup-banner');
     banner.className = 'alert alert-info alert-dismissible fade show d-flex align-items-center justify-content-between';
     banner.innerHTML = `
         <div>
             <i class="fas fa-info-circle me-2"></i>
-            <strong>Auto-backup created:</strong> "${escapeHtml(autoBackup.name)}" 
-            with ${autoBackup.item_count} exercises
+            <strong>Auto-backup created:</strong> your data was saved to
+            <code>data/auto_backup/${escapeHtml(autoBackup.filename)}</code> before erasing.
         </div>
-        <div class="d-flex gap-2 align-items-center">
-            <button type="button" class="btn btn-sm btn-primary" id="restore-auto-backup-btn">
-                <i class="fas fa-undo me-1"></i>Restore Now
-            </button>
-            <button type="button" class="btn-close" data-bs-dismiss="alert" aria-label="Close"></button>
-        </div>
+        <button type="button" class="btn-close" data-bs-dismiss="alert" aria-label="Close"></button>
     `;
-    
+
     // Insert at top of main content
     const main = document.querySelector('main') || document.querySelector('.container-fluid');
     if (main) {
         main.insertBefore(banner, main.firstChild);
-        
-        // Attach restore handler
-        document.getElementById('restore-auto-backup-btn').addEventListener('click', async () => {
-            const btn = document.getElementById('restore-auto-backup-btn');
-            btn.disabled = true;
-            btn.innerHTML = '<i class="fas fa-spinner fa-spin me-1"></i>Restoring...';
-            
-            try {
-                const result = await restoreBackup(autoBackup.id);
-                showToast('success', `Restored ${result.restored_count} exercises`);
-                banner.remove();
-                
-                // Refresh workout plan
-                if (typeof window.fetchWorkoutPlan === 'function') {
-                    window.fetchWorkoutPlan();
-                    notifyVolumeAffectingPlanChange('program-backup-restore');
-                } else {
-                    window.location.reload();
-                }
-            } catch (error) {
-                showToast('error', `Failed to restore: ${error.message}`);
-                btn.disabled = false;
-                btn.innerHTML = '<i class="fas fa-undo me-1"></i>Restore Now';
-            }
-        });
     }
 }
 

--- a/templates/welcome.html
+++ b/templates/welcome.html
@@ -399,6 +399,12 @@ document.addEventListener('DOMContentLoaded', function() {
                 const toast = new bootstrap.Toast(document.getElementById('successToast'));
                 document.querySelector('#successToast .toast-body span').textContent = data.message;
                 toast.show();
+
+                const autoBackup = data.data && data.data.auto_backup;
+                if (autoBackup && typeof window.showAutoBackupBanner === 'function') {
+                    window.showAutoBackupBanner(autoBackup);
+                }
+
                 setTimeout(() => window.location.reload(), 2000);
             } else {
                 throw new Error(data.message);

--- a/tests/test_auto_backup.py
+++ b/tests/test_auto_backup.py
@@ -1,0 +1,32 @@
+"""Tests for utils/auto_backup.py's API-response metadata helper.
+
+`describe_snapshot()` turns the `Path | None` returned by
+`create_startup_backup()` into the JSON-safe shape the `/erase-data` route
+hands to the frontend's `showAutoBackupBanner()` (Track B WPB.8). It is
+intentionally decoupled from the SQLite copy itself so the erase route's
+response contract can be exercised without touching a real database file.
+"""
+from __future__ import annotations
+
+from pathlib import Path
+
+from utils.auto_backup import describe_snapshot
+
+
+def test_describe_snapshot_returns_none_when_no_snapshot_taken():
+    assert describe_snapshot(None) is None
+
+
+def test_describe_snapshot_returns_filename_only():
+    snapshot_path = Path("data") / "auto_backup" / "database_20260704_153012.db"
+
+    result = describe_snapshot(snapshot_path)
+
+    assert result == {"filename": "database_20260704_153012.db"}
+
+
+def test_describe_snapshot_strips_directory_regardless_of_path_shape():
+    # Accepts a bare string path too, not just a Path instance.
+    result = describe_snapshot("/some/absolute/dir/database_20260101_000000.db")
+
+    assert result == {"filename": "database_20260101_000000.db"}

--- a/utils/auto_backup.py
+++ b/utils/auto_backup.py
@@ -85,3 +85,14 @@ def create_startup_backup() -> Path | None:
     except (sqlite3.Error, OSError):
         logger.exception("Auto-backup failed")
         return None
+
+
+def describe_snapshot(snapshot_path: Path | str | None) -> dict | None:
+    """Build JSON-safe metadata for a snapshot path, for API responses.
+
+    Returns None when no snapshot was taken (e.g. `create_startup_backup`
+    skipped it), so callers can pass the result straight through untouched.
+    """
+    if snapshot_path is None:
+        return None
+    return {"filename": Path(snapshot_path).name}


### PR DESCRIPTION
## Summary

Executes **Track B WPB.8 (owner decision OD8)** from `docs/REFACTOR_PLAN.md`: wire the previously-exported-but-never-invoked `showAutoBackupBanner()` (`static/js/modules/program-backup.js`) into the erase flow, referencing the **live file-copy snapshot in `data/auto_backup/`** — not the DB-table `create_auto_backup_before_erase` variant that WPB.7 is removing (this PR never calls, imports, or depends on it; `utils/program_backup.py` is untouched).

## Wiring

1. **`utils/auto_backup.py`** — new `describe_snapshot(path)` helper: turns the `Path | None` returned by `create_startup_backup()` into JSON-safe `{"filename": "database_<timestamp>.db"}` metadata, or `None` passthrough when no snapshot was taken (TESTING=1, missing DB, or <100-exercise skip).
2. **`app.py` `/erase-data`** — captures the pre-erase `create_startup_backup()` return value and includes it as `data.auto_backup` in the existing `success_response()`. Additive only: `ok`, `status`, and `message` are unchanged; `data` was previously always `null`.
3. **`static/js/modules/program-backup.js`** — `showAutoBackupBanner()` reworked for the file-snapshot contract: dismissible informational alert naming `data/auto_backup/<filename>` (HTML-escaped). The old code expected the DB-table backup shape (`{id, name, item_count}` + a "Restore Now" button hitting `/api/backups/<id>/restore`) — that restore path is impossible post-erase anyway, since `/erase-data` drops the `program_backups` tables. Recovery from the raw file snapshot is a manual file-copy, so the banner is informational by design. Unused `showToast`/`notifyVolumeAffectingPlanChange` imports dropped (flake8-F401-equivalent hygiene).
4. **`templates/welcome.html`** — the confirm-erase handler passes `data.data.auto_backup` to `window.showAutoBackupBanner` (already assigned in `app.js:61`) before the 2s page reload.
5. **`.github/workflows/ci.yml`** — new **`e2e-erase-flow`** job, "E2E Erase Flow (Chromium, isolated, non-required)": runs `e2e/erase-flow.spec.ts` in its own job with a fresh server + throwaway DB, mirroring the `e2e-fatigue-context` idiom (#100). The spec must NOT join the `e2e-functional-shard` lists — `/erase-data` wipes the live DB mid-run, the same destructive-mutation reason `program-backup.spec.ts` is isolated in `e2e-backup`. Purely additive: no existing job names or steps touched; not a branch-protection required context.

## Migration notes

- `/erase-data` (POST) response gains `data.auto_backup`: `{"filename": string} | null`. All existing fields keep their prior shape and values — additive only.
- User-facing behavior: confirming "Erase All Data" on the welcome page now shows a dismissible banner naming the pre-erase snapshot file in `data/auto_backup/`, alongside the existing success toast, until the automatic reload.
- `showAutoBackupBanner(autoBackup)` argument contract changed from the dead DB-table shape (`{id, name, item_count}`) to `{filename}`. No caller existed before this PR, so nothing breaks.

## Test plan

- **New pytest (+3 → my delta on the 1629 baseline):** `tests/test_auto_backup.py` — `describe_snapshot` returns `None` for no-snapshot, `{"filename": ...}` for `Path` input, and strips directories from string paths.
- **New E2E (regression — fails without this wiring):** `e2e/erase-flow.spec.ts` — no banner pre-erase; after confirming erase, `[data-testid="auto-backup-banner"]` is visible and references `data/auto_backup/` + a `database_\d{8}_\d{6}\.db` filename. The E2E seed DB keeps the full exercise catalog (>100 rows), so `create_startup_backup()` genuinely writes the snapshot during the run.
- **CI execution:** the new spec runs in the new isolated `e2e-erase-flow` job on this PR (it is in no shard list, so without the job it would execute nowhere). Per parallel-agent constraints it was not executed locally (no port-5000 server); tsc-verified locally, executed by CI.
- **Verified locally:** full pytest `tests/` → **1632 passed** (1629 baseline + 3 new); flake8 blocking select (`E9,F63,F7,F82,F811,E711,E712,F401`) → 0; pyright 1.1.410 on touched files → 0 errors; `npx tsc --noEmit` → clean; ci.yml validated with `yaml.safe_load` (11 jobs, all 10 existing names byte-identical).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
