### PR TITLE
test(refactor): close Phase -1 characterization gaps

### DIFF
--- a/e2e/body-composition.spec.ts
+++ b/e2e/body-composition.spec.ts
@@ -5,6 +5,7 @@
  */
 import type { Page } from '@playwright/test';
 import { test, expect, waitForPageReady } from './fixtures';
+import parityCases from './fixtures/body-fat-parity.json';
 
 const ROUTE = '/body_composition';
 
@@ -124,4 +125,37 @@ test.describe('Body Composition page', () => {
     // Python formulas have drifted.
     expect(Math.abs(previewValue - Number(snap.bfp_navy.toFixed(1)))).toBeLessThanOrEqual(0.05);
   });
+
+  for (const parityCase of parityCases) {
+    test(`shared JS/Python parity: ${parityCase.id}`, async ({ page }) => {
+      const profileResp = await page.request.post('/api/user_profile', {
+        data: {
+          gender: parityCase.profile.gender,
+          age: parityCase.profile.age,
+          height_cm: parityCase.profile.height_cm,
+          weight_kg: parityCase.profile.weight_kg,
+          experience_years: 5,
+        },
+      });
+      expect(profileResp.ok(), 'parity profile seed must succeed').toBeTruthy();
+
+      await page.goto(ROUTE);
+      await waitForPageReady(page);
+      if (parityCase.tape) {
+        await page.locator('#bc-neck').fill(String(parityCase.tape.neck_cm));
+        await page.locator('#bc-waist').fill(String(parityCase.tape.waist_cm));
+        if ('hip_cm' in parityCase.tape) {
+          await page.locator('#bc-hip').fill(String(parityCase.tape.hip_cm));
+        }
+      }
+
+      await expect(page.locator('[data-bc-method-label]')).toHaveText(parityCase.expected.method);
+      await expect(page.locator('[data-bc-bfp]')).toHaveText(`${parityCase.expected.bfp.toFixed(1)} %`);
+      await expect(page.locator('[data-bc-bmi]')).toHaveText(parityCase.expected.bmi.toFixed(1));
+      await expect(page.locator('[data-bc-band-label]')).toHaveText(parityCase.expected.ace);
+      await expect(page.locator('[data-bc-jp-ideal]')).toHaveText(
+        `${parityCase.expected.jackson_pollock_ideal.toFixed(1)} %`,
+      );
+    });
+  }
 });

--- a/e2e/fixtures/body-fat-parity.json
+++ b/e2e/fixtures/body-fat-parity.json
@@ -1,0 +1,26 @@
+[
+  {
+    "id": "male-navy-adult",
+    "profile": {"gender": "M", "age": 34, "height_cm": 180, "weight_kg": 80},
+    "tape": {"neck_cm": 38, "waist_cm": 85},
+    "expected": {"method": "U.S. Navy method", "bfp": 16.1, "bmi": 24.7, "ace": "Fitness", "jackson_pollock_ideal": 13.5}
+  },
+  {
+    "id": "female-navy-adult",
+    "profile": {"gender": "F", "age": 42, "height_cm": 165, "weight_kg": 60},
+    "tape": {"neck_cm": 32, "waist_cm": 70, "hip_cm": 95},
+    "expected": {"method": "U.S. Navy method", "bfp": 24.9, "bmi": 22.0, "ace": "Fitness", "jackson_pollock_ideal": 22.5}
+  },
+  {
+    "id": "male-bmi-minor",
+    "profile": {"gender": "M", "age": 14, "height_cm": 160, "weight_kg": 50},
+    "tape": null,
+    "expected": {"method": "BMI method (fallback)", "bfp": 17.5, "bmi": 19.5, "ace": "Fitness", "jackson_pollock_ideal": 8.5}
+  },
+  {
+    "id": "female-bmi-older-adult",
+    "profile": {"gender": "F", "age": 60, "height_cm": 165, "weight_kg": 70},
+    "tape": null,
+    "expected": {"method": "BMI method (fallback)", "bfp": 39.3, "bmi": 25.7, "ace": "Obese", "jackson_pollock_ideal": 26.3}
+  }
+]

