### PR TITLE
docs(refactor): sync Phase -1 repository truth

### DIFF
--- a/.claude/rules/routes.md
+++ b/.claude/rules/routes.md
@@ -58,10 +58,14 @@ To add a filterable column:
 - [ ] If muscle-type: add mapping in `SIMPLE_TO_DB_MUSCLE` / `SIMPLE_TO_ADVANCED_ISOLATED` (`routes/filters.py:17-69`)
 
 ## Input validation
-Routes validate bounds before calling utils. Example pattern in `routes/workout_plan.py`: sets 1-20, reps 1-100, weight ≥ 0, RIR 0-10.
+Validation is currently path-specific; do not assume browser input attributes are a
+server contract. The add-exercise service checks required fields, `min_rep_range <=
+max_rep_range`, RIR ≥ 0, and weight in 0–1000. The plan-update and workout-log-update
+routes currently allowlist field names but do not enforce value bounds. Track B WPB.2
+owns the pending canonical server bounds and their application across add/update paths.
 
 ## Auth boundaries
-**No authentication exists.** Single-user local app. `POST /erase-data` (`app.py:125`) requires `{"confirm": "ERASE_ALL_DATA"}` in body; requests without it return 400. A pre-erase snapshot writes to `data/auto_backup/` before wiping. **Do not expose this app to an untrusted network.**
+**No authentication exists.** Single-user local app. `POST /erase-data` (`app.py:158`) requires `{"confirm": "ERASE_ALL_DATA"}` in body; requests without it return 400. A pre-erase snapshot writes to `data/auto_backup/` before wiping. **Do not expose this app to an untrusted network.**
 
 ## Filename sanitization
 `utils/export_utils.py` has `sanitize_filename()` to strip path traversal and dangerous characters from export filenames.

--- a/.claude/rules/testing.md
+++ b/.claude/rules/testing.md
@@ -9,14 +9,15 @@ paths:
 # Testing guide
 
 ## Baselines (re-verify after significant changes)
-- **pytest**: 913 passed, 1 skipped (~116s) — `.venv/Scripts/python.exe -m pytest tests/ -q`
-- **E2E Playwright**: 314 passed (~7.2m, Chromium only) — `npx playwright test --project=chromium --reporter=line`
-- **Summary-page Playwright**: 20 passed (~25s) — `npx playwright test e2e/summary-pages.spec.ts --project=chromium --reporter=line`
+- **pytest**: 1613 passed on integrated `main` @ `c0d5c38` (2026-07-05) — `.venv/Scripts/python.exe -m pytest tests/ -q`
+- **Playwright inventory**: 501 tests across 30 specs — `npx playwright test --list --project=chromium`
+- **Required functional CI set**: 404 tests, split **202 + 202** across two Chromium shards
+- **Summary-page Playwright**: 20 tests — `npx playwright test e2e/summary-pages.spec.ts --project=chromium --reporter=line`
 
 ## Fixture hierarchy (`tests/conftest.py`)
 ```
 test_db_path (function)         — unique `tmp_path` SQLite file per test
-  app (function)                — Flask app + fresh schema at that DB, all 10 blueprints + erase-data route
+  app (function)                — Flask app + fresh schema at that DB, all 13 blueprints + erase-data route
     client (function)           — test client bound to the same isolated DB
     db_handler (function)       — DatabaseHandler at the same DB; verifies FK=ON
       clean_db (function)       — DELETEs all rows, preserves tables
@@ -51,27 +52,40 @@ Config: `playwright.config.ts` — auto-starts Flask via `.venv/Scripts/python.e
 
 Fixtures: `e2e/fixtures.ts` exports `test` (console-error collector), `ROUTES`, `API_ENDPOINTS`, `SELECTORS`, `waitForPageReady()`, `expectToast()`.
 
-## E2E test map (Chromium, 315 total across 17 specs)
+## E2E test map (Chromium, 501 total across 30 specs)
 
 | Spec | Tests | User flow | Fixtures needed |
 |---|---|---|---|
 | `smoke-navigation.spec.ts` | 10 | Page loads, navbar links, full navigation cycle | None |
 | `dark-mode.spec.ts` | 6 | Toggle dark mode, localStorage persistence | None |
