### PR TITLE
refactor: remove proven Python dead code (WP0.1)

### DIFF
--- a/docs/user_profile/PLANNING.md
+++ b/docs/user_profile/PLANNING.md
@@ -122,7 +122,7 @@ Pure-Python module; no Flask imports. All logic lives here so it's unit-testable
 - [x] `KEY_LIFTS: frozenset[str]` — 14 slugs matching questionnaire.
 - [x] `COMPLEX_ALLOWLIST: frozenset[str]` — exercise-name keywords (lowercase, substring match) for tier classification.
 - [x] `EXCLUDED_EQUIPMENT: frozenset[str]` — `{'Trx','Bosu_Ball','Cardio','Recovery','Yoga','Vitruvian','Band','Stretches'}`.
-- [x] `TIER_RATIOS: dict[str,float]` and `REP_RANGE_PCT: dict[str,float]` per A.3/A.4.
+- [x] `TIER_RATIOS: dict[str,float]` and `REP_RANGE_PRESETS` `pct_1rm` entries per A.3/A.4.
 - [x] `MUSCLE_TO_KEY_LIFT: dict[str, list[str]]` per A.5 (ordered fallback chain).
 
 ### C.2 Public functions

--- a/tests/test_errors_utils.py
+++ b/tests/test_errors_utils.py
@@ -18,6 +18,7 @@ from utils.errors import (
     ERROR_CODES,
     get_request_id,
 )
+from utils.request_id import get_request_id as canonical_get_request_id
 
 
 class TestSuccessResponse:
@@ -252,6 +253,10 @@ class TestGetRequestId:
         with app.test_request_context():
             # Don't set g.request_id
             assert get_request_id() is None
+
+    def test_errors_reexports_canonical_request_id_helper(self):
+        """The legacy errors import path must remain an identity-preserving re-export."""
+        assert get_request_id is canonical_get_request_id
 
 
 # Fixtures for errors tests

