### PR TITLE
chore(js): remove dead workout-log filter block and nonexistent-endpoint call (WP0.4)

### DIFF
--- a/static/js/modules/workout-log.js
+++ b/static/js/modules/workout-log.js
@@ -87,9 +87,6 @@ export function initializeWorkoutLog() {
     // Initialize editable cells
     initializeEditableCells();
 
-    // Initialize filters
-    initializeWorkoutLogFilters();
-
     // §5 — wire reference-video play buttons in server-rendered rows.
     initializeVideoPlayButtons();
 
@@ -594,78 +591,6 @@ function initializeEditableCells() {
             });
         }
     });
-}
-
-export function initializeWorkoutLogFilters() {
-    const dateFilter = document.getElementById('date-filter');
-    const routineFilter = document.getElementById('routine-filter');
-    
-    if (dateFilter) {
-        dateFilter.addEventListener('change', filterWorkoutLogs);
-    }
-    if (routineFilter) {
-        routineFilter.addEventListener('change', filterWorkoutLogs);
-    }
-}
-
-async function filterWorkoutLogs() {
-    try {
-        const date = document.getElementById('date-filter')?.value;
-        const routine = document.getElementById('routine-filter')?.value;
-
-        const response = await api.post('/filter_workout_logs', { date, routine }, { showLoading: false, showErrorToast: false });
-        
-        // response.data contains the logs array
-        const data = response.data !== undefined ? response.data : response;
-        updateWorkoutLogTable(data);
-    } catch (error) {
-        console.error('Error filtering workout logs:', error);
-        showToast('error', 'Failed to filter workout logs');
-    }
-}
-
-function updateWorkoutLogTable(data) {
-    const tbody = document.querySelector('#workout-log-table tbody');
-    if (!tbody) return;
-
-    tbody.innerHTML = data.length ? 
-        data.map(log => createWorkoutLogRow(log)).join('') :
-        '<tr><td colspan="8" class="text-center">No workout logs found</td></tr>';
-}
-
-function createWorkoutLogRow(log) {
-    return `
-        <tr data-log-id="${log.id}">
-            <td>${log.date}</td>
-            <td>${log.routine}</td>
-            <td>${log.exercise}</td>
-            <td class="editable-cell" data-field="scored_sets">
-                <span class="editable-text">${log.scored_sets || 'Click to edit'}</span>
-                <input type="number" class="editable-input form-control input-calm-inset"
-                    value="${log.scored_sets || ''}" style="display: none;">
-            </td>
-            <td class="editable-cell" data-field="scored_reps">
-                <span class="editable-text">${log.scored_reps || 'Click to edit'}</span>
-                <input type="number" class="editable-input form-control input-calm-inset"
-                    value="${log.scored_reps || ''}" style="display: none;">
-            </td>
-            <td class="editable-cell" data-field="scored_weight">
-                <span class="editable-text">${log.scored_weight || 'Click to edit'}</span>
-                <input type="number" class="editable-input form-control input-calm-inset"
-                    value="${log.scored_weight || ''}" style="display: none;">
-            </td>
-            <td>
-                <span class="badge ${log.progression_status === 'Achieved' ? 'bg-success' : 'bg-warning'}">
-                    ${log.progression_status}
-                </span>
-            </td>
-            <td>
-                <button class="btn btn-danger btn-sm" onclick="deleteWorkoutLog(${log.id})">
-                    Delete
-                </button>
-            </td>
-        </tr>
-    `;
 }
 
 export async function checkProgressionStatus(logId) {


### PR DESCRIPTION
## WP0.4 — dead workout-log vertical slice

Behavior-preserving deletion of a complete dead slice in `static/js/modules/workout-log.js`: the workout-log filter UI/logic block plus its call to a route that does not exist server-side.

### Removed
- `initializeWorkoutLogFilters()` + its unconditional call site in `initializeWorkoutLog()`
- `filterWorkoutLogs()` (POSTed to the nonexistent `/filter_workout_logs`)
- `updateWorkoutLogTable()`
- `createWorkoutLogRow()`

(75 lines removed, one file.)

### Dead-code proof (Global rule 5)
**Filter block DOM-absent** — the block queries `#date-filter` and `#routine-filter`; repo-wide grep of `templates/**` finds **zero** elements with those ids. The `if (dateFilter)` / `if (routineFilter)` guards silently no-op, so no listeners are ever attached and the chain never runs.

**Endpoint route-absent** — `/filter_workout_logs` has **no route** in `routes/**` or `app.py`; grep finds only this one JS call site (plus scan docs `docs/scan/PHASE_15.md`). It would 404 even if the DOM elements were restored.

**Caller dead** — `initializeWorkoutLogFilters` is exported but imported nowhere (`app.js` does not import it); its sole reference was the removed call site. `filterWorkoutLogs` / `updateWorkoutLogTable` / `createWorkoutLogRow` were referenced only inside this now-removed block.

**Live behavior preserved** — `deleteWorkoutLog` is intentionally **kept**: it is live via the real template (`templates/workout_log.html:242` inline `onclick`) and the `app.js` `window` assignment. Only `createWorkoutLogRow`'s duplicate reference to it was removed. Import/edit/delete/date/media flows untouched.

**Did not touch** `static/js/app.js` or `static/js/modules/ui-handlers.js`.

### Gate
- Full pytest: **1691 passed** (unchanged).
- `node --check static/js/modules/workout-log.js`: clean.
- E2E gate deferred to CI (`workout-log.spec.ts`, `learned-calibration.spec.ts`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)