### PR TITLE
fix(validation): enforce canonical workout bounds (WPB.2)

### DIFF
--- a/.claude/rules/routes.md
+++ b/.claude/rules/routes.md
@@ -59,10 +59,12 @@ To add a filterable column:
 
 ## Input validation
 Validation is currently path-specific; do not assume browser input attributes are a
-server contract. The add-exercise service checks required fields, `min_rep_range <=
-max_rep_range`, RIR ≥ 0, and weight in 0–1000. The plan-update and workout-log-update
-routes currently allowlist field names but do not enforce value bounds. Track B WPB.2
-owns the pending canonical server bounds and their application across add/update paths.
+server contract. `utils/workout_validation.py` applies the shared persisted-workout
+bounds: weight **0–1000 kg inclusive**, RIR **0–10 inclusive**, and minimum reps no
+greater than maximum reps. These bounds are enforced for plan add/update,
+plan-to-workout-log import, and scored-log update paths; invalid writes use the standard
+HTTP 400 `VALIDATION_ERROR` envelope. Scored-log fields retain their nullable/blank
+clear contract, while plan required-field validation continues to reject supplied blanks.
 
 ## Auth boundaries
 **No authentication exists.** Single-user local app. `POST /erase-data` (`app.py:158`) requires `{"confirm": "ERASE_ALL_DATA"}` in body; requests without it return 400. A pre-erase snapshot writes to `data/auto_backup/` before wiping. **Do not expose this app to an untrusted network.**

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to Hypertrophy Toolbox v3.
 
 ## Unreleased - May 23, 2026
 
+### Workout plan/log validation contract (Track B WPB.2)
+
+- Plan adds, plan edits, plan-to-log imports, and scored-log edits now share canonical server-side bounds: weight is **0–1000 kg inclusive**, RIR is **0–10 inclusive**, and minimum reps cannot exceed maximum reps. Invalid writes return the existing `VALIDATION_ERROR` response envelope with HTTP 400; scored-log fields remain nullable. Imports validate every source row before writing, so invalid legacy plans cannot be partially imported.
+- Migration note: clients that previously persisted weight above 1000 kg, RIR outside 0–10, or inverted rep ranges through update endpoints must correct those values before retrying. No schema or successful-response shape changed.
+
 ### Docs — CI/CD Plan Archived
 
 - Moved the completed CI/CD Improvement Plan and its per-phase council docs (Phases 0–5, shipped via PRs #40–#51) into `docs/archive/ci_cd/` (`CI_CD_IMPROVEMENT_PLAN.md` + `phase1/3/4_2/5/PLANNING.md`). The live CI artifact `docs/ci_cd_phase3/pyright-baseline.json` stays in the active tree — it is referenced by a hardcoded path in `.github/workflows/ci.yml` and `scripts/pyright_baseline_diff.py`. Repointed all references in `ci.yml`, `deep-gate.yml`, `docs/README.md`, and `docs/LEFTOVERS_BY_PRIORITY.md`. Deleted the obsolete `docs/archive/PUPPETEER_TEST_FINDINGS.md` (Puppeteer was replaced by Playwright).

--- a/docs/UI_SCENARIOS_GAP_ANALYSIS.md
+++ b/docs/UI_SCENARIOS_GAP_ANALYSIS.md
@@ -151,11 +151,11 @@ Document corrections made in this revision:
 **File**: `exercises.js`, `workout-log.js`, `workout-plan.js`
 | Scenario | Current Behavior | Status |
 |----------|------------------|--------|
-| Weight = 0 entered | Allowed for bodyweight use cases | ✅ |
+| Weight in 0–1000 kg | Inclusive server-side bound; 0 remains valid for bodyweight/assisted entries | ✅ |
 | Negative rep range | Rejected | ✅ |
-| Min rep > Max rep | Rejected with validation message | ✅ |
+| Min rep > Max rep | Rejected server-side on plan add/edit and scored-log edit | ✅ |
 | Sets = 0 | Rejected | ✅ |
-| RIR > 10 | Rejected | ✅ |
+| RIR outside 0–10 | Rejected server-side on plan add/edit and scored-log edit | ✅ |
 | RPE > 10 | Rejected | ✅ |
 
 **E2E Coverage**: ✅ Covered in [validation-boundary.spec.ts](../e2e/validation-boundary.spec.ts)

--- a/routes/exports.py
+++ b/routes/exports.py
@@ -13,6 +13,7 @@ from utils.weekly_summary import (
 )
 from utils.errors import error_response, success_response
 from utils.logger import get_logger
+from utils.workout_validation import validate_workout_bounds
 
 exports_bp = Blueprint('exports', __name__)
 logger = get_logger()
@@ -499,6 +500,19 @@ def export_to_workout_log():
                     "No exercises to export",
                     400
                 )