-| `workout-plan.spec.ts` | 17 | Routine cascade, add exercise, filters, export, plan generator | Exercises in DB |
-| `workout-log.spec.ts` | 19 | Table, import from plan, edit scored fields, date filter, clear | Plan + log entries |
+| `nav-dropdown.spec.ts` | 7 | Desktop/mobile navbar behavior and actionability | None |
+| `workout-plan.spec.ts` | 35 | Routine cascade, plan CRUD, filters, generator, controls, media | Exercises in DB |
+| `workout-log.spec.ts` | 23 | Import/edit/delete/date/mobile/media flows | Plan + log entries |
 | `summary-pages.spec.ts` | 20 | Weekly + session structure, Effective/Raw columns, contribution mode, pattern coverage | Exercises |
-| `progression.spec.ts` | 24 | Page, selector, goals CRUD, methodology, status indicators | Exercises + log |
-| `volume-splitter.spec.ts` | 26 | Sliders, mode toggle, calculate, reset, export | None |
-| `program-backup.spec.ts` | 18 | Modal, create/list/restore/delete, API | Plan data |
+| `progression.spec.ts` | 26 | Page, selector, goals CRUD, methodology, status indicators | Exercises + log |
+| `volume-splitter.spec.ts` | 27 | Sliders, modes, calculate/reset/export/history | None |
+| `volume-progress.spec.ts` | 16 | Active-plan volume drawer behavior and geometry | Exercises in DB |
+| `program-backup.spec.ts` | 20 | Backup Center CRUD, restore, confirmations, API | Plan data |
+| `erase-flow.spec.ts` | 2 | Erase confirmation and auto-backup banner | None |
 | `exercise-interactions.spec.ts` | 21 | Delete, replace, superset, inline edit, details | Exercises in plan |
 | `accessibility.spec.ts` | 24 | Keyboard, ARIA, focus, skip links, contrast | None |
-| `api-integration.spec.ts` | 56 | All API endpoints | Varies |
+| `api-integration.spec.ts` | 58 | API contracts across core workflows | Varies |
 | `empty-states.spec.ts` | 16 | Empty plan/log/filters/summaries | None |
 | `error-handling.spec.ts` | 12 | Server 500/503, malformed JSON, double-click | None (mocked) |
 | `superset-edge-cases.spec.ts` | 12 | Link >2/<2, delete, unlink, replace, persistence | 2+ exercises |
 | `validation-boundary.spec.ts` | 23 | Negative, rep range, zero, RIR/RPE bounds, decimals | Exercise available |
 | `browser-navigation-state.spec.ts` | 3 | Back button, refresh, deep-link | None |
 | `replace-exercise-errors.spec.ts` | 3 | No alternative, all in routine, missing metadata | Specific setup |
+| `body-composition.spec.ts` | 5 | Snapshot CRUD, BMI fallback, JS/Python parity | None |
+| `fatigue.spec.ts` | 8 | Fatigue page, periods, empty/mobile/dark states | None |
+| `fatigue-context.spec.ts` | 6 | Profile setting and advisory Workout Controls | Mocked estimate API |
+| `fatigue-stage4-smokes.spec.ts` | 5 | Badge mobile geometry and dark contrast | None |
+| `learned-calibration.spec.ts` | 8 | Calibration settings, actions, golden path | Profile + log data |
+| `listener-cleanup.spec.ts` | 3 | Detached picker/dropdown listener cleanup | Exercises in plan |
+| `ui-hardening.spec.ts` | 12 | Toast, form-state, modal keyboard/focus contracts | Varies |
+| `user-profile.spec.ts` | 24 | Profile, lifts, settings, body map, insights | None |
+| `visual.spec.ts` | 48 | Eight-page viewport/theme screenshot matrix | Visual seed |
+| `visual-baseline-thumbnails.spec.ts` | 18 | Plan/log thumbnail screenshot matrix | Visual seed |
 
 Support files:
 - `e2e/fixtures.ts` — shared fixtures, route constants, selectors, helpers

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -48,11 +48,14 @@ initialize_database()           ← utils/db_initializer.py — tables + normali
 add_progression_goals_table()   ← utils/database.py
 add_volume_tracking_tables()    ← utils/database.py
 add_user_profile_tables()       ← utils/database.py