--- a/tests/test_auto_backup.py
+++ b/tests/test_auto_backup.py
@@ -8,8 +8,12 @@ response contract can be exercised without touching a real database file.
 """
 from __future__ import annotations
 
+import os
 from pathlib import Path
+import sqlite3
 
+import utils.auto_backup as auto_backup
+import utils.config
 from utils.auto_backup import describe_snapshot
 
 
@@ -30,3 +34,91 @@ def test_describe_snapshot_strips_directory_regardless_of_path_shape():
     result = describe_snapshot("/some/absolute/dir/database_20260101_000000.db")
 
     assert result == {"filename": "database_20260101_000000.db"}
+
+
+def _seed_exercises(db_path: Path, count: int) -> None:
+    with sqlite3.connect(db_path) as conn:
+        conn.execute("CREATE TABLE exercises (exercise_name TEXT PRIMARY KEY)")
+        conn.executemany(
+            "INSERT INTO exercises (exercise_name) VALUES (?)",
+            [(f"Exercise {index}",) for index in range(count)],
+        )
+
+
+def test_create_startup_backup_skips_in_test_mode(tmp_path, monkeypatch):
+    live_db = tmp_path / "database.db"
+    _seed_exercises(live_db, auto_backup.MIN_EXERCISES_TO_BACKUP)
+    monkeypatch.setattr(utils.config, "DB_FILE", str(live_db))
+    monkeypatch.setenv("TESTING", "1")
+
+    assert auto_backup.create_startup_backup() is None
+    assert not (tmp_path / auto_backup.AUTO_BACKUP_DIRNAME).exists()
+
+
+def test_create_startup_backup_skips_missing_sparse_and_invalid_databases(
+    tmp_path, monkeypatch
+):
+    monkeypatch.delenv("TESTING", raising=False)
+
+    missing = tmp_path / "missing.db"
+    monkeypatch.setattr(utils.config, "DB_FILE", str(missing))
+    assert auto_backup.create_startup_backup() is None
+
+    sparse = tmp_path / "sparse.db"
+    _seed_exercises(sparse, auto_backup.MIN_EXERCISES_TO_BACKUP - 1)
+    monkeypatch.setattr(utils.config, "DB_FILE", str(sparse))
+    assert auto_backup.create_startup_backup() is None
+
+    invalid = tmp_path / "invalid.db"
+    with sqlite3.connect(invalid) as conn:
+        conn.execute("CREATE TABLE something_else (id INTEGER)")
+    monkeypatch.setattr(utils.config, "DB_FILE", str(invalid))
+    assert auto_backup.create_startup_backup() is None
+    assert not (tmp_path / auto_backup.AUTO_BACKUP_DIRNAME).exists()
+
+
+def test_create_startup_backup_copies_database_and_rotates_old_snapshots(
+    tmp_path, monkeypatch
+):
+    live_db = tmp_path / "database.db"
+    _seed_exercises(live_db, auto_backup.MIN_EXERCISES_TO_BACKUP)
+    backup_dir = tmp_path / auto_backup.AUTO_BACKUP_DIRNAME
+    backup_dir.mkdir()
+    old_paths = []
+    for index in range(auto_backup.AUTO_BACKUP_KEEP):
+        path = backup_dir / f"database_20000101_00000{index}.db"
+        path.write_bytes(b"old")
+        os.utime(path, (index + 1, index + 1))
+        old_paths.append(path)
+
+    monkeypatch.delenv("TESTING", raising=False)
+    monkeypatch.setattr(utils.config, "DB_FILE", str(live_db))
+
+    snapshot = auto_backup.create_startup_backup()
+
+    assert snapshot is not None
+    assert snapshot.parent == backup_dir
+    assert snapshot.name.startswith("database_")
+    assert snapshot.suffix == ".db"
+    with sqlite3.connect(snapshot) as conn:
+        count = conn.execute("SELECT COUNT(*) FROM exercises").fetchone()[0]
+    assert count == auto_backup.MIN_EXERCISES_TO_BACKUP
+    snapshots = list(backup_dir.glob("database_*.db"))
+    assert len(snapshots) == auto_backup.AUTO_BACKUP_KEEP
+    assert not old_paths[0].exists()
+
+
+def test_create_startup_backup_returns_none_when_sqlite_open_fails(
+    tmp_path, monkeypatch
+):
+    live_db = tmp_path / "database.db"
+    live_db.touch()
+    monkeypatch.delenv("TESTING", raising=False)
+    monkeypatch.setattr(utils.config, "DB_FILE", str(live_db))
+
+    def fail_connect(_path):
+        raise sqlite3.OperationalError("forced open failure")
+
+    monkeypatch.setattr(auto_backup.sqlite3, "connect", fail_connect)
+
+    assert auto_backup.create_startup_backup() is None

--- a/tests/test_body_fat.py
+++ b/tests/test_body_fat.py
@@ -6,6 +6,9 @@ and small rounding differences are expected across implementations.
 """
 from __future__ import annotations
 