+
+            # Validate the full source set before inserting any log row so a
+            # legacy/out-of-band invalid plan cannot produce a partial import.
+            for exercise in workout_plan:
+                bounds_error = validate_workout_bounds(
+                    weight=exercise["weight"],
+                    rir=exercise["rir"],
+                    min_reps=exercise["min_rep_range"],
+                    max_reps=exercise["max_rep_range"],
+                    allow_null=True,
+                )
+                if bounds_error:
+                    return error_response("VALIDATION_ERROR", bounds_error, 400)
 
             exported_count = 0
             skipped_count = 0

--- a/routes/workout_log.py
+++ b/routes/workout_log.py
@@ -13,6 +13,7 @@ from utils.strength_calibration import (
     recompute_calibration_after_log,
     update_calibration_for_exercise,
 )
+from utils.workout_validation import UNSET, validate_workout_bounds
 
 workout_log_bp = Blueprint('workout_log', __name__)
 logger = get_logger()
@@ -64,10 +65,27 @@ def update_workout_log():
         calibration = None
         with DatabaseHandler() as db:
             # Check if log entry exists
-            check_query = "SELECT id, exercise FROM workout_log WHERE id = ?"
+            check_query = (
+                "SELECT id, exercise, scored_min_reps, scored_max_reps "
+                "FROM workout_log WHERE id = ?"
+            )
             existing = db.fetch_one(check_query, (log_id,))
             if not existing:
                 return error_response("NOT_FOUND", f"Workout log entry with ID {log_id} not found", 404)
+
+            min_reps = max_reps = UNSET
+            if "scored_min_reps" in valid_updates or "scored_max_reps" in valid_updates:
+                min_reps = valid_updates.get("scored_min_reps", existing["scored_min_reps"])
+                max_reps = valid_updates.get("scored_max_reps", existing["scored_max_reps"])
+            bounds_error = validate_workout_bounds(
+                weight=valid_updates.get("scored_weight", UNSET),
+                rir=valid_updates.get("scored_rir", UNSET),
+                min_reps=min_reps,
+                max_reps=max_reps,
+                allow_null=True,
+            )
+            if bounds_error:
+                return error_response("VALIDATION_ERROR", bounds_error, 400)
 
             db.execute_query(query, params)
 

--- a/routes/workout_plan.py
+++ b/routes/workout_plan.py
@@ -13,6 +13,7 @@ from routes.filters import ALLOWED_COLUMNS, validate_column_name
 from utils.constants import DIFFICULTY, MECHANIC, UTILITY, ANTAGONIST_PAIRS
 from utils.plan_generator import GENERATOR_ROUTINE_PROGRAMS, generate_starter_plan
 from utils.volume_progress import get_volume_progress
+from utils.workout_validation import UNSET, validate_workout_bounds
 
 workout_plan_bp = Blueprint('workout_plan', __name__)
 logger = get_logger()
@@ -141,6 +142,16 @@ def add_exercise():
         data = request.get_json()
         if not data:
             return error_response("VALIDATION_ERROR", "No data provided", 400)
