### PR TITLE
test: make catalog pytest baseline hermetic

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -3,6 +3,7 @@ Pytest configuration and fixtures for Priority 0 security tests.
 """
 import pytest
 import os
+import shutil
 from pathlib import Path
 from flask import Flask, jsonify
 from utils.database import (
@@ -67,6 +68,18 @@ def _cleanup_database_files(database_path: str) -> None:
 def test_db_path(tmp_path):
     """Create a unique temporary database file path per test."""
     return str(tmp_path / TEST_DB_FILENAME)
+
+
+@pytest.fixture
+def catalog_db_path(tmp_path):
+    """Copy the shipped catalog into a test-scoped, read-only snapshot."""
+    repo_root = Path(__file__).resolve().parents[1]
+    source = repo_root / "data" / "database.db"
+    destination = tmp_path / "catalog.db"
+
+    assert source.exists(), f"Shipped catalog database is missing: {source}"
+    shutil.copyfile(source, destination)
+    return str(destination)
 
 
 @pytest.fixture

--- a/tests/test_catalog_invariants.py
+++ b/tests/test_catalog_invariants.py
@@ -1,32 +1,23 @@
-"""Live-DB invariants for the shipped exercise catalog.
-
-These tests read data/database.db directly (the same pattern as
-test_volume_taxonomy.py) because the invariants gate the real shipped
-catalog, not seeded fixtures.
-"""
+"""Invariants for a test-scoped snapshot of the shipped exercise catalog."""
 from __future__ import annotations
 
 import sqlite3
 from pathlib import Path
 
 
-REPO_ROOT = Path(__file__).resolve().parents[1]
-LIVE_DB = REPO_ROOT / "data" / "database.db"
-
-
-def _connect() -> sqlite3.Connection:
-    assert LIVE_DB.exists(), f"Live DB is required for catalog invariants: {LIVE_DB}"
-    conn = sqlite3.connect(LIVE_DB)
+def _connect(catalog_db_path: str) -> sqlite3.Connection:
+    uri = Path(catalog_db_path).resolve().as_uri() + "?mode=ro"
+    conn = sqlite3.connect(uri, uri=True)
     conn.row_factory = sqlite3.Row
     return conn
 
 
-def test_catalog_primary_muscle_group_has_no_nulls():
+def test_catalog_primary_muscle_group_has_no_nulls(catalog_db_path: str):
     """Fatigue Meter Phase 2 Stage 1 (D2.13) — every catalog row must have a
     non-NULL, non-blank primary_muscle_group so per-muscle accumulation does
     not silently drop rows into an unassigned bucket due to missing data.
     """
-    with _connect() as conn:
+    with _connect(catalog_db_path) as conn:
         row = conn.execute(
             """
             SELECT COUNT(*) AS n
@@ -41,13 +32,13 @@ def test_catalog_primary_muscle_group_has_no_nulls():
     )
 
 
-def test_catalog_movement_pattern_has_no_nulls():
+def test_catalog_movement_pattern_has_no_nulls(catalog_db_path: str):
     """Fatigue Meter Phase 2 §10 #5 — every catalog row must have a non-NULL,
     non-blank movement_pattern so fatigue's pattern-weight resolution and the
     plan-generator's blueprint-slot matching never hit a NULL path for a
     shipped exercise. Unresolved rows carry the 'unassigned' sentinel.
     """