--- a/tests/test_priority7_error_handling.py
+++ b/tests/test_priority7_error_handling.py
@@ -22,7 +22,7 @@ def error_app():
     the shared app from conftest.py.
     """
     import utils.config
-    from flask import Flask
+    from flask import Flask, abort, make_response
     from routes.workout_plan import workout_plan_bp, initialize_exercise_order
     from routes.workout_log import workout_log_bp
     from routes.main import main_bp
@@ -54,11 +54,35 @@ def error_app():
     # Register middleware and error handlers
     add_request_id_middleware(app)
     register_error_handlers(app)
+
+    # app.py registers these two handlers after register_error_handlers(). Keep
+    # the fixture layered the same way so tests prove the production winners,
+    # rather than relying on the shadowed helper registrations removed in WP0.1.
+    @app.errorhandler(404)
+    def layered_not_found(_error):
+        if is_xhr_request():
+            return error_response("NOT_FOUND", "The requested resource was not found", 404)
+        return make_response("<html><h1>Not Found</h1></html>", 404)
+
+    @app.errorhandler(Exception)
+    def layered_exception(_error):
+        if is_xhr_request():
+            return error_response("INTERNAL_ERROR", "An unexpected error occurred", 500)
+        return make_response("<html><h1>Internal Server Error</h1></html>", 500)
     
     # Add error trigger route BEFORE any requests
     @app.route('/__trigger_internal_error')
     def __trigger_internal_error():
         raise RuntimeError('forced test error')
+
+    @app.route('/__trigger_http_error/<int:status_code>')
+    def __trigger_http_error(status_code):
+        abort(status_code)
+
+    @app.route('/__trigger_api_error')
+    def __trigger_api_error():
+        from utils.errors import APIError
+        raise APIError('TEST_API_ERROR', 'forced API error', 409)
     
     # Initialize database within app context
     with app.app_context():
@@ -118,6 +142,7 @@ class TestErrorHandlers:
         data = json.loads(response.data)
         assert data['ok'] is False
         assert data['error']['code'] == 'NOT_FOUND'
+        assert data['error']['message'] == 'The requested resource was not found'
         assert 'requestId' in data['error']
     
     def test_404_html_response(self, error_client):
@@ -134,6 +159,7 @@ class TestErrorHandlers:
         data = json.loads(response.data)
         assert data['ok'] is False
         assert data['error']['code'] == 'INTERNAL_ERROR'
+        assert data['error']['message'] == 'An unexpected error occurred'
 
     def test_500_html_response(self, error_client):
         """Test 500 handler returns HTML for browser requests."""
@@ -141,6 +167,35 @@ class TestErrorHandlers:
         assert response.status_code == 500
         assert response.mimetype == 'text/html'
         assert b'Internal Server Error' in response.data
+
+    @pytest.mark.parametrize(('status_code', 'error_code'), [
+        (400, 'BAD_REQUEST'),
+        (422, 'UNPROCESSABLE_ENTITY'),
+        (500, 'INTERNAL_ERROR'),
+    ])
+    def test_helper_owned_status_handlers_remain_live(
+        self, error_client, status_code, error_code
+    ):
+        response = error_client.get(
+            f'/__trigger_http_error/{status_code}',
+            headers={'Accept': 'application/json'},
+        )
+        assert response.status_code == status_code
+        assert response.get_json()['error']['code'] == error_code
+
+    def test_api_error_handler_remains_live(self, error_client):
+        response = error_client.get(
+            '/__trigger_api_error', headers={'Accept': 'application/json'}
+        )
+        assert response.status_code == 409
+        assert response.get_json()['error']['code'] == 'TEST_API_ERROR'
+
+    def test_later_exception_handler_owns_unrecognized_http_errors(self, error_client):
+        response = error_client.get(
+            '/__trigger_http_error/418', headers={'Accept': 'application/json'}
+        )
+        assert response.status_code == 500
+        assert response.get_json()['error']['message'] == 'An unexpected error occurred'
     
     def test_error_response_helper(self, error_app):
         """Test error_response helper function."""

--- a/utils/errors.py
+++ b/utils/errors.py
@@ -1,8 +1,11 @@
 """
 Standardized API error responses and helpers.
 """
-from flask import jsonify, request, g, make_response
 from typing import Optional, Dict, Any
+
+from flask import jsonify, request, make_response
+
+from utils.request_id import get_request_id
 
 
 class APIError(Exception):
@@ -12,11 +15,6 @@ class APIError(Exception):
         self.message = message
         self.status_code = status_code
         super().__init__(self.message)
-
-
-def get_request_id():
-    """Get the current request ID from Flask g object."""
-    return getattr(g, 'request_id', None)
 
 
 def success_response(data: Any = None, message: Optional[str] = None) -> Dict:
@@ -136,8 +134,6 @@ def register_error_handlers(app):
     Args:
         app: Flask application instance
     """
-    from werkzeug.exceptions import HTTPException
-    
     def _html_error(status_code: int, title: str, message: str):
         html = (
             "<!DOCTYPE html>"
@@ -162,17 +158,6 @@ def register_error_handlers(app):
                 400
             )
         return _html_error(400, "Bad Request", "The request could not be understood or was missing required parameters.")
-    
-    @app.errorhandler(404)
-    def not_found(e):
-        """Handle 404 Not Found errors."""
-        if is_xhr_request():
-            return error_response(
-                "NOT_FOUND",
-                "The requested resource could not be found.",
-                404
-            )
-        return _html_error(404, "Not Found", "The requested resource could not be found.")
     
     @app.errorhandler(422)
     def unprocessable_entity(e):
@@ -220,40 +205,4 @@ def register_error_handlers(app):
     def handle_api_error(e):
         """Handle custom APIError exceptions."""
         return error_response(e.code, e.message, e.status_code)
-    
-    @app.errorhandler(Exception)
-    def handle_unexpected_error(e):
-        """Handle any unexpected exceptions."""
-        # Don't handle HTTP exceptions here (they're handled above)
-        if isinstance(e, HTTPException):
-            return e
-        
-        # Get request context for logging
-        request_id = get_request_id()
-        endpoint = request.endpoint if request else None
-        method = request.method if request else None
-        path = request.path if request else None
-        user_agent = request.headers.get('User-Agent', '')[:50] if request else None
-        
-        # Log the unexpected error with full context
-        app.logger.exception(
-            f"Unexpected error: {type(e).__name__}",
-            extra={
-                'error_type': type(e).__name__,
-                'endpoint': endpoint,
-                'method': method,
-                'path': path,
-                'user_agent': user_agent,
-                'request_id': request_id
-            }
-        )
-        
-        if is_xhr_request():
-            return error_response(
-                "INTERNAL_ERROR",
-                "An unexpected error occurred. Please try again later.",
-                500
-            )
-
-        return _html_error(500, "Internal Server Error", "An unexpected error occurred. Please try again later.")
 

