### PR TITLE
refactor(filters): central filter allowlist registry + validators (WP1.1)

### DIFF
--- a/routes/filters.py
+++ b/routes/filters.py
@@ -4,6 +4,15 @@ from utils.database import DatabaseHandler
 from utils.errors import success_response, error_response
 from utils.logger import get_logger
 from utils.constants import DIFFICULTY, MECHANIC, UTILITY
+# The SQL-name allowlists and validators are owned by utils.filter_registry.
+# Re-exported here (unchanged names) so existing callers/tests that do
+# `from routes.filters import ALLOWED_COLUMNS, validate_column_name` keep working.
+from utils.filter_registry import (  # noqa: F401  (re-exported)
+    ALLOWED_TABLES,
+    ALLOWED_COLUMNS,
+    validate_table_name,
+    validate_column_name,
+)
 
 filters_bp = Blueprint('filters', __name__)
 logger = get_logger()
@@ -103,51 +112,6 @@ FILTER_MAPPING = {
     "synergists": "synergists",
     "difficulty": "difficulty",
 }
-
-# Whitelist for safe table and column names (prevents SQL injection)
-ALLOWED_TABLES = {
-    'exercises': 'exercises',
-    'user_selection': 'user_selection',
-    'workout_log': 'workout_log',
-    'progression_goals': 'progression_goals',
-}
-
-ALLOWED_COLUMNS = {
-    # Exercises table columns
-    'primary_muscle_group': 'primary_muscle_group',
-    'secondary_muscle_group': 'secondary_muscle_group',
-    'tertiary_muscle_group': 'tertiary_muscle_group',
-    'advanced_isolated_muscles': 'advanced_isolated_muscles',
-    'force': 'force',
-    'equipment': 'equipment',
-    'mechanic': 'mechanic',
-    'utility': 'utility',
-    'grips': 'grips',
-    'stabilizers': 'stabilizers',
-    'synergists': 'synergists',
-    'difficulty': 'difficulty',
-    'exercise_name': 'exercise_name',
-    # User selection columns
-    'routine': 'routine',
-    'exercise': 'exercise',
-    'sets': 'sets',
-    'min_rep_range': 'min_rep_range',
-    'max_rep_range': 'max_rep_range',
-    'rir': 'rir',
-    'rpe': 'rpe',
-    'weight': 'weight',
-}
-
-
-def validate_table_name(table: str) -> bool:
-    """Validate that table name is in whitelist."""
-    return table.lower() in {k.lower(): v for k, v in ALLOWED_TABLES.items()}
-
-
-def validate_column_name(column: str) -> bool:
-    """Validate that column name is in whitelist."""
-    return column.lower() in {k.lower(): v for k, v in ALLOWED_COLUMNS.items()}
-
 
 ENUM_VALUE_MAP = {
     'mechanic': sorted(set(MECHANIC.values())),

--- a/tests/test_filter_registry.py
+++ b/tests/test_filter_registry.py
@@ -1,0 +1,84 @@
+"""Tests for the central filter allowlist registry (WP1.1).
+
+Covers three things:
+1. Table/column validators reject malicious / unknown names and accept known ones.
+2. `routes.filters` still re-exports the same objects (backward-compat contract).
+3. The registry vocabulary reconciles EXACTLY with
+   `FilterPredicates.VALID_FILTER_FIELDS` via the documented grouping frozensets,
+   so future drift in either list fails a test instead of silently diverging.
+"""
+import routes.filters as filters_route
+from utils import filter_registry as reg
+from utils.filter_predicates import FilterPredicates
+
+
+class TestTableValidation:
+    def test_known_tables_accepted(self):
+        for table in ("exercises", "user_selection", "workout_log", "progression_goals"):
+            assert reg.validate_table_name(table) is True
+
+    def test_case_insensitive(self):
+        assert reg.validate_table_name("EXERCISES") is True
+        assert reg.validate_column_name("PRIMARY_MUSCLE_GROUP") is True
+
+    def test_malicious_table_names_rejected(self):
+        for bad in (
+            "evil_table",
+            "exercises; DROP TABLE exercises;--",
+            "exercises,user_selection",
+            "sqlite_master",
+            "",
+            "1=1",
+        ):
+            assert reg.validate_table_name(bad) is False
+
+    def test_malicious_column_names_rejected(self):
+        for bad in (
+            "evil_column",
+            "column; DROP TABLE exercises;--",
+            "weight OR 1=1",
+            "",
+            "*",
+        ):
+            assert reg.validate_column_name(bad) is False
+
+
+class TestReExportContract:
+    def test_route_reexports_are_registry_objects(self):
+        # Existing callers/tests import these from routes.filters; they must be
+        # the very same objects the registry owns.
+        assert filters_route.ALLOWED_TABLES is reg.ALLOWED_TABLES
+        assert filters_route.ALLOWED_COLUMNS is reg.ALLOWED_COLUMNS
+        assert filters_route.validate_table_name is reg.validate_table_name
+        assert filters_route.validate_column_name is reg.validate_column_name
+
+
+class TestVocabularyReconciliation:
+    """The allowlist and the filter-predicate field set are DIFFERENT on
+    purpose; assert the documented relationship rather than a union."""
+
+    def test_exercises_filter_columns_are_allowed_columns(self):
+        # Every real (non-virtual) filter field must be a safe column.
+        assert reg.EXERCISES_FILTER_COLUMNS <= set(reg.ALLOWED_COLUMNS)
+
+    def test_valid_filter_fields_equals_exercises_columns_plus_virtual(self):
+        assert set(FilterPredicates.VALID_FILTER_FIELDS) == (
+            reg.EXERCISES_FILTER_COLUMNS | reg.VIRTUAL_FILTER_FIELDS
+        )
+
+    def test_virtual_fields_absent_from_allowed_columns(self):
+        # target_muscles is filterable but has no physical column.
+        assert reg.VIRTUAL_FILTER_FIELDS.isdisjoint(set(reg.ALLOWED_COLUMNS))
+
+    def test_non_filter_columns_partition(self):
+        # ALLOWED_COLUMNS partitions cleanly into filter columns + non-filter columns.
+        assert (reg.EXERCISES_FILTER_COLUMNS | reg.NON_FILTER_ALLOWED_COLUMNS) == set(
+            reg.ALLOWED_COLUMNS
+        )
+        assert reg.EXERCISES_FILTER_COLUMNS.isdisjoint(reg.NON_FILTER_ALLOWED_COLUMNS)
+
+    def test_non_filter_columns_are_not_filter_fields(self):
+        # exercise_name + user_selection columns are queryable but not filter fields.
+        assert reg.NON_FILTER_ALLOWED_COLUMNS.isdisjoint(
+            set(FilterPredicates.VALID_FILTER_FIELDS)
+        )

--- a/utils/filter_registry.py
+++ b/utils/filter_registry.py
@@ -1,0 +1,117 @@
+"""Central filter allowlist and table/column validators.
+
+Single owner of the SQL-name safety whitelists used for dynamic table/column
+interpolation by the filter routes (`/get_unique_values/<table>/<column>`,
+`/get_filtered_exercises`) and by `routes.workout_plan.fetch_unique_values`.
+`routes.filters` re-exports `ALLOWED_TABLES`, `ALLOWED_COLUMNS`,
+`validate_table_name`, and `validate_column_name` from here so existing callers
+and tests (`from routes.filters import ALLOWED_COLUMNS, validate_column_name`)
+keep working unchanged.
+
+Relationship to ``FilterPredicates.VALID_FILTER_FIELDS`` (do NOT union them)
+---------------------------------------------------------------------------
+These two vocabularies are intentionally different and serve different purposes:
+
+* ``ALLOWED_COLUMNS`` is the **SQL-injection safety whitelist** — every column
+  name that may be interpolated into a dynamic ``SELECT``. It spans exercises
+  columns *and* ``user_selection`` columns (``routine``, ``sets``, ``weight`` …)
+  plus ``exercise_name``. Its job is to make dynamic identifiers safe, not to
+  define what is filterable.
+* ``FilterPredicates.VALID_FILTER_FIELDS`` is the set of fields the exercise
+  **filter-predicate builder** accepts. It is the exercises filter columns
+  (``EXERCISES_FILTER_COLUMNS`` below) **plus** the virtual field
+  ``target_muscles`` (a computed/mapped filter with no physical ``exercises``
+  column) and **minus** ``exercise_name`` and the ``user_selection`` columns
+  (queryable, but not exercise filters).
+
+The grouping frozensets below encode these intentional differences explicitly so
+that vocabulary drift is caught by the parity tests in
+``tests/test_filter_registry.py`` rather than silently papered over by a union.
+"""
+
+# Whitelist for safe table names (prevents SQL injection).
+ALLOWED_TABLES = {
+    'exercises': 'exercises',
+    'user_selection': 'user_selection',
+    'workout_log': 'workout_log',
+    'progression_goals': 'progression_goals',
+}
+
+# Whitelist for safe column names (prevents SQL injection).
+ALLOWED_COLUMNS = {
+    # Exercises table columns
+    'primary_muscle_group': 'primary_muscle_group',
+    'secondary_muscle_group': 'secondary_muscle_group',
+    'tertiary_muscle_group': 'tertiary_muscle_group',
+    'advanced_isolated_muscles': 'advanced_isolated_muscles',
+    'force': 'force',
+    'equipment': 'equipment',
+    'mechanic': 'mechanic',
+    'utility': 'utility',
+    'grips': 'grips',
+    'stabilizers': 'stabilizers',
+    'synergists': 'synergists',
+    'difficulty': 'difficulty',
+    'exercise_name': 'exercise_name',
+    # User selection columns
+    'routine': 'routine',
+    'exercise': 'exercise',
+    'sets': 'sets',
+    'min_rep_range': 'min_rep_range',
+    'max_rep_range': 'max_rep_range',
+    'rir': 'rir',
+    'rpe': 'rpe',
+    'weight': 'weight',
+}
+
+
+def validate_table_name(table: str) -> bool:
+    """Validate that table name is in the whitelist (case-insensitive)."""
+    return table.lower() in {k.lower(): v for k, v in ALLOWED_TABLES.items()}
+
+
+def validate_column_name(column: str) -> bool:
+    """Validate that column name is in the whitelist (case-insensitive)."""
+    return column.lower() in {k.lower(): v for k, v in ALLOWED_COLUMNS.items()}
+
+
+# ---------------------------------------------------------------------------
+# Explicit reconciliation with FilterPredicates.VALID_FILTER_FIELDS.
+# These are documentation + parity-test anchors, not a second source of truth
+# for the allowlist above. See the module docstring.
+# ---------------------------------------------------------------------------
+
+# Exercises columns that are also exercise filter fields (the overlap between
+# ALLOWED_COLUMNS and VALID_FILTER_FIELDS).
+EXERCISES_FILTER_COLUMNS = frozenset({
+    'primary_muscle_group',
+    'secondary_muscle_group',
+    'tertiary_muscle_group',
+    'advanced_isolated_muscles',
+    'force',
+    'equipment',
+    'mechanic',
+    'utility',
+    'grips',
+    'stabilizers',
+    'synergists',
+    'difficulty',
+})
+
+# Virtual filter field(s): valid for filtering but with no physical exercises
+# column, so intentionally absent from ALLOWED_COLUMNS.
+VIRTUAL_FILTER_FIELDS = frozenset({'target_muscles'})
+
+# Columns that are safe to query but are NOT exercise filter fields
+# (exercise_name plus the user_selection columns).
+NON_FILTER_ALLOWED_COLUMNS = frozenset({
+    'exercise_name',
+    'routine',
+    'exercise',
+    'sets',
+    'min_rep_range',
+    'max_rep_range',
+    'rir',
+    'rpe',
+    'weight',
+})


### PR DESCRIPTION
## WP1.1 — central filter allowlist + validators (Phase 1)

Moves the SQL-name safety whitelists and validators into a utils-owned registry, with an **explicit** reconciliation to `FilterPredicates.VALID_FILTER_FIELDS` (not a silent union).

### Migration notes
- **New `utils/filter_registry.py`** owns `ALLOWED_TABLES`, `ALLOWED_COLUMNS`, `validate_table_name`, `validate_column_name` (verbatim from routes/filters.py).
- **`routes/filters.py`** re-exports the same objects (object-identical — verified by test), so `from routes.filters import ALLOWED_COLUMNS, validate_column_name` (used by `routes/workout_plan.py`) and existing tests are unchanged.
- **Reconciliation encoded, not unioned:** `EXERCISES_FILTER_COLUMNS`, `VIRTUAL_FILTER_FIELDS={target_muscles}`, `NON_FILTER_ALLOWED_COLUMNS` document the intentional differences. `ALLOWED_COLUMNS` = SQL-name safety set (exercises + user_selection cols); `VALID_FILTER_FIELDS` = filter-predicate fields (exercises filter cols + virtual `target_muscles`).
- **No behavior change:** same validation logic, same whitelists, same envelopes.

### Tests
- New `tests/test_filter_registry.py` (10): malicious table/column rejection, case-insensitivity, route re-export identity, and parity assertions that fail on vocabulary drift.

### Gate
- Focused filter suites: **72 passed**.
- Full pytest: **1701 passed** (1691 baseline + 10 new registry tests).
- API-integration E2E on CI.

Unblocks WP1.2 (unique-value contracts via the registry) and WPB.6 (endpoint removals).

🤖 Generated with [Claude Code](https://claude.com/claude-code)