### PR TITLE
refactor(a11y): normalize main content landmark

### DIFF
--- a/e2e/accessibility.spec.ts
+++ b/e2e/accessibility.spec.ts
@@ -333,18 +333,20 @@ test.describe('Focus Management', () => {
 });
 
 test.describe('Skip Links', () => {
-  test('skip to main content link exists', async ({ page }) => {
+  test('skip link targets and focuses the single main landmark', async ({ page }) => {
     await page.goto(ROUTES.HOME);
     await waitForPageReady(page);
 
-    // Skip link is usually the first focusable element
+    const main = page.locator('main#main-content');
+    await expect(page.locator('main')).toHaveCount(1);
+    await expect(main).toHaveAttribute('tabindex', '-1');
+
     await page.keyboard.press('Tab');
-
-    const skipLink = page.locator('a[href="#main"], a[href="#content"], .skip-link, .skip-to-main');
-    const count = await skipLink.count();
-
-    // Skip link should exist (may be visually hidden until focused)
-    expect(count >= 0).toBeTruthy();
+    const skipLink = page.locator('.nb-skip-link');
+    await expect(skipLink).toBeFocused();
+    await expect(skipLink).toHaveAttribute('href', '#main-content');
+    await skipLink.click();
+    await expect(main).toBeFocused();
   });
 });
 

--- a/e2e/erase-flow.spec.ts
+++ b/e2e/erase-flow.spec.ts
@@ -31,6 +31,7 @@ test.describe('Erase flow — auto-backup banner', () => {
 
     const banner = page.locator(AUTO_BACKUP_BANNER);
     await expect(banner).toBeVisible();
+    await expect(page.locator('#welcome > [data-testid="auto-backup-banner"]')).toHaveCount(1);
     await expect(banner).toContainText('Auto-backup created');
     await expect(banner).toContainText('data/auto_backup/');
     await expect(banner).toContainText(SNAPSHOT_FILENAME_PATTERN);

--- a/e2e/smoke-navigation.spec.ts
+++ b/e2e/smoke-navigation.spec.ts
@@ -182,6 +182,8 @@ test.describe('Global Smoke and Navigation', () => {
       await page.goto(route.url);
       await waitForPageReady(page);
       await expect(page.locator(route.selector)).toBeVisible({ timeout: 10000 });
+      await expect(page.locator('main#main-content')).toHaveCount(1);
+      await expect(page.locator('[role="main"]')).toHaveCount(0);
     }
   });
 });

--- a/static/js/modules/program-backup.js
+++ b/static/js/modules/program-backup.js
@@ -129,10 +129,13 @@ export function showAutoBackupBanner(autoBackup) {
         <button type="button" class="btn-close" data-bs-dismiss="alert" aria-label="Close"></button>
     `;
 
-    // Insert at top of main content
-    const main = document.querySelector('main') || document.querySelector('.container-fluid');
-    if (main) {
-        main.insertBefore(banner, main.firstChild);
+    // Keep the home-page banner inside the welcome content. The base template
+    // owns the document's sole <main> landmark, so selecting the first main
+    // would otherwise move this banner outside its historical page wrapper.
+    const bannerHost = document.querySelector('[data-page="welcome"]')
+        || document.getElementById('main-content');
+    if (bannerHost) {
+        bannerHost.insertBefore(banner, bannerHost.firstChild);
     }
 }
 

--- a/templates/backup.html
+++ b/templates/backup.html
@@ -7,7 +7,7 @@
 {% endblock %}
 
 {% block content %}
-<main class="backup-center-page" data-page="backup-center" data-testid="backup-center-page" role="main">
+<div class="backup-center-page" data-page="backup-center" data-testid="backup-center-page">
     <header class="backup-center-header text-center">
         <p class="backup-center-eyebrow">Primary Workspace</p>
         <h1>Backup Center</h1>
@@ -223,5 +223,5 @@
             </div>
         </section>
     </section>
-</main>
+</div>
 {% endblock %}

--- a/templates/base.html
+++ b/templates/base.html
@@ -216,14 +216,14 @@
     </header>
 
     <!-- Main Content Area -->
-    <div id="main-content" class="container-fluid mt-4">
+    <main id="main-content" class="container-fluid mt-4" tabindex="-1">
         {% block content %}
         <!-- Default Fallback Content -->
         <div class="alert alert-info text-center" role="alert">
             Content is loading. Please wait...
         </div>
         {% endblock %}
-    </div>
+    </main>
 
     <!-- Toast Notification Section -->
     <div 

--- a/templates/body_composition.html
+++ b/templates/body_composition.html
@@ -7,7 +7,7 @@
 {% endblock %}
 
 {% block content %}
-<main id="body-composition" class="body-composition-page" data-page="body-composition" data-testid="body-composition-page" role="main"
+<div id="body-composition" class="body-composition-page" data-page="body-composition" data-testid="body-composition-page"
       data-bc-app="true"
       data-profile-gender="{{ profile.get('gender') or '' }}"
       data-profile-age="{{ profile.get('age') or '' }}"
@@ -212,7 +212,7 @@
             </section>
         </div>
     </div>
-</main>
+</div>
 {% endblock %}
 
 {% block page_js %}

--- a/templates/user_profile.html
+++ b/templates/user_profile.html
@@ -7,7 +7,7 @@
 {% endblock %}
 
 {% block content %}
-<main id="user-profile" class="user-profile-page" data-page="user-profile" role="main">
+<div id="user-profile" class="user-profile-page" data-page="user-profile">
     <div class="container-fluid">
         <header class="table-header text-center">
             <h1>User Profile</h1>
@@ -640,7 +640,7 @@
             </section>
         </div>
     </div>
-</main>
+</div>
 {% endblock %}
 
 {% block page_js %}

--- a/templates/welcome.html
+++ b/templates/welcome.html
@@ -7,7 +7,7 @@
 {% endblock %}
 
 {% block content %}
-<main id="welcome" data-page="welcome">
+<div id="welcome" data-page="welcome">
 <div class="welcome-container">
     <!-- Developer Credit Banner -->
     <div class="developer-credit-banner">
@@ -315,7 +315,7 @@
         </button>
     </section>
 </div>
-</main>
+</div>
 
 <!-- Erase Data Modal -->
 <div class="modal fade" id="eraseDataModal" tabindex="-1" aria-labelledby="eraseDataModalLabel" aria-hidden="true">

--- a/templates/workout_plan.html
+++ b/templates/workout_plan.html
@@ -7,7 +7,7 @@
 {% endblock %}
 
 {% block content %}
-<main id="workout" data-page="workout-plan" role="main">
+<div id="workout" data-page="workout-plan">
     <div class="container-fluid">
         <!-- Page Header - 2026 Glass Style -->
         <header class="table-header text-center">
@@ -553,7 +553,7 @@
         <section id="vpDrawerBody" class="vp-drawer__body"></section>
     </aside>
     <div id="vpBackdrop" class="vp-backdrop" hidden></div>
-</main>
+</div>
 
 <script src="https://cdnjs.cloudflare.com/ajax/libs/Sortable/1.14.0/Sortable.min.js"></script>
 <script src="{{ url_for('static', filename='js/modules/muscle-selector.js') }}"></script>

--- a/tests/test_template_landmarks.py
+++ b/tests/test_template_landmarks.py
@@ -1,0 +1,27 @@
+"""Structural contracts for the shared main-content landmark."""
+
+from pathlib import Path
+
+
+TEMPLATES = Path(__file__).resolve().parents[1] / "templates"
+
+
+def test_base_owns_skip_target_and_single_main_landmark():
+    base = (TEMPLATES / "base.html").read_text(encoding="utf-8")
+
+    assert 'class="nb-skip-link" href="#main-content"' in base
+    assert '<main id="main-content" class="container-fluid mt-4" tabindex="-1">' in base
+    assert base.count("<main") == 1
+    assert base.count("</main>") == 1
+
+
+def test_child_templates_do_not_define_additional_main_landmarks():
+    offenders = []
+    for template in TEMPLATES.glob("*.html"):
+        if template.name == "base.html":
+            continue
+        source = template.read_text(encoding="utf-8")
+        if "<main" in source or 'role="main"' in source:
+            offenders.append(template.name)
+
+    assert offenders == []


### PR DESCRIPTION
## Summary
- make base.html own the single main#main-content landmark while preserving every page ID, class, and data hook
- make the skip link focus the canonical landmark and verify one main across the navigation cycle
- preserve the auto-backup banner's historical placement inside the welcome wrapper
- add static template contracts preventing nested or duplicate main landmarks

## Verification
- python -m pytest tests/test_template_landmarks.py -q (2 passed)
- npx playwright test e2e/accessibility.spec.ts e2e/smoke-navigation.spec.ts --project=chromium --reporter=line (34 passed)
- npx playwright test e2e/erase-flow.spec.ts --project=chromium --reporter=line (2 passed)
- npx tsc --noEmit
- git diff --check

Ref: WP-1.5 in docs/REFACTOR_PLAN.md