+
+        bounds_error = validate_workout_bounds(
+            weight=data.get('weight', UNSET),
+            rir=data.get('rir', UNSET),
+            min_reps=data.get('min_rep_range', UNSET),
+            max_reps=data.get('max_rep_range', UNSET),
+            allow_null=True,
+        )
+        if bounds_error:
+            return error_response("VALIDATION_ERROR", bounds_error, 400)
         
         # Log request with context
         logger.info(
@@ -581,6 +592,29 @@ def update_exercise():
         update_fields = []
         params = []
         valid_fields = {'sets', 'min_rep_range', 'max_rep_range', 'rir', 'rpe', 'weight'}
+        bounded_updates = {key: value for key, value in updates.items() if key in valid_fields}
+
+        min_reps = max_reps = UNSET
+        if 'min_rep_range' in bounded_updates or 'max_rep_range' in bounded_updates:
+            with DatabaseHandler() as db:
+                current = db.fetch_one(
+                    "SELECT min_rep_range, max_rep_range FROM user_selection WHERE id = ?",
+                    (exercise_id,),
+                )
+            min_reps = bounded_updates.get(
+                'min_rep_range', current.get('min_rep_range', UNSET) if current else UNSET
+            )
+            max_reps = bounded_updates.get(
+                'max_rep_range', current.get('max_rep_range', UNSET) if current else UNSET
+            )
+        bounds_error = validate_workout_bounds(
+            weight=bounded_updates.get('weight', UNSET),
+            rir=bounded_updates.get('rir', UNSET),
+            min_reps=min_reps,
+            max_reps=max_reps,
+        )
+        if bounds_error:
+            return error_response("VALIDATION_ERROR", bounds_error, 400)
         
         for field, value in updates.items():
             if field in valid_fields:

--- a/tests/test_exports.py
+++ b/tests/test_exports.py
@@ -382,6 +382,7 @@ class TestExportsEndpoints:
         assert response.get_json()["error"]["code"] == "VALIDATION_ERROR"
         with DatabaseHandler() as db:
             row = db.fetch_one("SELECT COUNT(*) AS count FROM workout_log")
+        assert row is not None
         assert row["count"] == 0
     
     def test_export_to_workout_log_empty_plan(self, client, clean_database):

--- a/tests/test_exports.py
+++ b/tests/test_exports.py
@@ -341,6 +341,48 @@ class TestExportsEndpoints:
         data = json.loads(response.data)
         assert data['status'] == 'success'
         assert 'message' in data
+
+    @pytest.mark.parametrize(
+        ("weight", "rir", "minimum", "maximum"),
+        [(0, 0, 8, 8), (1000, 10, 8, 12)],
+    )
+    def test_export_to_workout_log_accepts_canonical_boundaries(
+        self, client, sample_workout_plan, weight, rir, minimum, maximum
+    ):
+        from utils.database import DatabaseHandler
+
+        with DatabaseHandler() as db:
+            db.execute_query(
+                "UPDATE user_selection SET weight = ?, rir = ?, "
+                "min_rep_range = ?, max_rep_range = ?",
+                (weight, rir, minimum, maximum),
+            )
+
+        response = client.post('/export_to_workout_log')
+        assert response.status_code == 200
+
+    @pytest.mark.parametrize(
+        ("column", "value"),
+        [
+            ("weight", -0.01), ("weight", 1000.01),
+            ("rir", -0.01), ("rir", 10.01),
+            ("min_rep_range", 13), ("max_rep_range", 7),
+        ],
+    )
+    def test_export_to_workout_log_rejects_invalid_legacy_plan_atomically(
+        self, client, sample_workout_plan, column, value
+    ):
+        from utils.database import DatabaseHandler
+
+        with DatabaseHandler() as db:
+            db.execute_query(f"UPDATE user_selection SET {column} = ?", (value,))
+
+        response = client.post('/export_to_workout_log')
+        assert response.status_code == 400
+        assert response.get_json()["error"]["code"] == "VALIDATION_ERROR"
+        with DatabaseHandler() as db:
+            row = db.fetch_one("SELECT COUNT(*) AS count FROM workout_log")
+        assert row["count"] == 0
     
     def test_export_to_workout_log_empty_plan(self, client, clean_database):
         """Test exporting empty workout plan."""

--- a/tests/test_workout_log_routes.py
+++ b/tests/test_workout_log_routes.py
@@ -248,7 +248,11 @@ class TestUpdateWorkoutLog:
 
     @pytest.mark.parametrize(
         ("field", "value"),
-        [("scored_weight", None), ("scored_rir", None), ("scored_min_reps", None)],
+        [
+            ("scored_weight", None), ("scored_weight", ""),
+            ("scored_rir", None), ("scored_rir", ""),
+            ("scored_min_reps", None), ("scored_min_reps", ""),
+        ],
     )
     def test_update_log_preserves_nullable_scored_fields(
         self, client, clean_db, workout_log_entry, field, value

--- a/tests/test_workout_log_routes.py
+++ b/tests/test_workout_log_routes.py
@@ -175,6 +175,89 @@ class TestUpdateWorkoutLog:
         })
         assert resp.status_code == 200
 