+import json
+from pathlib import Path
+
 import pytest
 
 from utils.body_fat import (
@@ -14,6 +17,41 @@ from utils.body_fat import (
     compute_navy,
     jackson_pollock_ideal,
 )
+
+
+PARITY_FIXTURE = (
+    Path(__file__).resolve().parents[1] / "e2e" / "fixtures" / "body-fat-parity.json"
+)
+
+
+def test_shared_js_python_parity_fixture_matches_all_four_public_functions():
+    cases = json.loads(PARITY_FIXTURE.read_text(encoding="utf-8"))
+    assert cases
+
+    for case in cases:
+        profile = case["profile"]
+        expected = case["expected"]
+        bmi = compute_bmi(
+            gender=profile["gender"],
+            age_years=profile["age"],
+            height_cm=profile["height_cm"],
+            bodyweight_kg=profile["weight_kg"],
+        )
+        if case["tape"] is None:
+            effective_bfp = bmi["bfp"]
+        else:
+            effective_bfp = compute_navy(
+                gender=profile["gender"],
+                height_cm=profile["height_cm"],
+                **case["tape"],
+            )
+
+        assert round(effective_bfp, 1) == expected["bfp"], case["id"]
+        assert round(bmi["bmi"], 1) == expected["bmi"], case["id"]
+        assert ace_category(effective_bfp, profile["gender"]) == expected["ace"], case["id"]
+        assert round(jackson_pollock_ideal(profile["age"], profile["gender"]), 1) == expected[
+            "jackson_pollock_ideal"
+        ], case["id"]
 
 
 # -- compute_navy -----------------------------------------------------------

--- a/tests/test_exercise_media.py
+++ b/tests/test_exercise_media.py
@@ -1,0 +1,91 @@
+"""Direct characterization of exercise-media fallback and fuzzy matching."""
+
+import utils.exercise_media as exercise_media
+
+
+def _clear_caches() -> None:
+    exercise_media._load_catalog_media_entries.cache_clear()
+    exercise_media._load_fallback_media_map.cache_clear()
+    exercise_media._resolve_fuzzy_media_path.cache_clear()
+
+
+def setup_function():
+    _clear_caches()
+
+
+def teardown_function():
+    _clear_caches()
+
+
+def test_match_key_normalizes_phrases_drops_noise_and_singularizes():
+    assert (
+        exercise_media._match_key(" Dumbbell Pull-Ups — 45 Degrees Supported ")
+        == "dumbbell pull ups"
+    )
+    assert exercise_media._match_key(None) == ""
+
+
+def test_score_candidate_requires_two_shared_tokens_and_rewards_exact_match():
+    assert exercise_media._score_candidate(["bench"], "bench press") == 0.0
+    assert exercise_media._score_candidate(["bench", "press"], "bench press") == 1.0
+    partial = exercise_media._score_candidate(
+        ["incline", "dumbbell", "press"], "incline dumbbell bench press"
+    )
+    assert exercise_media.MIN_FUZZY_SCORE <= partial < 1.0
+
+
+def test_valid_database_media_path_wins_without_loading_fallbacks(monkeypatch):
+    def unexpected_load():
+        raise AssertionError("fallback lookup should not run")
+
+    monkeypatch.setattr(exercise_media, "_load_fallback_media_map", unexpected_load)
+
+    assert (
+        exercise_media.resolve_exercise_media_path(
+            "Anything", "Existing_Reviewed_Path/0.jpg"
+        )
+        == "Existing_Reviewed_Path/0.jpg"
+    )
+
+
+def test_invalid_database_path_uses_exact_reviewed_fallback(monkeypatch):
+    monkeypatch.setattr(
+        exercise_media,
+        "_load_fallback_media_map",
+        lambda: {"barbell bench press": "Bench_Press/0.jpg"},
+    )
+
+    assert (
+        exercise_media.resolve_exercise_media_path(
+            "  Barbell BENCH Press ", "../unsafe.jpg"
+        )
+        == "Bench_Press/0.jpg"
+    )
+
+
+def test_fuzzy_fallback_selects_best_catalog_candidate(monkeypatch):
+    monkeypatch.setattr(exercise_media, "_load_fallback_media_map", lambda: {})
+    monkeypatch.setattr(
+        exercise_media,
+        "_load_catalog_media_entries",
+        lambda: (
+            ("Incline Dumbbell Bench Press", "incline dumbbell bench press", "Incline/0.jpg"),
+            ("Seated Cable Row", "seated cable row", "Row/0.jpg"),
+        ),
+    )
+
+    assert (
+        exercise_media.resolve_exercise_media_path("Incline Dumbbell Press")
+        == "Incline/0.jpg"
+    )
+
+
+def test_fuzzy_fallback_returns_none_below_threshold(monkeypatch):
+    monkeypatch.setattr(exercise_media, "_load_fallback_media_map", lambda: {})
+    monkeypatch.setattr(
+        exercise_media,
+        "_load_catalog_media_entries",
+        lambda: (("Seated Cable Row", "seated cable row", "Row/0.jpg"),),
+    )
+
+    assert exercise_media.resolve_exercise_media_path("Barbell Curl") is None

--- a/tests/test_lift_matching.py
+++ b/tests/test_lift_matching.py
@@ -1,0 +1,30 @@
+"""Direct characterization of the shared lift-name matching contract."""
+
+from utils.lift_matching import DIRECT_LIFT_MATCHERS, match_direct_lift_key
+
+
+def test_every_declared_keyword_resolves_to_its_declared_lift_key():
+    for keyword, lift_key in DIRECT_LIFT_MATCHERS:
+        assert match_direct_lift_key(keyword) == lift_key, keyword
+
+
+def test_specific_variants_precede_broader_substring_fallbacks():
+    cases = {
+        "Weighted Pull Up": "weighted_pullups",
+        "Leg Press Calf Raise": "leg_press_calf_raise",
+        "Reverse Lunge": "reverse_lunge",
+        "B-Stance Hip Thrust": "b_stance_hip_thrust",
+        "Loaded Back Extension": "loaded_back_extension",
+        "Seated Good Morning": "seated_good_morning",
+    }
+
+    assert list(cases)  # make an accidentally emptied characterization fail loudly
+    for exercise_name, expected in cases.items():
+        assert match_direct_lift_key(exercise_name) == expected
+
+
+def test_matching_is_case_insensitive_substring_based_and_empty_safe():
+    assert match_direct_lift_key("Tempo BARBELL BACK SQUAT (Paused)") == "barbell_back_squat"
+    assert match_direct_lift_key("Cable movement with no reference lift") is None
+    assert match_direct_lift_key("") is None
+    assert match_direct_lift_key(None) is None  # type: ignore[arg-type]

--- a/tests/test_profile_estimator_contract.py
+++ b/tests/test_profile_estimator_contract.py
@@ -1,0 +1,89 @@
+"""Stable import/export contracts required before profile_estimator is split."""
+
+from __future__ import annotations
+
+import subprocess
+import sys
+
+import pytest
+
+import utils.lift_matching as lift_matching
+import utils.profile_estimator as profile_estimator
+
+
+SUPPORTED_ESTIMATOR_EXPORTS = {
+    "ACCURACY_MAJOR_MUSCLE_GROUPS",
+    "ADVANCED_COHORT_REACH",
+    "BODYMAP_MUSCLE_KEYS",
+    "DEFAULT_ESTIMATE",
+    "DEFAULT_PREFERENCES",
+    "DIRECT_LIFT_MATCHERS",
+    "DUMBBELL_LIFT_KEYS",
+    "EXPERIENCE_MULTIPLIERS",
+    "KEY_LIFTS",
+    "KEY_LIFT_LABELS",
+    "KEY_LIFT_SIDE",
+    "KEY_LIFT_TIER",
+    "MUSCLE_TO_KEY_LIFT",
+    "REP_RANGE_PRESETS",
+    "_load_basis_factor",
+    "_match_direct_lift_key",
+    "accuracy_band",
+    "classify_tier",
+    "cohort_bars",
+    "cohort_ranges",
+    "cold_start_1rm",
+    "cold_start_anchor_lifts",
+    "coverage_donut",
+    "epley_1rm",
+    "estimate_for_exercise",
+    "match_direct_lift_key",
+    "muscle_coverage_state",
+    "next_high_impact_lifts",
+    "replaced_anchor_lifts",
+    "round_weight",
+}
+
+
+def test_supported_estimator_export_surface_is_present():
+    missing = SUPPORTED_ESTIMATOR_EXPORTS - vars(profile_estimator).keys()
+    assert not missing, f"profile_estimator dropped supported exports: {sorted(missing)}"
+
+
+def test_lift_matching_aliases_preserve_object_identity():
+    assert profile_estimator.DIRECT_LIFT_MATCHERS is lift_matching.DIRECT_LIFT_MATCHERS
+    assert profile_estimator.match_direct_lift_key is lift_matching.match_direct_lift_key
+    assert profile_estimator._match_direct_lift_key is lift_matching.match_direct_lift_key
+
+
+@pytest.mark.parametrize(
+    "first, second",
+    [
+        ("utils.profile_estimator", "utils.strength_calibration"),
+        ("utils.strength_calibration", "utils.profile_estimator"),
+    ],
+)
+def test_profile_estimator_and_calibration_import_in_either_order(first, second):
+    script = f"""
+import importlib
+import sys
+
+first = importlib.import_module({first!r})
+second = importlib.import_module({second!r})
+profile = importlib.import_module('utils.profile_estimator')
+calibration = importlib.import_module('utils.strength_calibration')
+matching = importlib.import_module('utils.lift_matching')
+
+assert profile.epley_1rm is calibration.epley_1rm
+assert profile.match_direct_lift_key is matching.match_direct_lift_key
+assert profile._match_direct_lift_key is matching.match_direct_lift_key
+assert 'utils.profile_estimator' in sys.modules
+assert 'utils.strength_calibration' in sys.modules
+"""
+    result = subprocess.run(
+        [sys.executable, "-c", script],
+        text=True,
+        capture_output=True,
+        check=False,
+    )
+    assert result.returncode == 0, result.stderr


### PR DESCRIPTION
## Summary
- add direct characterization for startup backups, lift matching, and exercise media
- lock profile-estimator export/alias/import-order contracts before the staged split
- share four-function body-fat parity cases between pytest and Playwright

## Verification
- focused pytest: startup backup + body fat + media + lift matching + estimator contracts
- TypeScript: npx tsc --noEmit
- body-composition browser coverage is included in CI; local browser run was skipped because another isolated worktree owned port 5000

No production behavior, schema, API, or calculation changes.