--- a/utils/movement_patterns.py
+++ b/utils/movement_patterns.py
@@ -11,14 +11,6 @@ from enum import Enum
 from typing import Dict, List, Optional, Set, Tuple
 
 
-class MovementCategory(str, Enum):
-    """Top-level movement categories."""
-    LOWER_BODY = "lower_body"
-    UPPER_BODY = "upper_body"
-    CORE = "core"
-    ISOLATION = "isolation"
-
-
 class MovementPattern(str, Enum):
     """Primary movement patterns."""
     # Lower body patterns
@@ -251,10 +243,6 @@ ENVIRONMENT_EQUIPMENT: Dict[str, Set[str]] = {
 }
 
 
-# Default home equipment (minimal setup)
-HOME_BASIC_EQUIPMENT: Set[str] = {"Bodyweight", "Dumbbells", "Band"}
-
-
 @dataclass
 class SlotDefinition:
     """Definition of an exercise slot in a session blueprint."""
@@ -464,9 +452,6 @@ class PrescriptionRules:
     # Total sets per session constraints
     MIN_SETS_PER_SESSION: int = 15
     MAX_SETS_PER_SESSION: int = 24
-    DEFAULT_SETS_TARGET: int = 18
-
-
 def classify_exercise(
     exercise_name: str,
     primary_muscle: Optional[str] = None,

--- a/utils/profile_estimator.py
+++ b/utils/profile_estimator.py
@@ -279,8 +279,6 @@ REP_RANGE_PRESETS = {
     "moderate": {"min_rep": 6, "max_rep": 8, "pct_1rm": 0.77, "rir": 2, "rpe": 8.0},
     "light": {"min_rep": 10, "max_rep": 15, "pct_1rm": 0.65, "rir": 2, "rpe": 7.5},
 }
-REP_RANGE_PCT = {key: preset["pct_1rm"] for key, preset in REP_RANGE_PRESETS.items()}
-
 DEFAULT_PREFERENCES = {
     "complex": "heavy",
     "accessory": "moderate",

--- a/utils/weekly_summary.py
+++ b/utils/weekly_summary.py
@@ -16,13 +16,6 @@ from utils.effective_sets import (
 from utils.logger import get_logger
 
 
-STATUS_MAP = {
-    'low-volume': 'low',
-    'medium-volume': 'medium',
-    'high-volume': 'high',
-    'ultra-volume': 'excessive',
-}
-
 # Map new volume classes to CSS-compatible status
 EFFECTIVE_STATUS_MAP = {
     'low': 'low',


### PR DESCRIPTION
## Summary
- remove the two error-handler registrations shadowed by app.py's later 404 and Exception handlers
- replace utils.errors.get_request_id implementation with an identity-preserving import/re-export from utils.request_id
- remove definition-only HOME_BASIC_EQUIPMENT, MovementCategory, PrescriptionRules.DEFAULT_SETS_TARGET, REP_RANGE_PCT, and weekly_summary.STATUS_MAP
- replace standalone shadow-handler tests with layered production-order probes while pinning surviving 400/422/500/APIError behavior

## Contract notes
- utils.errors.get_request_id remains import-compatible and is now the exact canonical function object
- removing PrescriptionRules.DEFAULT_SETS_TARGET intentionally removes that unused dataclass constructor/asdict field, as explicitly authorized by WP0.1
- no HTTP response shape, status, calculation, schema, or persistence behavior changes

## Verification
- focused error/summary/movement/estimator gate: 230 passed
- full pytest against isolated committed HEAD catalog: 1690 passed
- blocking flake8 rules on changed Python: clean
- removed-symbol scan: no active-code/test references
- git diff --check

The first full-suite attempt used the intentionally stale visual seed and produced only the two known catalog-invariant failures (633/454 pre-cleanup nulls). The final gate used committed HEAD:data/database.db extracted into the isolated worktree; the main checkout DB was never read for seeding or modified.