+    @pytest.mark.parametrize(
+        ("field", "value"),
+        [("scored_weight", 0), ("scored_weight", 1000), ("scored_rir", 0), ("scored_rir", 10)],
+    )
+    def test_update_log_accepts_canonical_boundaries(
+        self, client, clean_db, workout_log_entry, field, value
+    ):
+        resp = client.post("/update_workout_log", json={
+            "id": workout_log_entry["id"], "updates": {field: value},
+        })
+        assert resp.status_code == 200
+
+    @pytest.mark.parametrize(
+        ("field", "value"),
+        [
+            ("scored_weight", -0.01), ("scored_weight", 1000.01),
+            ("scored_rir", -0.01), ("scored_rir", 10.01),
+        ],
+    )
+    def test_update_log_rejects_values_outside_canonical_boundaries(
+        self, client, clean_db, workout_log_entry, field, value
+    ):
+        resp = client.post("/update_workout_log", json={
+            "id": workout_log_entry["id"], "updates": {field: value},
+        })
+        assert resp.status_code == 400
+        assert resp.get_json()["error"]["code"] == "VALIDATION_ERROR"
+
+    @pytest.mark.parametrize(
+        "updates",
+        [
+            {"scored_min_reps": 13, "scored_max_reps": 12},
+            {"scored_min_reps": 8, "scored_max_reps": 7},
+            {"scored_min_reps": 12, "scored_max_reps": 8},
+        ],
+    )
+    def test_update_log_rejects_inverted_rep_ranges(
+        self, client, clean_db, workout_log_entry, updates
+    ):
+        resp = client.post("/update_workout_log", json={
+            "id": workout_log_entry["id"], "updates": updates,
+        })
+        assert resp.status_code == 400
+
+    def test_update_log_accepts_equal_rep_range(
+        self, client, clean_db, workout_log_entry
+    ):
+        resp = client.post("/update_workout_log", json={
+            "id": workout_log_entry["id"],
+            "updates": {"scored_min_reps": 10, "scored_max_reps": 10},
+        })
+        assert resp.status_code == 200
+
+    @pytest.mark.parametrize(
+        "updates",
+        [{"scored_min_reps": 13}, {"scored_max_reps": 7}],
+    )
+    def test_update_log_validates_partial_rep_edit_against_persisted_companion(
+        self, client, clean_db, workout_log_entry, updates
+    ):
+        seeded = client.post("/update_workout_log", json={
+            "id": workout_log_entry["id"],
+            "updates": {"scored_min_reps": 8, "scored_max_reps": 12},
+        })
+        assert seeded.status_code == 200
+
+        resp = client.post("/update_workout_log", json={
+            "id": workout_log_entry["id"], "updates": updates,
+        })
+        assert resp.status_code == 400
+
+    @pytest.mark.parametrize(
+        ("field", "value"),
+        [("scored_weight", None), ("scored_rir", None), ("scored_min_reps", None)],
+    )
+    def test_update_log_preserves_nullable_scored_fields(
+        self, client, clean_db, workout_log_entry, field, value
+    ):
+        resp = client.post("/update_workout_log", json={
+            "id": workout_log_entry["id"], "updates": {field: value},
+        })
+        assert resp.status_code == 200
+
 
 class TestDeleteWorkoutLog:
     """Tests for POST /delete_workout_log endpoint."""

--- a/tests/test_workout_plan_routes.py
+++ b/tests/test_workout_plan_routes.py
@@ -138,6 +138,67 @@ class TestAddExercise:
         assert payload["ok"] is False
         assert payload["error"]["code"] == "VALIDATION_ERROR"
 
