### PR TITLE
refactor(filters): extract filter value services (WP1.2)

### DIFF
--- a/routes/filters.py
+++ b/routes/filters.py
@@ -3,7 +3,7 @@ from utils.filter_predicates import FilterPredicates
 from utils.database import DatabaseHandler
 from utils.errors import success_response, error_response
 from utils.logger import get_logger
-from utils.constants import DIFFICULTY, MECHANIC, UTILITY
+from utils.filter_values import fetch_registered_unique_values
 # The SQL-name allowlists and validators are owned by utils.filter_registry.
 # Re-exported here (unchanged names) so existing callers/tests that do
 # `from routes.filters import ALLOWED_COLUMNS, validate_column_name` keep working.
@@ -111,12 +111,6 @@ FILTER_MAPPING = {
     "stabilizers": "stabilizers",
     "synergists": "synergists",
     "difficulty": "difficulty",
-}
-
-ENUM_VALUE_MAP = {
-    'mechanic': sorted(set(MECHANIC.values())),
-    'utility': sorted(set(UTILITY.values())),
-    'difficulty': sorted(set(DIFFICULTY.values())),
 }
 
 def expand_simple_muscle_value(field: str, value: str) -> tuple:
@@ -330,77 +324,8 @@ def get_unique_values(table, column):
             logger.warning(f"Invalid column name: {column}")
             return error_response("VALIDATION_ERROR", f"Invalid column: {column}", 400)
         
-        # Get safe table and column names from whitelist
-        safe_table = ALLOWED_TABLES.get(table.lower())
-        safe_column = ALLOWED_COLUMNS.get(column.lower())
-        
-        if not safe_table or not safe_column:
-            return error_response("VALIDATION_ERROR", "Invalid table or column", 400)
-        
-        # Use parameterized query with safe names
-        with DatabaseHandler() as db:
-            if safe_table == 'exercises' and safe_column == 'advanced_isolated_muscles':
-                records = db.fetch_all(
-                    "SELECT DISTINCT muscle FROM exercise_isolated_muscles ORDER BY muscle"
-                )
-                values = [row['muscle'] for row in records]
-                return jsonify(success_response(data=values))
-
-            if safe_column in ENUM_VALUE_MAP:
-                return jsonify(success_response(data=ENUM_VALUE_MAP[safe_column]))
-
-            # Force column: query DB and normalize to title case to merge variants
-            if safe_column == 'force':
-                query = (
-                    f"SELECT DISTINCT {safe_column} AS value FROM {safe_table} "
-                    f"WHERE {safe_column} IS NOT NULL AND TRIM({safe_column}) <> '' "
-                    f"ORDER BY {safe_column}"
-                )
-                rows = db.fetch_all(query)
-                # Normalize to title case and dedupe (merges 'push'/'Push', 'pull'/'Pull')
-                seen = set()
-                values = []
-                for row in rows:
-                    val = row['value']
-                    if val:
-                        normalized = val.strip().title()
-                        if normalized not in seen:
-                            seen.add(normalized)
-                            values.append(normalized)
-                return jsonify(success_response(data=sorted(values)))
-
-            if safe_column in {
-                'primary_muscle_group',
-                'secondary_muscle_group',
-                'tertiary_muscle_group',
-            }:
-                query = (
-                    f"SELECT DISTINCT {safe_column} AS value FROM {safe_table} "
-                    f"WHERE {safe_column} IS NOT NULL AND TRIM({safe_column}) <> '' "
-                    f"ORDER BY {safe_column}"
-                )
-                rows = db.fetch_all(query)
-                values = [row['value'] for row in rows]
-                return jsonify(success_response(data=values))
-
-            if safe_column == 'equipment':
-                query = (
-                    f"SELECT DISTINCT TRIM({safe_column}) AS value FROM {safe_table} "
-                    f"WHERE {safe_column} IS NOT NULL AND TRIM({safe_column}) <> '' "
-                    f"ORDER BY value"
-                )
-                rows = db.fetch_all(query)
-                values = [row['value'] for row in rows if row.get('value')]
-                return jsonify(success_response(data=values))
-
-            query = (
-                f"SELECT DISTINCT {safe_column} AS value FROM {safe_table} "
-                f"WHERE {safe_column} IS NOT NULL AND TRIM({safe_column}) <> '' "
-                f"ORDER BY {safe_column}"
-            )
-            results = db.fetch_all(query)
-            values = [row['value'] for row in results if row.get('value')]
-            return jsonify(success_response(data=values))
+        values = fetch_registered_unique_values(table, column)
+        return jsonify(success_response(data=values))
     except Exception as e:
         logger.exception(f"Error fetching unique values for {table}.{column}")
         return error_response("INTERNAL_ERROR", "Failed to fetch unique values", 500) 