+add_body_composition_snapshots_table() ← utils/database.py
+add_strength_calibration_tables()      ← utils/database.py
+add_fatigue_context_settings_table()   ← utils/database.py
 initialize_exercise_order()     ← routes/workout_plan.py — ALTERs user_selection
 init_backup_tables()            ← routes/program_backup.py → utils/program_backup.py
 create_startup_backup()         ← utils/auto_backup.py — snapshots live DB to data/auto_backup/
 ```
-Then registers 11 blueprints (`app.py:60-76`), plus one direct route: `POST /erase-data` (`app.py:130`).
+Then registers 13 blueprints (`app.py:84-98`), plus one direct route: `POST /erase-data` (`app.py:158`).
 
 ### Module boundaries
 ```
@@ -80,8 +83,10 @@ app.py                 ← startup + middleware only; no business logic
 | `workout_plan_bp` | `routes/workout_plan.py` | `GET /workout_plan`, `POST /add_exercise`, `POST /generate_starter_plan` |
 | `progression_plan_bp` | `routes/progression_plan.py` | `GET /progression` |
 | `user_profile_bp` | `routes/user_profile.py` | `GET /user_profile`, `GET /api/user_profile/estimate` |
+| `body_composition_bp` | `routes/body_composition.py` | `GET /body_composition`, `POST /api/body_composition/snapshots` |
 | `volume_splitter_bp` | `routes/volume_splitter.py` | `GET /volume_splitter` |
 | `program_backup_bp` | `routes/program_backup.py` | `GET/POST /api/backups`, `POST /api/backups/<id>/restore` |
+| `fatigue_bp` | `routes/fatigue.py` | `GET /fatigue` |
 
 ### Deeper references
 - Routes / API endpoints / filters / security → `.claude/rules/routes.md` (loads when editing `routes/**`).
@@ -167,36 +172,28 @@ npx playwright test --project=chromium --reporter=line
 
 ## 5. Current State & Risks
 
