### PR TITLE
chore(js): remove dead table-responsiveness internals (WP0.4)

### DIFF
--- a/static/js/table-responsiveness.js
+++ b/static/js/table-responsiveness.js
@@ -340,54 +340,6 @@ tableDebugLog('[TableResponsiveness] Version 2024-11-11-03 loaded');
     }
   }
 
-  // Keep legacy function for backward compatibility (no-op for click handlers)
-  function toggleColumn(tableEl, colIdentifier, show, pageKey) {
-    tableDebugLog('[toggleColumn] Legacy call ignored - use view mode toggle instead');
-  }
-
-  /**
-   * Apply column visibility to table
-   * @param {HTMLElement} tableEl - Table element
-   * @param {string} colIdentifier - Column identifier (data-label value)
-   * @param {boolean} show - Whether to show the column
-   */
-  function applyColumnVisibility(tableEl, colIdentifier, show) {
-  tableDebugLog('[applyColumnVisibility] Called with:', { colIdentifier, show });
-    
-    // Find the column index by matching the data-label in the header
-    const headers = qsa('th[data-label]', tableEl);
-    let columnIndex = -1;
-    
-    headers.forEach((th, index) => {
-      if (th.getAttribute('data-label') === colIdentifier) {
-        columnIndex = index;
-  tableDebugLog('[applyColumnVisibility] Found column at index:', index, 'Header text:', th.textContent.trim());
-      }
-    });
-    
-    if (columnIndex === -1) {
-      console.warn(`[applyColumnVisibility] Column with data-label "${colIdentifier}" not found`);
-      return;
-    }
-    
-    // Hide/show the header cell
-    const header = headers[columnIndex];
-    if (header) {
-      header.style.display = show ? '' : 'none';
-  tableDebugLog('[applyColumnVisibility] Header display set to:', header.style.display || 'default');
-    }
-    
-    // Hide/show all corresponding body cells using nth-child selector
-    // Note: nth-child is 1-indexed, and we need to account for the drag handle column
-    const nthChildIndex = columnIndex + 2; // +1 for nth-child indexing, +1 for drag handle
-  tableDebugLog('[applyColumnVisibility] Using nth-child selector:', nthChildIndex);
-  const bodyCells = qsa(`tbody tr td:nth-child(${nthChildIndex})`, tableEl);
-  tableDebugLog('[applyColumnVisibility] Found', bodyCells.length, 'body cells to toggle');
-    bodyCells.forEach(cell => {
-      cell.style.display = show ? '' : 'none';
-    });
-  }
-
   // ============================================================
   // DYNAMIC ROWS PER PAGE (ResizeObserver)
   // ============================================================


### PR DESCRIPTION
## WP0.4 — remove dead table-responsiveness internals

Behavior-preserving deletion of two proven-dead internal functions in
`static/js/table-responsiveness.js`. **Auto-init is preserved.**

### Removed (48 lines)
- `toggleColumn(tableEl, colIdentifier, show, pageKey)` — a documented no-op
  legacy stub (body was a single debug log).
- `applyColumnVisibility(tableEl, colIdentifier, show)` — per-column
  show/hide helper.

### Per-symbol dead-code proof (Global rule 5)
For each symbol: imports / DOM wiring / inline `on*=` handlers / dynamic
lookup / `window` assignments / actual callers all checked.

**`toggleColumn`**
- Not in the public API (`window.TableResponsiveness` exposes only
  `initColumnChooser`, `fitRowsToViewport`, `getPrefs`, `setPrefs`, `autoInit`).
- Zero callers in `static/**`, `templates/**`, `e2e/**`, `tests/**`.
- No `window['toggleColumn']` / `TableResponsiveness[...]` dynamic lookup, no
  inline `on*=` handler.
- No in-file caller (only its own definition).

**`applyColumnVisibility`**
- Not in the public API.
- Zero callers in `static/**`, `templates/**`, `e2e/**`, `tests/**`.
- No dynamic/bracket lookup, no inline handler.
- No in-file caller.
- Not on the auto-init path: `autoInit` → `initColumnChooser` → `applyViewMode`
  handles column visibility via CSS classes (`tbl--view-simple` /
  `tbl--view-advanced`); it never calls `applyColumnVisibility`.

### Auto-init preserved (CRITICAL)
No change to `autoInit`, `initColumnChooser`, `fitRowsToViewport`,
`createViewModeToggleUI`, `applyViewMode`, or the `DOMContentLoaded` wiring.
The only edit is deletion of the two unreferenced functions. `debounce`,
`qs`, `qsa`, and all live helpers untouched.

### Not touched
No CSS deleted. `app.js` and `ui-handlers.js` untouched.

### Gate
- `node --check static/js/table-responsiveness.js` — passes.
- Full pytest: **1691 passed**, unchanged from baseline.
- E2E gate deferred to CI. Relevant specs to watch: any spec exercising
  responsive tables / Simple-Advanced column toggle on `/workout_plan`, and
  visual-regression specs for the workout-plan table.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