-    with _connect() as conn:
+    with _connect(catalog_db_path) as conn:
         row = conn.execute(
             """
             SELECT COUNT(*) AS n

--- a/tests/test_harness_isolation.py
+++ b/tests/test_harness_isolation.py
@@ -26,6 +26,15 @@ def test_database_handler_uses_the_test_scoped_database_path(app, test_db_path):
         assert Path(db.database_path) == Path(test_db_path)
 
 
+def test_test_database_paths_never_resolve_to_the_live_database(
+    test_db_path, catalog_db_path
+):
+    live_db = Path(__file__).resolve().parents[1] / "data" / "database.db"
+
+    assert Path(test_db_path).resolve() != live_db.resolve()
+    assert Path(catalog_db_path).resolve() != live_db.resolve()
+
+
 def test_distinct_test_databases_do_not_share_sqlite_locks(tmp_path):
     primary_db = tmp_path / "primary.db"
     secondary_db = tmp_path / "secondary.db"

--- a/tests/test_volume_taxonomy.py
+++ b/tests/test_volume_taxonomy.py
@@ -1,8 +1,7 @@
 """Strict Phase 0 taxonomy checks for plan volume integration.
 
-These tests intentionally read the live development DB at data/database.db.
-They do not use the normal test DB fixture because Phase 0 gates on the real
-catalog taxonomy, not seeded fixtures.
+The catalog fixture is a test-scoped snapshot of the shipped catalog. This
+keeps the taxonomy gate representative without connecting to the live DB.
 """
 from __future__ import annotations
 
@@ -28,20 +27,19 @@ from utils.volume_taxonomy import (
 
 
 REPO_ROOT = Path(__file__).resolve().parents[1]
-LIVE_DB = REPO_ROOT / "data" / "database.db"
 AUDIT_DOC = REPO_ROOT / "docs" / "archive" / "VOLUME_TAXONOMY_AUDIT.md"
 
 
-def _connect() -> sqlite3.Connection:
-    assert LIVE_DB.exists(), f"Live DB is required for Phase 0: {LIVE_DB}"
-    conn = sqlite3.connect(LIVE_DB)
+def _connect(catalog_db_path: str) -> sqlite3.Connection:
+    uri = Path(catalog_db_path).resolve().as_uri() + "?mode=ro"
+    conn = sqlite3.connect(uri, uri=True)
     conn.row_factory = sqlite3.Row
     return conn
 
 
-def _distinct_pst_values() -> list[tuple[str, str]]:
+def _distinct_pst_values(catalog_db_path: str) -> list[tuple[str, str]]:
     values: list[tuple[str, str]] = []
-    with _connect() as conn:
+    with _connect(catalog_db_path) as conn:
         for column in (
             "primary_muscle_group",
             "secondary_muscle_group",
@@ -66,9 +64,9 @@ def _csv_tokens(raw: str | None) -> list[str]:
     return [token.strip() for token in re.split(r"[;,]", raw) if token.strip()]
 
 
-def _distinct_isolated_tokens() -> set[str]:
+def _distinct_isolated_tokens(catalog_db_path: str) -> set[str]:
     tokens: set[str] = set()
-    with _connect() as conn:
+    with _connect(catalog_db_path) as conn:
         for row in conn.execute("SELECT DISTINCT muscle FROM exercise_isolated_muscles"):
             tokens.add(row["muscle"])
         for row in conn.execute(
@@ -83,11 +81,11 @@ def _distinct_isolated_tokens() -> set[str]:
     return tokens
 
 
-def test_every_pst_value_has_basic_rollup() -> None:
+def test_every_pst_value_has_basic_rollup(catalog_db_path: str) -> None:
     missing: list[tuple[str, str, str | None]] = []
     invalid: list[tuple[str, str]] = []
 
-    for column, raw in _distinct_pst_values():
+    for column, raw in _distinct_pst_values(catalog_db_path):
         key = canonical_pst(raw)
         if key not in COARSE_TO_BASIC:
             missing.append((column, raw, key))
@@ -99,11 +97,11 @@ def test_every_pst_value_has_basic_rollup() -> None:
     assert invalid == []
 
 
-def test_every_pst_value_has_representative_advanced() -> None:
+def test_every_pst_value_has_representative_advanced(catalog_db_path: str) -> None:
     missing: list[tuple[str, str, str | None]] = []
     invalid: list[tuple[str, str]] = []
 
-    for column, raw in _distinct_pst_values():
+    for column, raw in _distinct_pst_values(catalog_db_path):
         key = canonical_pst(raw)
         if key not in COARSE_TO_REPRESENTATIVE_ADVANCED:
             missing.append((column, raw, key))
@@ -116,11 +114,11 @@ def test_every_pst_value_has_representative_advanced() -> None:
     assert invalid == []
 
 
-def test_every_isolated_token_handled() -> None:
+def test_every_isolated_token_handled(catalog_db_path: str) -> None:
     missing: list[tuple[str, str]] = []
     invalid: list[tuple[str, str | None]] = []
 
-    for raw in sorted(_distinct_isolated_tokens()):
+    for raw in sorted(_distinct_isolated_tokens(catalog_db_path)):
         normalized = normalize_isolated_token(raw)
         if normalized in DISTRIBUTED_UMBRELLA_TOKENS:
             continue
@@ -183,12 +181,12 @@ def test_blank_pst_strategy_is_set() -> None:
     assert BLANK_PST_STRATEGY in {"isolated_only", "backfill", "exclude"}
 
 
-def test_blank_pst_audit_section_present() -> None:
+def test_blank_pst_audit_section_present(catalog_db_path: str) -> None:
     assert AUDIT_DOC.exists(), f"Missing Phase 0 audit doc: {AUDIT_DOC}"
     text = AUDIT_DOC.read_text(encoding="utf-8")
     assert "## Blank P/S/T exercises" in text
 
-    with _connect() as conn:
+    with _connect(catalog_db_path) as conn:
         blank_count = conn.execute(
             """
             SELECT COUNT(*)


### PR DESCRIPTION
## Summary
- copy the shipped exercise catalog to a unique pytest `tmp_path` before taxonomy/invariant checks
- open catalog snapshots through SQLite read-only URIs
- add a harness guard that rejects normal or catalog test paths resolving to `data/database.db`

## Isolation
Production behavior is unchanged. The two catalog suites still characterize the shipped tracked catalog, but every SQL connection resolves to the per-test copy. Work was performed in a fresh `scripts/new-worktree.ps1 -Seed empty` worktree with its own restored tracked catalog; the user live DB was never used as the test target.

## Verification
- focused suite repeated 4x: `13 passed` each run
- full pytest: `1614 passed in 437.51s`
- user live DB SHA-256 before/after each focused run and after full suite: `469FDF1DD1868F207E12C4EA6B6D98C2DC977E696835BFA4E4696DB6E96EB922` (unchanged)
- `git diff --check`: clean

No schema, API, calculation, or production-code changes.