-### Verified test counts (2026-07-04 — Deep Refactor Plan v3 Track A close on `main`)
-- **2026-07-04 — Deep Refactor Plan v3 Track A close on `main` @ `55bca22`**:
-  pytest **1629 passed** (~1m 22s in CI); required Playwright Chromium functional
-  shards **202 + 202 passed** (~5m / ~8m). PRs #91–#98 shipped A1–A8; final
-  integrated PR #98 also passed smoke, backup, lint, security, frontend, and type gates.
-- **pytest**: 1447 passed (~4m 17s, full `tests/` run) — adds 4 new `tests/test_profile_estimator.py` cases for the barbell↔dumbbell per-hand load-basis conversion in `utils/profile_estimator.py` (`_load_basis_factor`). Fixes Workout Controls suggesting per-hand dumbbell weights ~2× too high when the chain reference was a total-load barbell/machine lift (e.g. Incline Dumbbell Press 71→36 kg/hand). Previous documented baseline was 1442 (2026-05-24); the +5 vs that figure reflects this checkout, not arithmetic. No E2E run this session.
+### Verified test counts (2026-07-05 — Plan v3 Phase -1 entry on `main`)
+- **Integrated `main` @ `c0d5c38`**: isolated-worktree pytest **1613 passed**;
+  latest merged PR CI functional shards **202 + 202 passed**; dedicated fatigue-context
+  **6 passed** and erase-flow **2 passed**; full inventory **501 tests / 30 specs**.
+- Track A shipped in PRs #91–#98. Track B has shipped WPB.1 (#103), WPB.5 (#101),
+  WPB.7 (#102), WPB.8 (#104), and WPB.9 step 1 (#100); WPB.2–WPB.4, WPB.6, and
+  WPB.9 promotion remain pending/prerequisite-gated.
 
-### Prior verified test counts
-- **2026-05-24 — Fatigue Meter Phase 2 Stage 3 verify-suite close on `main` @ d5b80bf, post-PR #35**: pytest 1442 passed (~2m 55s) — same baseline as Stage 2 implementation (no count drift post-squash).
-- **Playwright Chromium targeted (`e2e/fatigue.spec.ts`)**: 8 passed (~7.8s).
-- **Full E2E Playwright (Chromium)**: 449 passed / 13 failed / 17 did-not-run (~12.5m). The 13 + 17 reds match the documented pre-existing baseline **exactly** with **zero new Stage-2 reds**: 2 `workout-plan.spec.ts` tests on `#muscleModeToggle` off-viewport at 1280 width (same historical family as the now-fixed `nav-dropdown.spec.ts:117` issue #8), 10 sub-pixel `visual.spec.ts` desktop drifts on welcome / workout-plan / workout-log / progression / volume-splitter (zero Stage-2 surface), 1 `visual-baseline-thumbnails.spec.ts` plan-desktop-light-simple, and 17 `visual-baseline-thumbnails.spec.ts` cases that need the seed-DB preflight from `e2e/scripts/prepare_visual_db.py` per `e2e/CLAUDE.md`. The 12 weekly-summary + session-summary visual baselines re-snapshotted during Stage 2 implementation are now passing (`449 = 437 + 12`). Pre-merge restore point: backup id 5, label `pre-fatigue-meter-phase-2-stage-2-merge-2026-05-23`.
-- **2026-05-23, Stage 2 implementation gate (`feat/fatigue-meter-phase-2-stage-2`)**: pytest 1442 passed (~3m 07s) — 1351 Stage-1 baseline + 91 new Stage-2 tests (79 unit cases in `tests/test_fatigue.py` covering per-muscle math, logged-side, period windows, SFR sentinel, Unassigned-bucket invariant; 12 integration cases in `tests/test_fatigue_routes.py` covering `GET /fatigue` empty/populated/unranked paths + the Unassigned-via-route invariant). Targeted `e2e/fatigue.spec.ts` 8 passed (~7.7s). First verify-suite Chromium full run was 437 passed / 25 failed / 17 did-not-run; 12 of the 25 were the expected weekly + session summary visual baselines (badge gained the "View per-muscle breakdown →" link row, same pattern as PR #28) and were re-baselined via scoped `--update-snapshots`. PR #35 squash on `main` (d5b80bf) 2026-05-23.
-- **2026-05-23, Stage 1 close (`feat/fatigue-meter-phase-2`)**: pytest 1351 passed (~2m 55s) post-Stage-1 (1350 entry baseline + 1 new `tests/test_catalog_invariants.py::test_catalog_primary_muscle_group_has_no_nulls`). PR #34 squash on `main`.
-- **2026-05-21, `main` post-Body-Composition hygiene**: pytest 1374 passed (~2m 53s) — 1372 post-PR-#31 + 2 new `captured_at` ISO validation cases. Superseded 2026-05-23 by the `test_filter_cache.py` deletion (KI-001 dormant code removal).
-- **2026-05-03, `feat/fatigue-meter-phase-1-rebased`**: pytest 1160 passed (~2m 25s); Playwright Chromium 408 passed, 2 failed (effective 409 / 1 — `nav-dropdown.spec.ts:117` dark-mode-toggle off-viewport was a pre-existing red on `origin/main`, fixed later by issue #8; `program-backup.spec.ts:79` is a sequential-DB flake that passes in isolation). See `docs/fatigue_meter/PLANNING.md §2.7`.
-- **2026-04-28, pre-rebase**: pytest 1080 passed (~2m 22s); relevant E2E 41 passed (`user-profile.spec.ts` + `workout-plan.spec.ts`); adjacent E2E 55 passed (`exercise-interactions.spec.ts` + `accessibility.spec.ts` + `smoke-navigation.spec.ts`); last full E2E baseline 314 passed (~7.2m, 2026-04-18); summary-page Playwright 20 passed (~25s, 2026-04-18).
-
-Re-verify after significant changes and update counts above.
+Historical baselines live in `docs/MASTER_HANDOVER.md`. Re-verify after significant changes.
 
 ### Known response-contract exceptions (2026-05-21)
 None. The pattern-coverage and replace-exercise fallback paths were migrated to `success_response()` / `error_response()` (2026-05-21). The replace-exercise "no result" cases (`NO_CANDIDATES`, `DUPLICATE`, `SELECTION_FAILED`) keep HTTP 200 by passing `status_code=200` to `error_response()` — they're user-facing "couldn't be processed" outcomes that pytest + the JS swap handler treat as 200 + `ok:false`.
 
 ### exercise_order column
-Added at startup by `initialize_exercise_order()` (`routes/workout_plan.py:614`) via `ALTER TABLE`. Route handler `get_workout_plan` (lines 231-234) defensively checks `column_exists()` for pre-migration DBs.
+Added at startup by `initialize_exercise_order()` (`routes/workout_plan.py:634`) via `ALTER TABLE`. `get_workout_plan` (line 247) defensively checks `column_exists()` for pre-migration DBs.
 
 ### session_summary vs weekly_summary — not duplicates
 - `utils/session_summary.py:21` — `calculate_session_summary(routine, time_window, ...)`: groups by routine, optional date filter, per-session averages from `workout_log` join.
 - `utils/weekly_summary.py:35` — `calculate_weekly_summary(method, ...)`: aggregates across all routines weekly, no date filter, tracks frequency.
 
-`session_summary.py` imports `STATUS_MAP`/`EFFECTIVE_STATUS_MAP` from `weekly_summary.py` (line 9), but calculations are independent.
+`session_summary.py` imports only `EFFECTIVE_STATUS_MAP` from `weekly_summary.py`
+(`utils/session_summary.py:9`); the calculations remain independent.
 
 ### Historical audit trail
 Full file-by-file audit log and violation details: `docs/CLAUDE_MD_AUDIT.md`. Resolved items list (Cleanup Waves 1 and 2, `utils/database_indexes.py` retirement 2026-04-18, `volume_export.py` DatabaseHandler migration) lives there.

--- a/docs/ACTIVE_DEVELOPMENT.md
+++ b/docs/ACTIVE_DEVELOPMENT.md
@@ -4,6 +4,15 @@ This file is the execution source of truth for autonomous development sessions. 
 
 ## Current Objective
 
+**2026-07-05 — Deep Refactor Plan v3 Phase -1.** Owner approved structural-refactor
+execution. Current `main` baseline is `c0d5c38`: Track A is shipped; Track B has merged
+WPB.1 (#103), WPB.5 (#101), WPB.7 (#102), WPB.8 (#104), and WPB.9 step 1 (#100).
+WP-1.1 is synchronizing the documentation against the integrated code/CI state before
+the remaining Phase -1 evidence and test-hardening packets proceed. See
+`docs/REFACTOR_PLAN.md` and `docs/MASTER_HANDOVER.md` for the canonical packet/status map.
+
+---
+
 **2026-06-11 — Issue #8 navbar/dark-mode known-red fix ready.** Fixed the `e2e/nav-dropdown.spec.ts` 1440px dark-mode-toggle actionability red by compacting only the cramped desktop navbar utility chrome (`1360px–1500px`: hide decorative signature/dividers and the scale control, keep muscle + dark toggles reachable) and restoring the spec to a real Playwright `locator.click()`. Promoted `e2e/nav-dropdown.spec.ts` into the required `e2e-functional-shard` spec list without renaming any check context; `program-backup` remains isolated in `e2e-backup`, visual specs remain manual deep gate only. Local verification: `npx playwright test e2e/nav-dropdown.spec.ts --project=chromium --reporter=line` -> **7 passed**. `data/database.db` remains runtime dirt only.
 
 ---

--- a/docs/MASTER_HANDOVER.md
+++ b/docs/MASTER_HANDOVER.md
@@ -4,6 +4,17 @@
 
 ## Current State
 
+> **2026-07-05 — Plan v3 execution APPROVED; Phase -1 started (`main` @ `c0d5c38`).**
+> Track A remains shipped. Track B has merged WPB.1 (#103), WPB.5 (#101), WPB.7
+> (#102), WPB.8 (#104), and WPB.9's non-required observation job (#100); WPB.2–WPB.4,
+> WPB.6, and WPB.9's eventual required-context promotion remain pending. Integrated
+> pytest baseline: **1613 passed** in the isolated WP-1.1 worktree. Current required
+> Chromium functional inventory: **404 tests**, green as **202 + 202** in the latest
+> merged PR CI; dedicated fatigue-context **6 passed** and erase-flow **2 passed**.
+> The complete Playwright inventory is **501 tests across 30 specs**. The owner explicitly
+> approved Plan-v3 execution on 2026-07-05; the previous unapproved wording below is
+> retained only as the Track-A milestone's historical state.
+>
 > **2026-07-04 — Deep Refactor Plan v3 Track A SHIPPED (`main` @ `55bca22`, PRs #91–#98).** All eight confirmed bug-fix packets are complete: toast severity contract (A1), workout-log single-submit path (A2), assisted-progression badge consistency including date edits (A3), seven route error-page contracts plus fatigue XHR handling (A4), atomic backup creation (A5), execution-picker/dropdown listener cleanup (A6), removal of the unconditional export cleanup delay with retry-on-lock behavior (A7), and CTE-prefixed write classification for `DatabaseHandler` locking (A8). Work ran in isolated worktrees; live `data/database.db` was never staged. Final integrated PR #98 CI: **1629 pytest passed**; required Chromium functional shards **202 + 202 passed**; smoke, backup, lint, security, frontend, and type gates all green. Track B is owner-approved and its "Track A complete" prerequisites are now satisfied. Plan-v3 structural refactor execution remains unapproved/unchecked.
 >
 > **2026-06-11 — Issue #8 navbar/dark-mode known-red fix ready.** Fixed the `e2e/nav-dropdown.spec.ts` 1440px dark-mode-toggle actionability red by compacting only the cramped desktop navbar utility chrome (`1360px–1500px`: hide decorative signature/dividers and the scale control, keep muscle + dark toggles reachable) and restoring the spec to a real Playwright `locator.click()`. Promoted `e2e/nav-dropdown.spec.ts` into the required `e2e-functional-shard` spec list without renaming any check context; `program-backup` remains isolated in `e2e-backup`, visual specs remain manual deep gate only. Current docs updated: `e2e/CLAUDE.md`, `docs/ai_workflow/QUALITY_GATE.md`, `docs/CI_CD_IMPROVEMENT_PLAN.md`, `docs/UI_SCENARIOS_GAP_ANALYSIS.md`, `docs/LEFTOVERS_BY_PRIORITY.md`, and changelog. Local verification: `npx playwright test e2e/nav-dropdown.spec.ts --project=chromium --reporter=line` -> **7 passed**. `data/database.db` remains runtime dirt only.

--- a/docs/REFACTOR_PLAN.md
+++ b/docs/REFACTOR_PLAN.md
@@ -1,7 +1,7 @@
 # Deep Refactor Plan — v3 (2026-07-04, full-scan grounded)
 
-**Status: Track A completed on `main` (2026-07-04); Track B approved; Plan-v3
-structural-refactor execution still awaits owner approval.**
+**Status: Track A completed; Track B partially shipped; Plan-v3 structural-refactor
+execution approved by the owner on 2026-07-05. Phase -1 is in progress.**
 
 This supersedes v2. It incorporates:
 
@@ -44,8 +44,8 @@ track and must never be smuggled into move-only refactor PRs.
 - CSS contains an undeclared `@layer` ordering trap, duplicate token vocabularies,
   six local token namespaces, a four-copy summary/frame block, and misfiled page CSS.
 - The safety net has gaps: two pytest files read the live DB, several E2E assertions
-  are vacuous, live startup backup code lacks direct tests, and fatigue-context E2E is
-  absent from CI.
+  are vacuous, and live startup backup copying still lacks direct tests. Fatigue-context
+  E2E now has a dedicated non-required CI context (WPB.9 step 1), but is not yet required.
 
 ### Accepted with stricter safeguards
 
@@ -246,6 +246,11 @@ is interleaved with the phases, not a block; the prerequisite column in each ent
 Execution requires the owner's Track-A/Plan-v3 sign-off boxes plus this section's approval
 per the sign-off checklist.
 
+**Status at `main` @ `c0d5c38` (2026-07-05):** WPB.1 (#103), WPB.5 (#101),
+WPB.7 (#102), WPB.8 (#104), and WPB.9 step 1 (#100) are merged. WPB.2–WPB.4
+and WPB.6 remain prerequisite-gated; WPB.9 still needs its observation window and
+separate required-context promotion.
+
 ### WPB.1 (OD1) Allow plan weight 0 for bodyweight/assisted exercises
 
 - Fix the falsy-check family in `utils/exercise_manager.py`: weight `0` treated as
@@ -346,6 +351,8 @@ per the sign-off checklist.
 
 ### WP-1.1 Documentation truth sync
 
+**Completed 2026-07-05 on the WP-1.1 documentation branch.**
+
 - Correct the startup initializer inventory, blueprint count, current verified counts,
   handover SHA wording, route-validation claims, E2E spec ledger, and fatigue-context CI row.
 - Correct stale `STATUS_MAP` import documentation; current `session_summary.py` imports only
@@ -372,8 +379,8 @@ per the sign-off checklist.
 - Replace `expect(true)`, `x || true`, and equivalent non-assertions in
   `validation-boundary`, `empty-states`, `exercise-interactions`, and
   `superset-edge-cases` with observable outcomes.
-- Do not introduce new validation behavior while OD2 is unresolved; characterize actual
-  behavior or mark a case explicitly pending with a linked decision.
+- Do not introduce WPB.2's approved-but-not-yet-implemented validation behavior here;
+  characterize current behavior or mark the case pending on WPB.2.
 
 ### WP-1.5 Normalize the main landmark
 
@@ -809,4 +816,4 @@ decisions are silently outstanding; either resolve them or leave them explicitly
 - [x] OD follow-ups drafted as Track B work packets WPB.1–WPB.9 (2026-07-04).
 - [x] Owner approves Track A execution (2026-07-04).
 - [x] Owner approves Track B execution (behavior + contract changes) (2026-07-04).
-- [ ] Owner approves Plan v3 for refactor execution.
+- [x] Owner approves Plan v3 for refactor execution (2026-07-05).

--- a/e2e/CLAUDE.md
+++ b/e2e/CLAUDE.md
@@ -12,11 +12,12 @@ Playwright Chromium specs covering UI flows end-to-end. `playwright.config.ts` a
 | `dark-mode.spec.ts`, `nav-dropdown.spec.ts` | Theme + navbar |
 | `workout-plan.spec.ts`, `workout-log.spec.ts` | Plan/log CRUD |
 | `summary-pages.spec.ts`, `progression.spec.ts`, `volume-splitter.spec.ts` | Analyze + progress + distribute |
-| `program-backup.spec.ts`, `user-profile.spec.ts` | Backup modal, profile questionnaire |
+| `program-backup.spec.ts`, `erase-flow.spec.ts`, `user-profile.spec.ts` | Backup/erase recovery flows, profile questionnaire |
 | `exercise-interactions.spec.ts`, `superset-edge-cases.spec.ts`, `replace-exercise-errors.spec.ts` | Per-row actions |
 | `validation-boundary.spec.ts`, `error-handling.spec.ts`, `empty-states.spec.ts`, `accessibility.spec.ts` | Edge & a11y |
 | `api-integration.spec.ts` | All API endpoints |
-| `visual.spec.ts`, `volume-progress.spec.ts`, `fatigue-stage4-smokes.spec.ts` | Visual snapshots + recent feature smokes |
+| `fatigue-context.spec.ts`, `listener-cleanup.spec.ts` | Advisory fatigue context + listener lifecycle regressions |
+| `visual.spec.ts`, `visual-baseline-thumbnails.spec.ts`, `volume-progress.spec.ts`, `fatigue-stage4-smokes.spec.ts` | Visual snapshots + recent feature smokes |
 
 Full per-spec test count map: `.claude/rules/testing.md`.
 
@@ -41,6 +42,9 @@ The GitHub Actions gate runs a curated, deterministic subset on **ubuntu/Chromiu
 | `accessibility`, `api-integration`, `body-composition`, `browser-navigation-state`, `dark-mode`, `empty-states`, `error-handling`, `exercise-interactions`, `fatigue`, `fatigue-stage4-smokes`, `learned-calibration`, `nav-dropdown`, `progression`, `replace-exercise-errors`, `smoke-navigation`, `summary-pages`, `superset-edge-cases`, `ui-hardening`, `user-profile`, `validation-boundary`, `volume-progress`, `volume-splitter`, `workout-log`, `workout-plan` | `e2e-functional-shard` matrix job (`--shard=i/2`) | Deterministic functional/product coverage |
 | `smoke-navigation` | also `e2e-smoke` job | Fast standalone "is the app up" signal |
 | `program-backup` | `e2e-backup` job (isolated) | Live backup/restore mutations — own server + fresh seed avoids intra-run sequential-DB pollution without any between-spec reset |
+| `fatigue-context` | `e2e-fatigue-context` job (**non-required**) | WPB.9 step 1: dedicated green-run observation context; promotion remains a separate later step |
+| `erase-flow` | `e2e-erase-flow` job (**non-required**) | Live erase/reset mutation and WPB.8 banner proof run on an isolated server/DB |
+| `listener-cleanup` | local/targeted and manual deep gate only | Track A regression instrumentation; intentionally not in the required functional list |
 | `accessibility`, `fatigue-stage4-smokes`, `volume-progress` | **promoted to `e2e-functional` (A10, 2026-06-11)** | Were measure-first (a11y run-cost; geometry/sub-pixel asserts). Promoted after a 5×-repeat ubuntu stability probe (225/225 green, zero flakes) + the 2026-06-05 deep-gate full-e2e green. Their asserts are coarse thresholds (tap-target ≥32/≥44, viewport-bound ±1px, overflow boolean), not pixel-exact snapshots. Watch the first ~10 PR runs for any geometry flake; revert that one spec line if one appears. |
 | `nav-dropdown` | **promoted to `e2e-functional` (2026-06-11)** | Fixed the 1440px dark-mode-toggle actionability red with compact desktop navbar utility chrome; spec now uses a real Playwright click. |
 | `visual`, `visual-baseline-thumbnails` | manual deep gate only (`visual-linux` job) | Cross-OS rendering: compared against Linux baselines, never a required PR check. See "Visual spec contract" below. |

--- a/utils/CLAUDE.md
+++ b/utils/CLAUDE.md
@@ -21,7 +21,8 @@ All business logic and DB access. Routes call into here; nothing in here imports
 ## Gotchas
 - **Effective sets are informational only** (`effective_sets.py:6-7`). Never auto-adjust or block user actions on them.
 - **FLASK_DEBUG default mismatch**: `app.py:259` defaults `'0'`, `database.py:90` defaults `'1'`. Result: `python app.py` runs Flask non-debug but DB uses DELETE-journal/FULL-sync (safe).
-- `session_summary.py` imports `STATUS_MAP` from `weekly_summary.py` — not duplicates; per-session vs cross-routine weekly aggregation.
+- `session_summary.py` imports only `EFFECTIVE_STATUS_MAP` from `weekly_summary.py` —
+  not duplicates; per-session vs cross-routine weekly aggregation.
 
 ## See also
 - `.claude/rules/database.md` — schema table, DatabaseHandler pattern, adding a table


### PR DESCRIPTION
## Summary
- records the 2026-07-05 Plan-v3 execution approval and current merged Track B state through WPB.8
- reconciles startup initializers, 13 blueprint registrations, route-validation truth, and STATUS_MAP documentation with current code
- replaces the stale Playwright ledger with the generated 30-spec / 501-test inventory and documents every CI placement, including non-required fatigue-context and erase-flow jobs
- refreshes current handover/baseline wording at main c0d5c38 while preserving scan files as historical evidence

## Verification
- docs self-review and git diff --check
- npx playwright test --list --project=chromium -> 501 tests in 30 files
- ledger parser -> 30 rows / 501 tests
- blueprint inventory -> 13 app registrations / 13 test-fixture registrations
- pytest --collect-only -> 1613 tests

## Migration notes
Documentation only; no runtime, schema, API, or calculation behavior changes.