### PR TITLE
test(e2e): replace vacuous Phase -1 assertions

### DIFF
--- a/e2e/empty-states.spec.ts
+++ b/e2e/empty-states.spec.ts
@@ -56,27 +56,19 @@ test.describe('Empty Workout Plan - Export', () => {
     
     const rows = await page.locator('#workout_plan_table_body tr').count();
     
-    if (rows === 0) {
-      const exportBtn = page.locator(SELECTORS.EXPORT_EXCEL_BTN);
-      
-      if (await exportBtn.isVisible()) {
-        // Track if download started
-        let downloadStarted = false;
-        page.on('download', () => {
-          downloadStarted = true;
-        });
-        
-        await exportBtn.click();
-        await page.waitForTimeout(1000);
-        
-        // Should either show warning toast OR not trigger download
-        const toast = page.locator('.toast, #liveToast');
-        const toastVisible = await toast.isVisible().catch(() => false);
-        
-        // Either warning shown OR no download happens
-        expect(toastVisible || !downloadStarted).toBeTruthy();
-      }
-    }
+    expect(rows).toBe(0);
+    const exportBtn = page.locator(SELECTORS.EXPORT_EXCEL_BTN);
+    await expect(exportBtn).toBeVisible();
+
+    let downloadStarted = false;
+    page.on('download', () => {
+      downloadStarted = true;
+    });
+
+    await exportBtn.click();
+    await expect(page.locator('#liveToast')).toBeVisible();
+    await expect(page.locator('#toast-body')).toContainText('No exercises to export');
+    expect(downloadStarted).toBe(false);
   });
 
   test('export to log with empty plan shows helpful message', async ({ page }) => {
@@ -85,29 +77,12 @@ test.describe('Empty Workout Plan - Export', () => {
     
     const rows = await page.locator('#workout_plan_table_body tr').count();
     
-    if (rows === 0) {
-      const exportToLogBtn = page.locator(SELECTORS.EXPORT_TO_LOG_BTN);
-      
-      if (await exportToLogBtn.isVisible()) {
-        await exportToLogBtn.click();
-        await page.waitForTimeout(1000);
-        
-        // Should show message about empty plan
-        const toast = page.locator('.toast, #liveToast');
-        const toastVisible = await toast.isVisible().catch(() => false);
-        
-        if (toastVisible) {
-          const toastText = await page.locator('#toast-body, .toast-body').textContent();
-          // Should mention empty or no exercises
-          expect(
-            toastText?.toLowerCase().includes('empty') ||
-            toastText?.toLowerCase().includes('no exercise') ||
-            toastText?.toLowerCase().includes('add') ||
-            true
-          ).toBeTruthy();
-        }
-      }
-    }
+    expect(rows).toBe(0);
+    const exportToLogBtn = page.locator(SELECTORS.EXPORT_TO_LOG_BTN);
+    await expect(exportToLogBtn).toBeVisible();
+    await exportToLogBtn.click();
+    await expect(page.locator('#liveToast')).toBeVisible();
+    await expect(page.locator('#toast-body')).toContainText('No exercises to export');
   });
 });
 
@@ -165,30 +140,16 @@ test.describe('Empty Workout Log Operations', () => {
       await page.waitForTimeout(1000);
       
       // Should show message about no exercises to import
-      const toast = page.locator('.toast, #liveToast');
-      const toastVisible = await toast.isVisible().catch(() => false);
-      
-      // Either toast shown or page remains functional
-      await expect(page.locator('h1')).toContainText('Workout Log');
+      await expect(page.locator('#liveToast')).toBeVisible();
+      await expect(page.locator('#toast-body')).toContainText(/no exercises|empty/i);
     }
   });
 
   test('empty log table shows appropriate message', async ({ page }) => {
     const table = page.locator('.workout-log-table');
     
-    if (await table.isVisible()) {
-      const rows = await table.locator('tbody tr').count();
-      
-      // If no data rows, should show empty state
-      if (rows === 0) {
-        // Look for empty state message
-        const emptyMessage = page.locator('.empty-state, .no-data, td[colspan]');
-        const messageVisible = await emptyMessage.isVisible().catch(() => false);
-        
-        // Either shows empty message or table is simply empty
-        expect(messageVisible || rows === 0).toBeTruthy();
-      }
-    }
+    await expect(table).toBeVisible();
+    await expect(table.locator('tbody tr')).toHaveCount(0);
   });
 });
 
@@ -217,11 +178,8 @@ test.describe('Empty Filter Results', () => {
         await muscleFilter.selectOption(unusedMuscle);
         await page.waitForTimeout(500);
         
-        // Check table for empty state
-        const visibleRows = await page.locator('#workout_plan_table_body tr:visible').count();
-        
-        // Either shows 0 rows or empty message
-        expect(visibleRows >= 0).toBeTruthy();
+        await expect(muscleFilter.locator('option:checked')).toHaveText(unusedMuscle);
+        await expect(page.locator('#workout_plan_table_body')).toBeAttached();
       }
     }
   });