@@ -451,4 +376,4 @@ def get_filtered_exercises():
             return jsonify(success_response(data=exercises))
     except Exception as e:
         logger.exception("Error filtering exercises")
-        return error_response("INTERNAL_ERROR", "Failed to filter exercises", 500) 
+        return error_response("INTERNAL_ERROR", "Failed to filter exercises", 500)

--- a/routes/workout_plan.py
+++ b/routes/workout_plan.py
@@ -9,8 +9,8 @@ from utils.exercise_manager import (
 from utils.errors import success_response, error_response
 from utils.exercise_media import resolve_exercise_media_path
 from utils.logger import get_logger
-from routes.filters import ALLOWED_COLUMNS, validate_column_name
-from utils.constants import DIFFICULTY, MECHANIC, UTILITY, ANTAGONIST_PAIRS
+from utils.filter_values import fetch_filter_values
+from utils.constants import ANTAGONIST_PAIRS
 from utils.plan_generator import GENERATOR_ROUTINE_PROGRAMS, generate_starter_plan
 from utils.volume_progress import get_volume_progress
 from utils.workout_validation import UNSET, validate_workout_bounds
@@ -19,87 +19,8 @@ workout_plan_bp = Blueprint('workout_plan', __name__)
 logger = get_logger()
 
 def fetch_unique_values(column):
-    """Fetch unique values for a specified column from the exercises table."""
-    # Validate column name is whitelisted
-    if not validate_column_name(column):
-        logger.warning(f"Invalid column name in fetch_unique_values: {column}")
-        return []
-    
-    # Get safe column name from whitelist
-    safe_column = ALLOWED_COLUMNS.get(column.lower())
-    if not safe_column:
-        logger.warning(f"Column not found in whitelist: {column}")
-        return []
-    
-    enum_map = {
-        'mechanic': sorted(set(MECHANIC.values())),
-        'utility': sorted(set(UTILITY.values())),
-        'difficulty': sorted(set(DIFFICULTY.values())),
-    }
-
-    try:
-        with DatabaseHandler() as db:
-            if safe_column in enum_map:
-                return enum_map[safe_column]
-
-            # Force column: query DB and normalize to title case to merge variants
-            if safe_column == 'force':
-                query = (
-                    f"SELECT DISTINCT {safe_column} AS value FROM exercises "
-                    f"WHERE {safe_column} IS NOT NULL AND TRIM({safe_column}) <> '' "
-                    f"ORDER BY {safe_column}"
-                )
-                rows = db.fetch_all(query)
-                # Normalize to title case and dedupe (merges 'push'/'Push', 'pull'/'Pull')
-                seen = set()
-                values = []
-                for row in rows:
-                    val = row['value']
-                    if val:
-                        normalized = val.strip().title()
-                        if normalized not in seen:
-                            seen.add(normalized)
-                            values.append(normalized)
-                return sorted(values)
-
-            if safe_column == 'advanced_isolated_muscles':
-                rows = db.fetch_all(
-                    "SELECT DISTINCT muscle FROM exercise_isolated_muscles ORDER BY muscle"
-                )
-                return [row['muscle'] for row in rows]
-
-            if safe_column in {
-                'primary_muscle_group',
-                'secondary_muscle_group',
-                'tertiary_muscle_group',
-            }:
-                query = (
-                    f"SELECT DISTINCT {safe_column} AS value FROM exercises "
-                    f"WHERE {safe_column} IS NOT NULL AND TRIM({safe_column}) <> '' "
-                    f"ORDER BY {safe_column}"
-                )
-                rows = db.fetch_all(query)
-                return [row['value'] for row in rows]
-
-            if safe_column == 'equipment':
-                query = (
-                    f"SELECT DISTINCT TRIM({safe_column}) AS value FROM exercises "
-                    f"WHERE {safe_column} IS NOT NULL AND TRIM({safe_column}) <> '' "
-                    f"ORDER BY value"
-                )
-                rows = db.fetch_all(query)
-                return [row['value'] for row in rows if row.get('value')]
-
-            query = (
-                f"SELECT DISTINCT {safe_column} AS value FROM exercises "
-                f"WHERE {safe_column} IS NOT NULL AND TRIM({safe_column}) <> '' "
-                f"ORDER BY {safe_column}"
-            )
-            rows = db.fetch_all(query)
-            return [row['value'] for row in rows if row.get('value')]
-    except Exception as e:
-        logger.error(f"Error fetching unique values for {column}: {e}", exc_info=True)
-        return []
+    """Backward-compatible route-level alias for the extracted contract."""
+    return fetch_filter_values(column)
 
 @workout_plan_bp.route("/workout_plan")
 def workout_plan():

--- a/tests/test_filter_values.py
+++ b/tests/test_filter_values.py
@@ -1,0 +1,133 @@
+"""Characterization tests for the two extracted filter-value contracts."""
+
+import pytest
+
+from routes import filters as filters_route
+from routes import workout_plan as workout_plan_route
+from utils.constants import MECHANIC
+from utils import filter_values
+from utils.filter_values import (
+    fetch_filter_values,
+    fetch_registered_unique_values,
+)
+
+
+class TestWorkoutPlanFilterValues:
+    def test_invalid_column_keeps_forgiving_empty_list_contract(self, app):
+        assert fetch_filter_values("not_a_column") == []
+
+    def test_enum_values_come_from_canonical_constants(self, app):
+        assert fetch_filter_values("mechanic") == sorted(set(MECHANIC.values()))
+
+    def test_enum_results_are_fresh_and_do_not_mutate_generic_contract(self, app):
+        first = fetch_filter_values("mechanic")
+        first.append("Mutated")
+
+        assert "Mutated" not in fetch_filter_values("mechanic")
+        assert "Mutated" not in fetch_registered_unique_values(
+            "exercises", "mechanic"
+        )
+
+    def test_force_values_are_title_cased_and_deduplicated(
+        self, app, exercise_factory
+    ):
+        exercise_factory("Lower Push", force="push")
+        exercise_factory("Upper Push", force=" Push ")
+        exercise_factory("Pull", force="pull")
+
+        assert fetch_filter_values("force") == ["Pull", "Push"]
+
+    def test_equipment_values_are_trimmed(self, app, exercise_factory):
+        exercise_factory("Trimmed", equipment="  Cable  ")
+        exercise_factory("Clean", equipment="Barbell")
+
+        assert fetch_filter_values("equipment") == ["Barbell", "Cable"]
+
+    def test_advanced_muscles_use_mapping_table(self, app, clean_db):
+        clean_db.execute_query(
+            "INSERT INTO exercises (exercise_name) VALUES (?)", ("Curl",)
+        )
+        clean_db.execute_query(
+            "INSERT INTO exercise_isolated_muscles (exercise_name, muscle) "
+            "VALUES (?, ?)",
+            ("Curl", "long-head-bicep"),
+        )
+
+        assert fetch_filter_values("advanced_isolated_muscles") == [
+            "long-head-bicep"
+        ]
+
+    def test_route_level_name_remains_a_compatibility_wrapper(self, monkeypatch):
+        monkeypatch.setattr(
+            workout_plan_route,
+            "fetch_filter_values",
+            lambda column: [f"value-for-{column}"],
+        )
+
+        assert workout_plan_route.fetch_unique_values("force") == [
+            "value-for-force"
+        ]
+
+    def test_database_failure_keeps_forgiving_empty_list_contract(
+        self, monkeypatch
+    ):
+        class BrokenDatabase:
+            def __enter__(self):
+                raise RuntimeError("database unavailable")
+
+            def __exit__(self, *args):
+                return False
+
+        monkeypatch.setattr(filter_values, "DatabaseHandler", BrokenDatabase)
+
+        assert fetch_filter_values("equipment") == []
+
+
+class TestRegisteredUniqueValues:
+    @pytest.mark.parametrize(
+        ("table", "column"),
+        [("not_a_table", "equipment"), ("exercises", "not_a_column")],
+    )
+    def test_invalid_identifiers_raise_for_route_to_shape(self, app, table, column):
+        with pytest.raises(ValueError, match="Invalid"):
+            fetch_registered_unique_values(table, column)
+
+    def test_table_column_query_contract_remains_generic(
+        self, app, exercise_factory, workout_plan_factory
+    ):
+        workout_plan_factory(routine="Routine B")
+        exercise_factory("Second Exercise")
+        workout_plan_factory(
+            exercise_name="Second Exercise",
+            routine="Routine A",
+        )
+
+        assert fetch_registered_unique_values("user_selection", "routine") == [
+            "Routine A",
+            "Routine B",
+        ]
+
+    def test_route_delegates_and_preserves_success_envelope(self, client, monkeypatch):
+        monkeypatch.setattr(
+            filters_route,
+            "fetch_registered_unique_values",
+            lambda table, column: [f"{table}.{column}"],
+        )
+
+        response = client.get("/get_unique_values/exercises/equipment")
+
+        assert response.status_code == 200
+        assert response.get_json()["data"] == ["exercises.equipment"]
+
+    def test_database_failures_propagate_for_route_to_shape(self, monkeypatch):
+        class BrokenDatabase:
+            def __enter__(self):
+                raise RuntimeError("database unavailable")
+
+            def __exit__(self, *args):
+                return False
+
+        monkeypatch.setattr(filter_values, "DatabaseHandler", BrokenDatabase)
+
+        with pytest.raises(RuntimeError, match="database unavailable"):
+            fetch_registered_unique_values("exercises", "equipment")

--- a/utils/filter_values.py
+++ b/utils/filter_values.py
@@ -1,0 +1,160 @@
+"""Filter-value query contracts shared by the workout-plan and filter routes."""
+
+from utils.constants import DIFFICULTY, MECHANIC, UTILITY
+from utils.database import DatabaseHandler
+from utils.filter_registry import (
+    ALLOWED_COLUMNS,
+    ALLOWED_TABLES,
+    validate_column_name,
+    validate_table_name,
+)
+from utils.logger import get_logger
+
+
+logger = get_logger()
+
+ENUM_VALUE_MAP = {
+    "mechanic": sorted(set(MECHANIC.values())),
+    "utility": sorted(set(UTILITY.values())),
+    "difficulty": sorted(set(DIFFICULTY.values())),
+}
+
+
+def _normalized_force_values(rows: list[dict]) -> list[str]:
+    """Normalize force values to title case and merge case variants."""
+    values = {
+        value.strip().title()
+        for row in rows
+        if (value := row.get("value"))
+    }
+    return sorted(values)
+
+
+def fetch_filter_values(column: str) -> list:
+    """Return the workout-plan filter values for an exercises column.
+
+    This preserves the historical route helper's forgiving contract: invalid
+    columns and database errors are logged and returned as an empty list.
+    """
+    if not validate_column_name(column):
+        logger.warning("Invalid column name in fetch_filter_values: %s", column)
+        return []
+
+    safe_column = ALLOWED_COLUMNS.get(column.lower())
+    if not safe_column:
+        logger.warning("Column not found in whitelist: %s", column)
+        return []
+
+    try:
+        with DatabaseHandler() as db:
+            if safe_column in ENUM_VALUE_MAP:
+                # The historical workout-plan helper built this mapping inside
+                # each call, so callers received a fresh list.
+                return list(ENUM_VALUE_MAP[safe_column])
+
+            if safe_column == "force":
+                rows = db.fetch_all(
+                    f"SELECT DISTINCT {safe_column} AS value FROM exercises "
+                    f"WHERE {safe_column} IS NOT NULL AND TRIM({safe_column}) <> '' "
+                    f"ORDER BY {safe_column}"
+                )
+                return _normalized_force_values(rows)
+
+            if safe_column == "advanced_isolated_muscles":
+                rows = db.fetch_all(
+                    "SELECT DISTINCT muscle FROM exercise_isolated_muscles ORDER BY muscle"
+                )
+                return [row["muscle"] for row in rows]
+
+            if safe_column in {
+                "primary_muscle_group",
+                "secondary_muscle_group",
+                "tertiary_muscle_group",
+            }:
+                rows = db.fetch_all(
+                    f"SELECT DISTINCT {safe_column} AS value FROM exercises "
+                    f"WHERE {safe_column} IS NOT NULL AND TRIM({safe_column}) <> '' "
+                    f"ORDER BY {safe_column}"
+                )
+                return [row["value"] for row in rows]
+
+            if safe_column == "equipment":
+                rows = db.fetch_all(
+                    f"SELECT DISTINCT TRIM({safe_column}) AS value FROM exercises "
+                    f"WHERE {safe_column} IS NOT NULL AND TRIM({safe_column}) <> '' "
+                    "ORDER BY value"
+                )
+                return [row["value"] for row in rows if row.get("value")]
+
+            rows = db.fetch_all(
+                f"SELECT DISTINCT {safe_column} AS value FROM exercises "
+                f"WHERE {safe_column} IS NOT NULL AND TRIM({safe_column}) <> '' "
+                f"ORDER BY {safe_column}"
+            )
+            return [row["value"] for row in rows if row.get("value")]
+    except Exception:
+        logger.exception("Error fetching workout-plan filter values for %s", column)
+        return []
+
+
+def fetch_registered_unique_values(table: str, column: str) -> list:
+    """Return the generic route contract for an allowlisted table/column pair.
+
+    Unlike :func:`fetch_filter_values`, invalid identifiers raise ``ValueError``
+    so the HTTP route can preserve its existing validation envelopes. This is
+    intentionally separate from ``ExerciseManager.fetch_unique_values``.
+    """
+    if not validate_table_name(table):
+        raise ValueError(f"Invalid table: {table}")
+    if not validate_column_name(column):
+        raise ValueError(f"Invalid column: {column}")
+
+    safe_table = ALLOWED_TABLES.get(table.lower())
+    safe_column = ALLOWED_COLUMNS.get(column.lower())
+    if not safe_table or not safe_column:
+        raise ValueError("Invalid table or column")
+
+    with DatabaseHandler() as db:
+        if safe_table == "exercises" and safe_column == "advanced_isolated_muscles":
+            rows = db.fetch_all(
+                "SELECT DISTINCT muscle FROM exercise_isolated_muscles ORDER BY muscle"
+            )
+            return [row["muscle"] for row in rows]
+
+        if safe_column in ENUM_VALUE_MAP:
+            return ENUM_VALUE_MAP[safe_column]
+
+        if safe_column == "force":
+            rows = db.fetch_all(
+                f"SELECT DISTINCT {safe_column} AS value FROM {safe_table} "
+                f"WHERE {safe_column} IS NOT NULL AND TRIM({safe_column}) <> '' "
+                f"ORDER BY {safe_column}"
+            )
+            return _normalized_force_values(rows)
+
+        if safe_column in {
+            "primary_muscle_group",
+            "secondary_muscle_group",
+            "tertiary_muscle_group",
+        }:
+            rows = db.fetch_all(
+                f"SELECT DISTINCT {safe_column} AS value FROM {safe_table} "
+                f"WHERE {safe_column} IS NOT NULL AND TRIM({safe_column}) <> '' "
+                f"ORDER BY {safe_column}"
+            )
+            return [row["value"] for row in rows]
+
+        if safe_column == "equipment":
+            rows = db.fetch_all(
+                f"SELECT DISTINCT TRIM({safe_column}) AS value FROM {safe_table} "
+                f"WHERE {safe_column} IS NOT NULL AND TRIM({safe_column}) <> '' "
+                "ORDER BY value"
+            )
+            return [row["value"] for row in rows if row.get("value")]
+
+        rows = db.fetch_all(
+            f"SELECT DISTINCT {safe_column} AS value FROM {safe_table} "
+            f"WHERE {safe_column} IS NOT NULL AND TRIM({safe_column}) <> '' "
+            f"ORDER BY {safe_column}"
+        )
+        return [row["value"] for row in rows if row.get("value")]


### PR DESCRIPTION
## Summary
- move the workout-plan-specific value normalization contract to utils.filter_values.fetch_filter_values
- move the generic /get_unique_values table/column query contract to a separate registry-backed utility
- retain routes.workout_plan.fetch_unique_values as a compatibility wrapper and leave ExerciseManager.fetch_unique_values unchanged
- add direct characterization for enum isolation, normalization, mapping-table values, generic table queries, validation, and failure semantics

## Behavior / migration notes
Behavior-preserving refactor only. Endpoint URLs, JSON envelopes, normalization, ordering, and error status codes are unchanged. No database schema, calculation logic, or migration changes.

## Verification
- focused filter/exercise-manager/API pytest: 92 passed
- full pytest: 1707 passed, with 7 catalog-fixture setup errors caused solely by the intentionally empty worktree seed
- after seeding the worktree-owned catalog snapshot: all affected catalog/invariant cases passed (11 passed)
- blocking flake8 selection: passed
- pyright baseline: 0 net-new diagnostics
- py_compile and git diff --check: passed

CI is the authoritative full-suite and E2E gate (workout-plan, exercise-interactions, API integration).