+    @pytest.mark.parametrize("weight", [0, 1000])
+    def test_add_exercise_accepts_weight_boundaries(
+        self, client, clean_db, exercise_factory, weight
+    ):
+        exercise_factory("Boundary Press")
+        resp = client.post("/add_exercise", json={
+            "routine": "Push", "exercise": "Boundary Press", "sets": 3,
+            "min_rep_range": 8, "max_rep_range": 12, "rir": 2, "weight": weight,
+        })
+        assert resp.status_code == 200
+        assert resp.get_json()["ok"] is True
+
+    @pytest.mark.parametrize("weight", [-0.01, 1000.01])
+    def test_add_exercise_rejects_weight_outside_boundaries(
+        self, client, clean_db, exercise_factory, weight
+    ):
+        exercise_factory("Boundary Press")
+        resp = client.post("/add_exercise", json={
+            "routine": "Push", "exercise": "Boundary Press", "sets": 3,
+            "min_rep_range": 8, "max_rep_range": 12, "rir": 2, "weight": weight,
+        })
+        assert resp.status_code == 400
+        assert resp.get_json()["error"]["code"] == "VALIDATION_ERROR"
+
+    @pytest.mark.parametrize("rir", [0, 10])
+    def test_add_exercise_accepts_rir_boundaries(
+        self, client, clean_db, exercise_factory, rir
+    ):
+        exercise_factory("Boundary Press")
+        resp = client.post("/add_exercise", json={
+            "routine": "Push", "exercise": "Boundary Press", "sets": 3,
+            "min_rep_range": 8, "max_rep_range": 12, "rir": rir, "weight": 100,
+        })
+        assert resp.status_code == 200
+
+    @pytest.mark.parametrize("rir", [-0.01, 10.01])
+    def test_add_exercise_rejects_rir_outside_boundaries(
+        self, client, clean_db, exercise_factory, rir
+    ):
+        exercise_factory("Boundary Press")
+        resp = client.post("/add_exercise", json={
+            "routine": "Push", "exercise": "Boundary Press", "sets": 3,
+            "min_rep_range": 8, "max_rep_range": 12, "rir": rir, "weight": 100,
+        })
+        assert resp.status_code == 400
+
+    @pytest.mark.parametrize(
+        ("minimum", "maximum", "expected_status"),
+        [(8, 8, 200), (9, 8, 400)],
+    )
+    def test_add_exercise_enforces_rep_range_order(
+        self, client, clean_db, exercise_factory, minimum, maximum, expected_status
+    ):
+        exercise_factory("Boundary Press")
+        resp = client.post("/add_exercise", json={
+            "routine": "Push", "exercise": "Boundary Press", "sets": 3,
+            "min_rep_range": minimum, "max_rep_range": maximum,
+            "rir": 2, "weight": 100,
+        })
+        assert resp.status_code == expected_status
+
 
 class TestGetExerciseDetails:
     """Tests for GET /get_exercise_details/<id> endpoint."""
@@ -419,6 +480,56 @@ class TestUpdateExercise:
             "updates": {"sets": 5}
         })
         assert resp.status_code == 400
+
+    @pytest.mark.parametrize(
+        ("field", "value"),
+        [("weight", 0), ("weight", 1000), ("rir", 0), ("rir", 10)],
+    )
+    def test_update_exercise_accepts_canonical_boundaries(
+        self, client, clean_db, workout_plan_fixture, field, value
+    ):
+        resp = client.post("/update_exercise", json={
+            "id": workout_plan_fixture["id"], "updates": {field: value},
+        })
+        assert resp.status_code == 200
+
+    @pytest.mark.parametrize(
+        ("field", "value"),
+        [("weight", -0.01), ("weight", 1000.01), ("rir", -0.01), ("rir", 10.01)],
+    )
+    def test_update_exercise_rejects_values_outside_canonical_boundaries(
+        self, client, clean_db, workout_plan_fixture, field, value
+    ):
+        resp = client.post("/update_exercise", json={
+            "id": workout_plan_fixture["id"], "updates": {field: value},
+        })
+        assert resp.status_code == 400
+        assert resp.get_json()["error"]["code"] == "VALIDATION_ERROR"
+
+    @pytest.mark.parametrize(
+        "updates",
+        [
+            {"min_rep_range": 13},
+            {"max_rep_range": 7},
+            {"min_rep_range": 12, "max_rep_range": 8},
+        ],
+    )
+    def test_update_exercise_rejects_inverted_rep_ranges(
+        self, client, clean_db, workout_plan_fixture, updates
+    ):
+        resp = client.post("/update_exercise", json={
+            "id": workout_plan_fixture["id"], "updates": updates,
+        })
+        assert resp.status_code == 400
+
+    def test_update_exercise_accepts_equal_rep_range(
+        self, client, clean_db, workout_plan_fixture
+    ):
+        resp = client.post("/update_exercise", json={
+            "id": workout_plan_fixture["id"],
+            "updates": {"min_rep_range": 10, "max_rep_range": 10},
+        })
+        assert resp.status_code == 200
 
 
 class TestUpdateExerciseOrder:

--- a/utils/constants.py
+++ b/utils/constants.py
@@ -1,6 +1,14 @@
 """Canonical constants used across the Hypertrophy Toolbox backend."""
 from __future__ import annotations
 
+# Canonical persisted workout-value bounds. Weight is stored and displayed in
+# kilograms throughout the app; 1000 kg is an intentionally generous sanity
+# ceiling that still rejects accidental extra digits.
+MIN_WORKOUT_WEIGHT_KG = 0.0
+MAX_WORKOUT_WEIGHT_KG = 1000.0
+MIN_RIR = 0.0
+MAX_RIR = 10.0
+
 MUSCLE_GROUPS = [
     "Rectus Abdominis",
     "Biceps",

--- a/utils/exercise_manager.py
+++ b/utils/exercise_manager.py
@@ -4,6 +4,7 @@ from utils.database import DatabaseHandler
 from utils.filter_predicates import FilterPredicates
 from utils.logger import get_logger
 from utils.normalization import normalize_exercise_row, split_csv
+from utils.workout_validation import validate_workout_bounds
 
 
 logger = get_logger()
@@ -36,21 +37,16 @@ class ExerciseManager:
             logger.warning("Rejecting add_exercise due to missing fields")
             return "Error: Missing required fields."
 
-        if int(min_rep_range) > int(max_rep_range):
-            logger.warning("Rejecting add_exercise: min_rep_range (%s) > max_rep_range (%s)", min_rep_range, max_rep_range)
-            return "Error: Min rep range cannot exceed max rep range."
-
-        if rir is not None and int(rir) < 0:
-            logger.warning("Rejecting add_exercise: negative RIR (%s)", rir)
-            return "Error: RIR cannot be negative."
-
-        if float(weight) < 0:
-            logger.warning("Rejecting add_exercise: negative weight (%s)", weight)
-            return "Error: Weight cannot be negative."
-
-        if float(weight) > 1000:
-            logger.warning("Rejecting add_exercise: unreasonable weight (%s)", weight)
-            return "Error: Weight exceeds maximum allowed value (1000)."
+        bounds_error = validate_workout_bounds(
+            weight=weight,
+            rir=rir,
+            min_reps=min_rep_range,
+            max_reps=max_rep_range,
+            allow_null=True,
+        )
+        if bounds_error:
+            logger.warning("Rejecting add_exercise: %s", bounds_error)
+            return f"Error: {bounds_error}"
 
         duplicate_check_query = (
             "SELECT COUNT(*) AS count FROM user_selection WHERE routine = ? AND exercise = ?"

--- a/utils/workout_validation.py
+++ b/utils/workout_validation.py
@@ -1,0 +1,82 @@
+"""Shared validation for persisted workout-plan and workout-log values."""
+from __future__ import annotations
+
+import math
+from typing import Any, Optional
+
+from utils.constants import (
+    MAX_RIR,
+    MAX_WORKOUT_WEIGHT_KG,
+    MIN_RIR,
+    MIN_WORKOUT_WEIGHT_KG,
+)
+
+
+UNSET = object()
+
+
+def _number(value: Any, field_label: str) -> tuple[Optional[float], Optional[str]]:
+    """Coerce a JSON numeric value while rejecting booleans and non-finite values."""
+    if isinstance(value, bool):
+        return None, f"{field_label} must be a finite number."
+    try:
+        number = float(value)
+    except (TypeError, ValueError):
+        return None, f"{field_label} must be a finite number."
+    if not math.isfinite(number):
+        return None, f"{field_label} must be a finite number."
+    return number, None
+
+
+def validate_workout_bounds(
+    *,
+    weight: Any = UNSET,
+    rir: Any = UNSET,
+    min_reps: Any = UNSET,
+    max_reps: Any = UNSET,
+    allow_null: bool = False,
+) -> Optional[str]:
+    """Return a validation message, or ``None`` when canonical bounds hold.
+
+    ``UNSET`` distinguishes an omitted partial-update field from an explicit
+    JSON null. Scored log values are nullable, while bounded plan values are
+    not nullable when supplied.
+    """
+    numeric_values: dict[str, Optional[float]] = {}
+    for key, value, label in (
+        ("weight", weight, "Weight"),
+        ("rir", rir, "RIR"),
+        ("min_reps", min_reps, "Minimum reps"),
+        ("max_reps", max_reps, "Maximum reps"),
+    ):
+        if value is UNSET:
+            continue
+        if value is None and allow_null:
+            numeric_values[key] = None
+            continue
+        if value is None:
+            return f"{label} cannot be null."
+        number, error = _number(value, label)
+        if error:
+            return error
+        numeric_values[key] = number
+
+    parsed_weight = numeric_values.get("weight")
+    if parsed_weight is not None and not (
+        MIN_WORKOUT_WEIGHT_KG <= parsed_weight <= MAX_WORKOUT_WEIGHT_KG
+    ):
+        return (
+            f"Weight must be between {MIN_WORKOUT_WEIGHT_KG:g} and "
+            f"{MAX_WORKOUT_WEIGHT_KG:g} kg."
+        )
+
+    parsed_rir = numeric_values.get("rir")
+    if parsed_rir is not None and not (MIN_RIR <= parsed_rir <= MAX_RIR):
+        return f"RIR must be between {MIN_RIR:g} and {MAX_RIR:g}."
+
+    parsed_min = numeric_values.get("min_reps")
+    parsed_max = numeric_values.get("max_reps")
+    if parsed_min is not None and parsed_max is not None and parsed_min > parsed_max:
+        return "Minimum reps cannot exceed maximum reps."
+
+    return None

--- a/utils/workout_validation.py
+++ b/utils/workout_validation.py
@@ -39,8 +39,8 @@ def validate_workout_bounds(
     """Return a validation message, or ``None`` when canonical bounds hold.
 
     ``UNSET`` distinguishes an omitted partial-update field from an explicit
-    JSON null. Scored log values are nullable, while bounded plan values are
-    not nullable when supplied.
+    JSON null. Scored log values are nullable/blank, while bounded plan values
+    are not nullable when supplied.
     """
     numeric_values: dict[str, Optional[float]] = {}
     for key, value, label in (
@@ -51,7 +51,7 @@ def validate_workout_bounds(
     ):
         if value is UNSET:
             continue
-        if value is None and allow_null:
+        if allow_null and (value is None or value == ""):
             numeric_values[key] = None
             continue
         if value is None:


### PR DESCRIPTION
## Summary
- centralize canonical persisted workout bounds: weight 0–1000 kg inclusive, RIR 0–10 inclusive, and minimum reps <= maximum reps
- enforce them on plan add/edit, plan-to-log import, and scored-log edit paths with the existing HTTP 400 `VALIDATION_ERROR` envelope
- validate all import source rows before writes so invalid legacy plans cannot partially populate the log; preserve nullable scored-log fields
- add boundary/partial-update/atomic-import regression coverage and update validation/migration documentation

## Migration notes
Clients that previously persisted weight above 1000 kg, RIR outside 0–10, or inverted rep ranges must correct those values before retrying. Plan-to-log import now rejects an invalid legacy source plan before inserting any row. Successful response shapes and the database schema are unchanged; scored-log fields remain nullable.

## Verification
- `python -m pytest tests/test_exercise_manager.py tests/test_workout_plan_routes.py tests/test_workout_log_routes.py -q` -> 164 passed
- `python -m pytest tests/test_exports.py -q -k "export_to_workout_log"` -> 10 passed, 43 deselected
- post-rebase focused boundary gate -> 37 passed, 90 deselected
- `npx playwright test e2e/workout-plan.spec.ts e2e/workout-log.spec.ts e2e/validation-boundary.spec.ts --project=chromium --reporter=line` -> 81 passed

Base rebased onto `origin/main@c0d5c38` before push.