@@ -260,7 +218,7 @@ test.describe('Empty Summary Pages', () => {
     
     // Check for empty state or data display
     const container = page.locator(SELECTORS.PAGE_WEEKLY_SUMMARY);
-    await expect(container).toBeVisible({ timeout: 5000 }).catch(() => {});
+    await expect(container).toBeVisible({ timeout: 5000 });
     
     // Page should not crash
     await expect(page.locator('h1')).toContainText(/summary|weekly/i);
@@ -275,7 +233,7 @@ test.describe('Empty Summary Pages', () => {
     
     // Check for empty state or data display
     const container = page.locator(SELECTORS.PAGE_SESSION_SUMMARY);
-    await expect(container).toBeVisible({ timeout: 5000 }).catch(() => {});
+    await expect(container).toBeVisible({ timeout: 5000 });
     
     // Page should not crash
     await expect(page.locator('h1')).toContainText(/summary|session/i);
@@ -313,29 +271,12 @@ test.describe('Empty Progression Plan', () => {
     }
   });
 
-  test('selecting exercise with no progression data shows appropriate message', async ({ page }) => {
+  test('suggestions stay hidden when no exercise can be selected', async ({ page }) => {
     const exerciseSelector = page.locator('#exerciseSelect');
     
     if (await exerciseSelector.isVisible()) {
-      const options = exerciseSelector.locator('option');
-      const optionCount = await options.count();
-      let exerciseValue: string | null = null;
-
-      if (optionCount > 1) {
-        exerciseValue = await options.nth(1).getAttribute('value');
-      }
-
-      if (exerciseValue) {
-        await exerciseSelector.selectOption(exerciseValue);
-        await page.waitForTimeout(500);
-        
-        // Should show suggestions or empty state
-        const suggestionsContainer = page.locator('#suggestionsContainer');
-        const goalsTable = page.locator('.current-goals table');
-        
-        // Either shows data or appropriate empty state
-        expect(true).toBeTruthy();
-      }
+      await expect(exerciseSelector.locator('option')).toHaveCount(1);
+      await expect(page.locator('#suggestionsContainer')).toBeHidden();
     }
   });
 });
@@ -351,18 +292,17 @@ test.describe('Empty Volume Splitter', () => {
     consoleErrors.assertNoErrors();
   });
 
-  test('calculate with no input shows validation message', async ({ page }) => {
+  test('calculate with untouched inputs returns current default results', async ({ page }) => {
     const calculateBtn = page.locator(SELECTORS.CALCULATE_VOLUME_BTN);
     
     if (await calculateBtn.isVisible()) {
+      const responsePromise = page.waitForResponse(response =>
+        response.url().endsWith('/api/calculate_volume') && response.request().method() === 'POST'
+      );
       await calculateBtn.click();
-      await page.waitForTimeout(500);
-      
-      // Should show validation message
-      const toast = page.locator('.toast, #liveToast, .alert-danger, .invalid-feedback');
-      const messageVisible = await toast.isVisible().catch(() => false);
-      
-      expect(messageVisible || true).toBeTruthy();
+      const response = await responsePromise;
+      expect(response.status()).toBe(200);
+      expect((await response.json()).ok).toBe(true);
     }
   });
 
@@ -378,18 +318,14 @@ test.describe('Empty Volume Splitter', () => {
     }
   });
 
-  test('export empty volume results shows warning', async ({ page }) => {
+  test('export untouched volume inputs downloads a workbook', async ({ page }) => {
     const exportBtn = page.locator(SELECTORS.EXPORT_VOLUME_EXCEL_BTN);
     
     if (await exportBtn.isVisible()) {
+      const downloadPromise = page.waitForEvent('download');
       await exportBtn.click();
-      await page.waitForTimeout(1000);
-      
-      // Should show warning or not trigger download
-      const toast = page.locator('.toast, #liveToast');
-      const toastVisible = await toast.isVisible().catch(() => false);
-      
-      expect(toastVisible || true).toBeTruthy();
+      const download = await downloadPromise;
+      expect(download.suggestedFilename()).toMatch(/^volume_plan_\d{4}-\d{2}-\d{2}\.xlsx$/);
     }
   });
 });
@@ -408,18 +344,7 @@ test.describe('Table Empty State Messages', () => {
     const tableBody = page.locator('#workout_plan_table_body');
     const rows = await tableBody.locator('tr').count();
     
-    if (rows === 0 || rows === 1) {
-      // Check for empty state row or message
-      const emptyRow = tableBody.locator('tr td[colspan]');
-      const emptyMessage = tableBody.locator('.empty-state, .no-exercises');
-      
-      const hasEmptyIndicator = 
-        (await emptyRow.count()) > 0 ||
-        (await emptyMessage.count()) > 0 ||
-        rows === 0;
-      
-      expect(hasEmptyIndicator).toBeTruthy();
-    }
+    expect(rows).toBe(0);
     
     consoleErrors.assertNoErrors();
   });
@@ -431,12 +356,8 @@ test.describe('Table Empty State Messages', () => {
     
     const tableBody = page.locator('.workout-log-table tbody');
     
-    if (await tableBody.isVisible()) {
-      const rows = await tableBody.locator('tr').count();
-      
-      // Either has data or empty state
-      expect(rows >= 0).toBeTruthy();
-    }
+    await expect(tableBody).toBeAttached();
+    await expect(tableBody.locator('tr')).toHaveCount(0);
     
     consoleErrors.assertNoErrors();
   });

--- a/e2e/exercise-interactions.spec.ts
+++ b/e2e/exercise-interactions.spec.ts
@@ -150,7 +150,7 @@ test.describe('Exercise Delete Functionality', () => {
     }
   });
 
-  test('clicking delete shows confirmation', async ({ page }) => {
+  test('clicking delete sends the remove request', async ({ page }) => {
     await selectRoutine(page);
     await page.waitForSelector('#workout_plan_table_body tr');
 
@@ -159,17 +159,12 @@ test.describe('Exercise Delete Functionality', () => {
 
     if (count > 0) {
       const deleteBtn = rows.first().locator('button[data-action="delete"], .delete-btn, .btn-danger');
+      const responsePromise = page.waitForResponse(response =>
+        response.url().endsWith('/remove_exercise') && response.request().method() === 'POST'
+      );
       await deleteBtn.click();
-
-      // Either confirm modal appears or browser confirm
-      await page.waitForTimeout(500);
-      
-      // Check for modal or proceed with deletion
-      const confirmModal = page.locator('.modal.show, [role="dialog"]:visible');
-      const isModalVisible = await confirmModal.isVisible().catch(() => false);
-      
-      // Test passes - delete action was triggered
-      expect(true).toBe(true);
+      const response = await responsePromise;
+      expect(response.status()).toBe(200);
     }
   });
 
@@ -221,9 +216,8 @@ test.describe('Replace Exercise Functionality', () => {
 
     if (count > 0) {
       const replaceBtn = rows.first().locator('button[data-action="replace"], .replace-btn, [title*="Replace"]');
-      // Replace might be icon-only button
-      const hasReplace = await replaceBtn.count() > 0;
-      expect(hasReplace || true).toBe(true); // Pass even if not present (feature may be optional)
+      await expect(replaceBtn).toHaveCount(1);
+      await expect(replaceBtn).toBeVisible();
     }
   });
 
@@ -236,19 +230,18 @@ test.describe('Replace Exercise Functionality', () => {
 
     if (count > 0) {
       // Listen for API call
-      const requestPromise = page.waitForRequest(req => 
+      const requestPromise = page.waitForRequest(req =>
         req.url().includes('/replace_exercise') && req.method() === 'POST'
-      ).catch(() => null);
+      );
 
       const replaceBtn = rows.first().locator('button[data-action="replace"], .replace-btn, [title*="Replace"], .btn-replace');
-      const hasReplace = await replaceBtn.count() > 0;
-
-      if (hasReplace) {
-        await replaceBtn.click();
-        const request = await requestPromise;
-        // Test passes if replace button was found and clicked
-      }
-      // Test passes even if no replace button (feature may be optional)
+      await expect(replaceBtn).toBeVisible();
+      await replaceBtn.click();
+      const request = await requestPromise;
+      expect(request.postDataJSON()).toMatchObject({
+        id: expect.anything(),
+        strategy: 'ai',
+      });
     }
   });
 });
@@ -346,12 +339,9 @@ test.describe('Superset Functionality', () => {
         await page.waitForTimeout(1000);
       }
 
-      // Check for toast or visual indicator
-      const toastVisible = await page.locator('.toast').isVisible().catch(() => false);
-      const supersetIndicator = await page.locator('.superset-indicator, [data-superset]').count();
-
-      // Accept any reasonable outcome - we've verified the UI workflow exists
-      expect(toastVisible || supersetIndicator > 0 || isEnabled || true).toBe(true);
+      await expect.poll(() => page.locator(
+        '#workout_plan_table_body tr[data-superset-group]:not([data-superset-group=""])'
+      ).count()).toBe(2);
     }
   });
 });
@@ -457,25 +447,14 @@ test.describe('Exercise Details Modal', () => {
     }
   });
 
