### PR TITLE
chore(js): remove unreachable summary.js fallback render path (WP0.4)

### DIFF
--- a/static/js/modules/summary.js
+++ b/static/js/modules/summary.js
@@ -1,133 +1,36 @@
-import { showToast } from './toast.js';
-import { api } from './fetch-wrapper.js';
+// Weekly / session summary fetch entry points.
+//
+// The LIVE rendering path for both summary pages is the page-local inline
+// updater — `window.updateWeeklySummary` (templates/weekly_summary.html) and
+// `window.updateSessionSummary` (templates/session_summary.html). Both summary
+// pages define their inline updater unconditionally, and these exported
+// functions are only ever called on those two pages (from app.js init and the
+// ui-handlers method-change handler). `pageHasOwnUpdater()` is therefore always
+// true at every call site, so these functions short-circuit and never render.
+//
+// WP0.4 removed the module's fallback rendering path (updateSummaryUI + the
+// table builders + volume-class helpers), which was proven unreachable. The
+// guarded fetch stubs and their call sites are intentionally retained: removing
+// them means rationalizing the app.js / ui-handlers callers, which is WP3.2's
+// job (extract the inline summary scripts, then delete this module + its
+// callers together). Do not merge the inline updaters into this module.
 
-// Check if the page already has its own updateWeeklySummary function defined
-// If so, skip the module's version to avoid conflicts
+// Check if the page already has its own summary updater defined (inline).
 function pageHasOwnUpdater() {
     return typeof window.updateWeeklySummary === 'function' ||
            typeof window.updateSessionSummary === 'function';
 }
 
 export async function fetchWeeklySummary(method = 'Total') {
-    // Skip if page has its own update handler (new effective sets UI)
+    // The live weekly-summary UI (inline updateWeeklySummary) owns rendering.
     if (pageHasOwnUpdater()) {
         return;
-    }
-    
-    try {
-        const data = await api.get(`/weekly_summary?method=${method}`, { showLoading: false, showErrorToast: false });
-        
-        if (!data) {
-            throw new Error('No data received from server');
-        }
-        
-        updateSummaryUI(data.data || data);
-    } catch (error) {
-        console.error('Error fetching weekly summary:', error);
-        showToast('Failed to fetch weekly summary', true);
     }
 }
 
 export async function fetchSessionSummary(method = 'Total') {
-    // Skip if page has its own update handler (new effective sets UI)
+    // The live session-summary UI (inline updateSessionSummary) owns rendering.
     if (pageHasOwnUpdater()) {
         return;
     }
-    
-    try {
-        const data = await api.get(`/session_summary?method=${method}`, { showLoading: false, showErrorToast: false });
-        
-        if (!data) {
-            throw new Error('No data received from server');
-        }
-        
-        updateSummaryUI(data.data || data);
-    } catch (error) {
-        console.error('Error fetching session summary:', error);
-        showToast('Failed to fetch session summary', true);
-    }
-}
-
-function updateSummaryUI(data) {
-    const summaryData = data.session_summary || data.weekly_summary || [];
-    
-    // Update summary tables
-    updateSummaryTable(summaryData);
-    
-    // Update category breakdown
-    updateCategoryTable(data.categories || []);
-    
-    // Update isolated muscles stats
-    updateIsolatedMusclesTable(data.isolated_muscles || []);
-}
-
-function updateSummaryTable(summaryData) {
-    const tbody = document.querySelector('#session-summary-table, #weekly-summary-table');
-    if (!tbody || !summaryData) return;
-
-    tbody.innerHTML = summaryData.map(item => `
-        <tr>
-            ${item.routine ? `<td>${item.routine}</td>` : ''}
-            <td>${item.muscle_group || 'N/A'}</td>
-            <td>${item.total_sets || 0}</td>
-            <td>${item.total_reps || 0}</td>
-            <td>${item.total_volume || 0}</td>
-            <td>
-                <div class="volume-classification">
-                    <span class="volume-badge ${getVolumeClass(item.total_sets)}">
-                        ${getVolumeLabel(item.total_sets)}
-                    </span>
-                </div>
-            </td>
-        </tr>
-    `).join('');
-}
-
-function updateCategoryTable(categories) {
-    const tbody = document.querySelector('#categories-table tbody');
-    if (!tbody || !categories) return;
-
-    tbody.innerHTML = categories.map(cat => `
-        <tr>
-            <td>${cat.category || 'N/A'}</td>
-            <td>${cat.subcategory || 'N/A'}</td>
-            <td>${cat.total_exercises || 0}</td>
-        </tr>
-    `).join('');
-}
-
-function updateIsolatedMusclesTable(stats) {
-    const tbody = document.querySelector('#isolated-muscles-table tbody');
-    if (!tbody || !stats) return;
-
-    tbody.innerHTML = stats.map(stat => `
-        <tr>
-            <td>${stat.isolated_muscle || 'N/A'}</td>
-            <td>${stat.exercise_count || 0}</td>
-            <td>${stat.total_sets || 0}</td>
-            <td>${stat.total_reps || 0}</td>
-            <td>${stat.total_volume || 0}</td>
-            <td>
-                <div class="volume-classification">
-                    <span class="volume-badge ${getVolumeClass(stat.total_sets)}">
-                        ${getVolumeLabel(stat.total_sets)}
-                    </span>
-                </div>
-            </td>
-        </tr>
-    `).join('');
-}
-
-function getVolumeClass(sets) {
-    if (sets >= 30) return 'ultra-volume';
-    if (sets >= 20) return 'high-volume';
-    if (sets >= 10) return 'medium-volume';
-    return 'low-volume';
-}
-
-function getVolumeLabel(sets) {
-    if (sets >= 30) return 'Excessive Volume';
-    if (sets >= 20) return 'High Volume';
-    if (sets >= 10) return 'Medium Volume';
-    return 'Low Volume';
 }


### PR DESCRIPTION
## WP0.4 — summary.js no-op path (partial, WP3.2-coordinated)

Removes the **proven-unreachable** fallback rendering path in `static/js/modules/summary.js`.

### Proof (rule 5 — runtime wiring)
- `fetchWeeklySummary`/`fetchSessionSummary` are called **only** on `/weekly_summary` and `/session_summary` (app.js init + ui-handlers method-change handler).
- Both pages define their inline updater unconditionally — `window.updateWeeklySummary` (weekly_summary.html:448), `window.updateSessionSummary` (session_summary.html:335) — so `pageHasOwnUpdater()` is **always true** at every call site and both functions always early-return.
- The module's rendering tail is therefore never reached.

### Removed (net −97 lines)
`updateSummaryUI`, `updateSummaryTable`, `updateCategoryTable`, `updateIsolatedMusclesTable`, `getVolumeClass`, `getVolumeLabel`, both dead try/fetch bodies, and the now-unused `showToast`/`api` imports.

### Intentionally retained (WP3.2 scope)
Guarded `fetchWeeklySummary`/`fetchSessionSummary` stubs + `pageHasOwnUpdater`, and their **app.js / ui-handlers callers untouched**. Deleting the module + rationalizing callers is WP3.2 (inline-script extraction), per the plan's "delete only when callers gone" rule.

### Gate
- `node --check` clean; JS-only change (no pytest surface).
- Authoritative CI: **Run Tests**, `summary-pages.spec.ts` (20), and visual specs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)