-  test('clicking exercise shows details modal', async ({ page }) => {
+  test('exercise name is currently rendered as plain text', async ({ page }) => {
     await selectRoutine(page);
     await page.waitForSelector('#workout_plan_table_body tr');
 
-    const exerciseLink = page.locator('#workout_plan_table_body tr').first().locator('a.exercise-link, .exercise-name[role="button"], [data-bs-toggle="modal"]');
-    const count = await exerciseLink.count();
-
-    if (count > 0) {
-      await exerciseLink.click();
-
-      // Wait for modal
-      await page.waitForTimeout(500);
-
-      const modal = page.locator('.modal.show, #exerciseDetailsModal');
-      const isVisible = await modal.isVisible().catch(() => false);
-
-      // Feature may not be implemented
-      expect(isVisible || true).toBe(true);
-    }
+    const exerciseName = page.locator('#workout_plan_table_body tr').first().locator('.exercise-name');
+    await expect(exerciseName).toBeVisible();
+    await expect(exerciseName).not.toHaveAttribute('role', 'button');
+    await expect(page.locator('#exerciseDetailsModal')).toHaveCount(0);
   });
 });
 

--- a/e2e/superset-edge-cases.spec.ts
+++ b/e2e/superset-edge-cases.spec.ts
@@ -39,7 +39,7 @@ async function addExercise(page: import('@playwright/test').Page, exerciseName?:
   const exerciseSelect = page.locator(SELECTORS.EXERCISE_SEARCH);
   const options = await exerciseSelect.locator('option').allInnerTexts();
   const usedExercises = new Set(
-    (await page.locator('#workout_plan_table_body tr td:nth-child(4)').allInnerTexts())
+    (await page.locator('#workout_plan_table_body .exercise-name').allInnerTexts())
       .map(text => text.trim().toLowerCase())
       .filter(Boolean)
   );
@@ -58,17 +58,23 @@ async function addExercise(page: import('@playwright/test').Page, exerciseName?:
     targetExercise = options.find(opt => opt && opt.trim() !== '' && !opt.includes('Select'));
   }
   
-  if (targetExercise) {
-    await exerciseSelect.selectOption(targetExercise);
-  }
+  expect(targetExercise, 'an unused exercise option should be available').toBeTruthy();
+  await exerciseSelect.selectOption({ label: targetExercise! });
   
   await page.fill('#sets', '3');
   await page.fill('#min_rep', '8');
   await page.fill('#max_rep_range', '12');
   await page.fill('#weight', '100');
   
+  const rowCountBefore = await page.locator('#workout_plan_table_body tr').count();
+  const responsePromise = page.waitForResponse(response =>
+    response.url().includes(API_ENDPOINTS.ADD_EXERCISE) &&
+    response.request().method() === 'POST'
+  );
   await page.locator(SELECTORS.ADD_EXERCISE_BTN).click();
-  await page.waitForTimeout(1000);
+  const response = await responsePromise;
+  expect(response.status()).toBe(200);
+  await expect(page.locator('#workout_plan_table_body tr')).toHaveCount(rowCountBefore + 1);
 }
 
 /**
@@ -79,7 +85,7 @@ async function waitForExercisesInTable(page: import('@playwright/test').Page, mi
     (min) => document.querySelectorAll('#workout_plan_table_body tr').length >= min,
     minCount,
     { timeout: 5000 }
-  ).catch(() => {});
+  );
 }
 
 test.beforeEach(async ({ page }) => {
@@ -154,27 +160,22 @@ test.describe('Superset Linking Edge Cases', () => {
     await waitForExercisesInTable(page, 2);
     
     const checkboxes = page.locator('#workout_plan_table_body .superset-checkbox');
-    const count = await checkboxes.count();
-    
-    if (count >= 2) {
-      await checkboxes.nth(0).click();
-      await checkboxes.nth(1).click();
-      await page.waitForTimeout(300);
-      
-      const linkBtn = page.locator('#link-superset-btn');
-      const isEnabled = await linkBtn.isEnabled().catch(() => false);
-      
-      if (isEnabled) {
-        await linkBtn.click();
-        await page.waitForTimeout(1000);
-        
-        // Check for success toast or visual indicator of superset
-        const toast = page.locator('.toast, #liveToast');
-        const toastVisible = await toast.isVisible().catch(() => false);
-        
-        expect(toastVisible || true).toBeTruthy();
-      }
-    }
+    await expect(checkboxes).toHaveCount(2);
+    await checkboxes.nth(0).click();
+    await checkboxes.nth(1).click();
+
+    const linkBtn = page.locator('#link-superset-btn');
+    await expect(linkBtn).toBeEnabled();
+    const responsePromise = page.waitForResponse(response =>
+      response.url().endsWith('/api/superset/link') && response.request().method() === 'POST'
+    );
+    await linkBtn.click();
+    expect((await responsePromise).status()).toBe(200);
+
+    const linkedRows = page.locator(
+      '#workout_plan_table_body tr[data-superset-group]:not([data-superset-group=""])'
+    );
+    await expect(linkedRows).toHaveCount(2);
   });
 });
 
@@ -231,7 +232,7 @@ test.describe('Delete Exercise in Superset', () => {
     }
   });
 
-  test('delete confirmation mentions superset if applicable', async ({ page }) => {
+  test('deleting a linked exercise clears the partner superset group', async ({ page }) => {
     await addExercise(page);
     await addExercise(page);
     await waitForExercisesInTable(page, 2);
@@ -249,22 +250,18 @@ test.describe('Delete Exercise in Superset', () => {
       }
     }
     
-    // Try to delete - should warn about superset
+    // Deleting one member unlinks the remaining partner server-side.
     const deleteBtn = page.locator('#workout_plan_table_body tr').first().locator('button[data-action="delete"], .delete-btn, .btn-danger');
-    
-    if (await deleteBtn.isVisible()) {
-      let dialogMessage = '';
-      page.on('dialog', async dialog => {
-        dialogMessage = dialog.message();
-        await dialog.accept();
-      });
-      
-      await deleteBtn.click();
-      await page.waitForTimeout(500);
-      
-      // Test passes regardless - we're checking the flow doesn't crash
-      expect(true).toBeTruthy();
-    }
+    await expect(deleteBtn).toBeVisible();
+    const responsePromise = page.waitForResponse(response =>
+      response.url().endsWith('/remove_exercise') && response.request().method() === 'POST'
+    );
+    await deleteBtn.click();
+    expect((await responsePromise).status()).toBe(200);
+    await expect(page.locator('#workout_plan_table_body tr')).toHaveCount(1);
+    await expect(page.locator('#workout_plan_table_body tr').first()).not.toHaveAttribute(
+      'data-superset-group'
+    );
   });
 });
 
@@ -330,10 +327,8 @@ test.describe('Unlink Superset Edge Cases', () => {
         
         // Unlink should now be visible
         const unlinkBtn = page.locator('#unlink-superset-btn');
-        const display = await unlinkBtn.evaluate(el => window.getComputedStyle(el).display);
-        
-        // May be inline-flex or block when visible
-        expect(['inline-flex', 'block', 'inline', 'flex'].includes(display) || true).toBeTruthy();
+        await expect(unlinkBtn).toBeVisible();
+        await expect(unlinkBtn).toBeEnabled();
       }
     }
   });
@@ -363,14 +358,14 @@ test.describe('Unlink Superset Edge Cases', () => {
         // Click unlink
         const unlinkBtn = page.locator('#unlink-superset-btn');
         if (await unlinkBtn.isVisible() && await unlinkBtn.isEnabled()) {
+          const responsePromise = page.waitForResponse(response =>
+            response.url().endsWith('/api/superset/unlink') && response.request().method() === 'POST'
+          );
           await unlinkBtn.click();
-          await page.waitForTimeout(1000);
-          
-          // Both exercises should now be un-supersetted
-          // Check for toast indicating success
-          const toast = page.locator('.toast, #liveToast');
-          const toastVisible = await toast.isVisible().catch(() => false);
-          expect(toastVisible || true).toBeTruthy();
+          expect((await responsePromise).status()).toBe(200);
+          await expect(page.locator(
+            '#workout_plan_table_body tr[data-superset-group]:not([data-superset-group=""])'
+          )).toHaveCount(0);
         }
       }
     }
@@ -469,10 +464,7 @@ test.describe('Superset State Persistence', () => {
         
         // Check that superset styling/attributes are preserved
         const supersetRows = page.locator('#workout_plan_table_body tr[data-superset-group]:not([data-superset-group=""])');
-        const groupCount = await supersetRows.count();
-        
-        // If superset persisted, should have 2 rows with superset group
-        expect(groupCount === 2 || groupCount === 0).toBeTruthy(); // May not persist if not saved
+        await expect(supersetRows).toHaveCount(2);
       }
     }
   });
@@ -532,19 +524,8 @@ test.describe('Superset Visual Indicators', () => {
         await linkBtn.click();
         await page.waitForTimeout(1000);
         
-        // Check for visual indicator (class, border, badge, etc.)
-        const rows = page.locator('#workout_plan_table_body tr');
-        const firstRow = rows.first();
-        
-        // Could have superset class, data attribute, or badge
-        const hasSupersetClass = await firstRow.evaluate(el => 
-          el.classList.contains('superset') || 
-          el.classList.contains('superset-member') ||
-          el.hasAttribute('data-superset-group')
-        ).catch(() => false);
-        
-        // Visual indicator should exist
-        expect(hasSupersetClass || true).toBeTruthy();
+        const firstRow = page.locator('#workout_plan_table_body tr').first();
+        await expect(firstRow).toHaveAttribute('data-superset-group', /^SS-/);
       }
     }
   });

--- a/e2e/validation-boundary.spec.ts
+++ b/e2e/validation-boundary.spec.ts
@@ -44,6 +44,29 @@ async function selectExercise(page: import('@playwright/test').Page) {
   }
 }
 
+async function expectExerciseSubmission(
+  page: import('@playwright/test').Page,
+  expectedStatus: number,
+  expectedPayload: Record<string, number>
+) {
+  const rows = page.locator('#workout_plan_table_body tr');
+  const initialCount = await rows.count();
+  const responsePromise = page.waitForResponse(response =>
+    response.url().endsWith('/add_exercise') && response.request().method() === 'POST'
+  );
+
+  await page.locator(SELECTORS.ADD_EXERCISE_BTN).click();
+  const response = await responsePromise;
+
+  expect(response.status()).toBe(expectedStatus);
+  expect(response.request().postDataJSON()).toMatchObject(expectedPayload);
+  if (expectedStatus === 200) {
+    await expect.poll(() => rows.count()).toBe(initialCount + 1);
+  } else {
+    await expect.poll(() => rows.count()).toBe(initialCount);
+  }
+}
+
 test.beforeEach(async ({ page }) => {
   await resetWorkoutPlan(page);
 });
@@ -61,39 +84,22 @@ test.describe('Negative Value Validation', () => {
     consoleErrors.assertNoErrors();
   });
 
-  test('rejects negative sets value', async ({ page }) => {
+  test('clamps negative sets to the current minimum', async ({ page }) => {
     await page.fill('#sets', '-1');
     await page.fill('#min_rep', '8');
     await page.fill('#max_rep_range', '12');
     await page.fill('#weight', '100');
 
-    await page.locator(SELECTORS.ADD_EXERCISE_BTN).click();
-    await page.waitForTimeout(500);
-
-    // Should show validation error or API rejection
-    const toast = page.locator('.toast, #liveToast');
-    const toastVisible = await toast.isVisible().catch(() => false);
-    
-    // Check if exercise was NOT added (validation worked)
-    const initialRows = await page.locator('#workout_plan_table_body tr').count();
-    
-    // Either toast shown OR exercise not added = validation working
-    expect(toastVisible || initialRows === 0).toBeTruthy();
+    await expectExerciseSubmission(page, 200, { sets: 1 });
   });
 
-  test('rejects negative min rep value', async ({ page }) => {
+  test('clamps negative min rep to the current minimum', async ({ page }) => {
     await page.fill('#sets', '3');
     await page.fill('#min_rep', '-5');
     await page.fill('#max_rep_range', '12');
     await page.fill('#weight', '100');
 
-    await page.locator(SELECTORS.ADD_EXERCISE_BTN).click();
-    await page.waitForTimeout(500);
-
-    // Validation should prevent submission
-    const toast = page.locator('.toast, #liveToast');
-    const toastVisible = await toast.isVisible().catch(() => false);
-    expect(true).toBeTruthy(); // Test passes if no crash
+    await expectExerciseSubmission(page, 200, { min_rep_range: 1 });
   });
 
   test('rejects negative max rep value', async ({ page }) => {
@@ -102,22 +108,16 @@ test.describe('Negative Value Validation', () => {
     await page.fill('#max_rep_range', '-10');
     await page.fill('#weight', '100');
 
-    await page.locator(SELECTORS.ADD_EXERCISE_BTN).click();
-    await page.waitForTimeout(500);
-
-    expect(true).toBeTruthy();
+    await expectExerciseSubmission(page, 400, { max_rep_range: 1 });
   });
 
-  test('rejects negative weight value', async ({ page }) => {
+  test('clamps negative weight to zero', async ({ page }) => {
     await page.fill('#sets', '3');
     await page.fill('#min_rep', '8');
     await page.fill('#max_rep_range', '12');
     await page.fill('#weight', '-50');
 
-    await page.locator(SELECTORS.ADD_EXERCISE_BTN).click();
-    await page.waitForTimeout(500);
-
-    expect(true).toBeTruthy();
+    await expectExerciseSubmission(page, 200, { weight: 0 });
   });
 });
 
@@ -140,19 +140,10 @@ test.describe('Rep Range Validation', () => {
     await page.fill('#max_rep_range', '8');
     await page.fill('#weight', '100');
 
-    await page.locator(SELECTORS.ADD_EXERCISE_BTN).click();
-    await page.waitForTimeout(500);
-
-    // Should show validation error
-    const toast = page.locator('.toast, #liveToast');
-    const toastVisible = await toast.isVisible().catch(() => false);
-    
-    // Check toast content for validation message
-    if (toastVisible) {
-      const toastText = await page.locator('#toast-body, .toast-body').textContent();
-      // Implementations may return a specific rep-range message or a generic validation error.
-      expect(toastText?.toLowerCase() ?? '').toMatch(/rep|invalid|error|unexpected/);
-    }
+    await expectExerciseSubmission(page, 400, {
+      min_rep_range: 15,
+      max_rep_range: 8,
+    });
   });
 
   test('accepts valid rep range (min < max)', async ({ page }) => {
@@ -161,17 +152,10 @@ test.describe('Rep Range Validation', () => {
     await page.fill('#max_rep_range', '12');
     await page.fill('#weight', '100');
 
-    const initialCount = await page.locator('#workout_plan_table_body tr').count();
-
-    await page.locator(SELECTORS.ADD_EXERCISE_BTN).click();
-    await page.waitForTimeout(1000);
-
-    // Should add successfully
-    const newCount = await page.locator('#workout_plan_table_body tr').count();
-    const toast = page.locator('.toast, #liveToast');
-    const toastVisible = await toast.isVisible().catch(() => false);
-
-    expect(newCount > initialCount || toastVisible).toBeTruthy();
+    await expectExerciseSubmission(page, 200, {
+      min_rep_range: 8,
+      max_rep_range: 12,
+    });
   });
 
   test('accepts equal min and max rep (min == max)', async ({ page }) => {
@@ -180,11 +164,10 @@ test.describe('Rep Range Validation', () => {
     await page.fill('#max_rep_range', '5');
     await page.fill('#weight', '100');
 
-    await page.locator(SELECTORS.ADD_EXERCISE_BTN).click();
-    await page.waitForTimeout(1000);
-
-    // Should be valid - same min and max means fixed rep target
-    expect(true).toBeTruthy();
+    await expectExerciseSubmission(page, 200, {
+      min_rep_range: 5,
+      max_rep_range: 5,
+    });
   });
 });
 
@@ -201,48 +184,31 @@ test.describe('Zero Value Validation', () => {
     consoleErrors.assertNoErrors();
   });
 
-  test('rejects zero sets', async ({ page }) => {
+  test('clamps zero sets to the current minimum', async ({ page }) => {
     await page.fill('#sets', '0');
     await page.fill('#min_rep', '8');
     await page.fill('#max_rep_range', '12');
     await page.fill('#weight', '100');
 
-    await page.locator(SELECTORS.ADD_EXERCISE_BTN).click();
-    await page.waitForTimeout(500);
-
-    // 0 sets should be rejected
-    const toast = page.locator('.toast, #liveToast');
-    const toastVisible = await toast.isVisible().catch(() => false);
-    expect(true).toBeTruthy();
+    await expectExerciseSubmission(page, 200, { sets: 1 });
   });
 
-  test('rejects zero min rep', async ({ page }) => {
+  test('clamps zero min rep to the current minimum', async ({ page }) => {
     await page.fill('#sets', '3');
     await page.fill('#min_rep', '0');
     await page.fill('#max_rep_range', '12');
     await page.fill('#weight', '100');
 
-    await page.locator(SELECTORS.ADD_EXERCISE_BTN).click();
-    await page.waitForTimeout(500);
-
-    expect(true).toBeTruthy();
+    await expectExerciseSubmission(page, 200, { min_rep_range: 1 });
   });
 
-  test('warns on zero weight', async ({ page }) => {
+  test('accepts zero weight for bodyweight or assisted exercise', async ({ page }) => {
     await page.fill('#sets', '3');
     await page.fill('#min_rep', '8');
     await page.fill('#max_rep_range', '12');
     await page.fill('#weight', '0');
 
-    await page.locator(SELECTORS.ADD_EXERCISE_BTN).click();
-    await page.waitForTimeout(500);
-
-    // Zero weight should warn user (bodyweight exercise?)
-    const toast = page.locator('.toast, #liveToast');
-    const toastVisible = await toast.isVisible().catch(() => false);
-    
-    // Either success (bodyweight allowed) or warning
-    expect(true).toBeTruthy();
+    await expectExerciseSubmission(page, 200, { weight: 0 });
   });
 });
 
@@ -270,11 +236,7 @@ test.describe('RIR/RPE Value Validation', () => {
       await rirField.fill('15');  // RIR > 10 doesn't make sense
     }
 
-    await page.locator(SELECTORS.ADD_EXERCISE_BTN).click();
-    await page.waitForTimeout(500);
-
-    // Should cap or reject excessive RIR
-    expect(true).toBeTruthy();
+    await expectExerciseSubmission(page, 200, { rir: 10 });
   });
 
   test('rejects negative RIR', async ({ page }) => {
@@ -288,10 +250,7 @@ test.describe('RIR/RPE Value Validation', () => {
       await rirField.fill('-2');
     }
 
-    await page.locator(SELECTORS.ADD_EXERCISE_BTN).click();
-    await page.waitForTimeout(500);
-
-    expect(true).toBeTruthy();
+    await expectExerciseSubmission(page, 200, { rir: 0 });
   });
 
   test('rejects RPE greater than 10', async ({ page }) => {
@@ -305,10 +264,7 @@ test.describe('RIR/RPE Value Validation', () => {
       await rpeField.fill('12');  // RPE scale is 1-10
     }
 
-    await page.locator(SELECTORS.ADD_EXERCISE_BTN).click();
-    await page.waitForTimeout(500);
-
-    expect(true).toBeTruthy();
+    await expectExerciseSubmission(page, 200, { rpe: 10 });
   });
 
   test('accepts valid RIR value (0-4 typical range)', async ({ page }) => {
@@ -322,11 +278,7 @@ test.describe('RIR/RPE Value Validation', () => {
       await rirField.fill('2');
     }
 
-    await page.locator(SELECTORS.ADD_EXERCISE_BTN).click();
-    await page.waitForTimeout(1000);
-
-    // Should succeed
-    expect(true).toBeTruthy();
+    await expectExerciseSubmission(page, 200, { rir: 2 });
   });
 });
 
@@ -349,11 +301,7 @@ test.describe('Decimal/Float Value Handling', () => {
     await page.fill('#max_rep_range', '12');
     await page.fill('#weight', '102.5');  // Decimal weight (common for kg)
 
-    await page.locator(SELECTORS.ADD_EXERCISE_BTN).click();
-    await page.waitForTimeout(1000);
-
-    // Decimal weight should be allowed
-    expect(true).toBeTruthy();
+    await expectExerciseSubmission(page, 200, { weight: 102.5 });
   });
 
   test('handles decimal sets by rounding', async ({ page }) => {
@@ -362,11 +310,7 @@ test.describe('Decimal/Float Value Handling', () => {
     await page.fill('#max_rep_range', '12');
     await page.fill('#weight', '100');
 
-    await page.locator(SELECTORS.ADD_EXERCISE_BTN).click();
-    await page.waitForTimeout(500);
-
-    // Should handle gracefully (round or reject)
-    expect(true).toBeTruthy();
+    await expectExerciseSubmission(page, 200, { sets: 3 });
   });
 
   test('handles decimal reps by rounding or rejecting', async ({ page }) => {
@@ -375,10 +319,7 @@ test.describe('Decimal/Float Value Handling', () => {
     await page.fill('#max_rep_range', '12');
     await page.fill('#weight', '100');
 
-    await page.locator(SELECTORS.ADD_EXERCISE_BTN).click();
-    await page.waitForTimeout(500);
-
-    expect(true).toBeTruthy();
+    await expectExerciseSubmission(page, 200, { min_rep_range: 8 });
   });
 });
 
@@ -417,10 +358,13 @@ test.describe('Empty Value Validation', () => {
     await page.fill('#max_rep_range', '12');
     await page.fill('#weight', '100');
 
+    let addRequestSent = false;
+    page.on('request', request => {
+      if (request.url().endsWith('/add_exercise')) addRequestSent = true;
+    });
     await page.locator(SELECTORS.ADD_EXERCISE_BTN).click();
-    await page.waitForTimeout(500);
-
-    expect(true).toBeTruthy();
+    await expect(page.locator('#liveToast')).toBeVisible();
+    expect(addRequestSent).toBe(false);
   });
 
   test('rejects empty weight field', async ({ page }) => {
@@ -458,11 +402,7 @@ test.describe('Extreme Value Handling', () => {
     await page.fill('#max_rep_range', '12');
     await page.fill('#weight', '100');
 
-    await page.locator(SELECTORS.ADD_EXERCISE_BTN).click();
-    await page.waitForTimeout(500);
-
-    // Should either accept (unlikely workout) or warn about unrealistic value
-    expect(true).toBeTruthy();
+    await expectExerciseSubmission(page, 200, { sets: 9999 });
   });
 
   test('handles very large weight value', async ({ page }) => {
@@ -471,10 +411,7 @@ test.describe('Extreme Value Handling', () => {
     await page.fill('#max_rep_range', '12');
     await page.fill('#weight', '50000');  // 50000 lbs = unrealistic
 
-    await page.locator(SELECTORS.ADD_EXERCISE_BTN).click();
-    await page.waitForTimeout(500);
-
-    expect(true).toBeTruthy();
+    await expectExerciseSubmission(page, 400, { weight: 50000 });
   });
 
   test('handles very large rep values', async ({ page }) => {
@@ -483,9 +420,9 @@ test.describe('Extreme Value Handling', () => {
     await page.fill('#max_rep_range', '1000');
     await page.fill('#weight', '100');
 
-    await page.locator(SELECTORS.ADD_EXERCISE_BTN).click();
-    await page.waitForTimeout(500);
-
-    expect(true).toBeTruthy();
+    await expectExerciseSubmission(page, 200, {
+      min_rep_range: 500,
+      max_rep_range: 1000,
+    });
   });
 });


### PR DESCRIPTION
## Summary
- replace always-passing and swallowed E2E assertions with observable DOM, request, response, and download contracts
- make superset setup deterministic by selecting distinct exercises and verifying each add
- align boundary tests with current browser clamping and backend validation behavior

## Verification
- npx tsc --noEmit
- npx playwright test e2e/validation-boundary.spec.ts e2e/empty-states.spec.ts e2e/exercise-interactions.spec.ts e2e/superset-edge-cases.spec.ts --project=chromium --reporter=line (72 passed)
- git diff --check
- vacuous-pattern scan across all four files returned no matches

Ref: WP-1.4 in docs/REFACTOR_PLAN.md