### PR TITLE
refactor(workout-plan): extract exercise replacement service (WP1.3)

### DIFF
--- a/routes/workout_plan.py
+++ b/routes/workout_plan.py
@@ -8,6 +8,7 @@ from utils.exercise_manager import (
 )
 from utils.errors import success_response, error_response
 from utils.exercise_media import resolve_exercise_media_path
+from utils import exercise_replacement as replacement_service
 from utils.logger import get_logger
 from utils.filter_values import fetch_filter_values
 from utils.constants import ANTAGONIST_PAIRS
@@ -17,6 +18,13 @@ from utils.workout_validation import UNSET, validate_workout_bounds
 
 workout_plan_bp = Blueprint('workout_plan', __name__)
 logger = get_logger()
+
+# Compatibility aliases: callers importing the pre-WP1.3 route helpers keep
+# working while the implementation and DB ownership live in utils.
+suggest_replacement_exercise = replacement_service.suggest_replacement_exercise
+_fetch_current_exercise_details = replacement_service._fetch_current_exercise_details
+_build_replacement_candidates = replacement_service._build_replacement_candidates
+_perform_exercise_swap = replacement_service._perform_exercise_swap
 
 def fetch_unique_values(column):
     """Backward-compatible route-level alias for the extracted contract."""
@@ -878,127 +886,6 @@ def get_generator_options():
         return error_response("INTERNAL_ERROR", "Failed to fetch generator options", 500)
 
 
-def suggest_replacement_exercise(current_exercise, muscle, equipment, candidates, strategy="fallback"):
-    """
-    Suggest a replacement exercise from the candidate pool.
-    
-    Args:
-        current_exercise: The exercise being replaced
-        muscle: Primary muscle group to match
-        equipment: Equipment type to match
-        candidates: List of valid candidate exercise names
-        strategy: "ai" for AI-based suggestion, "fallback" for deterministic
-    
-    Returns:
-        str: Selected exercise name from candidates, or None if no valid candidate
-    """
-    import random
-    
-    if not candidates:
-        return None
-    
-    # AI strategy placeholder - for now, use heuristic ranking
-    # In the future, this could call an LLM or ML model to rank candidates
-    if strategy == "ai":
-        # Simple heuristic: prefer exercises with similar name patterns
-        # (e.g., "Barbell Bench Press" -> prefer other "Bench" or "Press" exercises)
-        current_words = set(current_exercise.lower().split())
-        
-        def score_candidate(candidate):
-            candidate_words = set(candidate.lower().split())
-            # Count overlapping words (excluding common words like "the", "with")
-            common_words = {'the', 'with', 'a', 'an', 'and', 'or', 'for', 'to'}
-            meaningful_current = current_words - common_words
-            meaningful_candidate = candidate_words - common_words
-            overlap = len(meaningful_current & meaningful_candidate)
-            return overlap
-        
-        # Score all candidates
-        scored = [(score_candidate(c), c) for c in candidates]
-        scored.sort(reverse=True, key=lambda x: x[0])
-        
-        # Find the top score and all candidates with that score
-        top_score = scored[0][0]
-        top_candidates = [name for score, name in scored if score == top_score]
-        
-        # If only one top candidate, also include next tier to add variety
-        # This prevents deterministic cycling between just 2 exercises
-        if len(top_candidates) == 1 and len(scored) > 1:
-            second_score = scored[1][0]
-            # Include second-tier candidates if they're close enough (within 1 point)
-            if top_score - second_score <= 1:
-                top_candidates.extend([name for score, name in scored if score == second_score])
-        
-        # Randomly pick from top candidates
-        return random.choice(top_candidates)
-    
-    # Fallback: random selection
-    return random.choice(candidates)
-
-
-def _fetch_current_exercise_details(db: DatabaseHandler, exercise_id: int):
-    return db.fetch_one("""
-        SELECT 
-            us.id, us.routine, us.exercise, us.sets,
-            us.min_rep_range, us.max_rep_range, us.rir, us.rpe, us.weight,
-            e.primary_muscle_group, e.equipment
-        FROM user_selection us
-        LEFT JOIN exercises e ON us.exercise = e.exercise_name
-        WHERE us.id = ?
-    """, (exercise_id,))
-
-
-def _build_replacement_candidates(db: DatabaseHandler, routine: str, muscle: str, equipment: str, current_exercise: str) -> list[str]:
-    candidates_query = """
-        SELECT exercise_name
-        FROM exercises
-        WHERE LOWER(primary_muscle_group) = LOWER(?)
-          AND LOWER(equipment) = LOWER(?)
-          AND LOWER(exercise_name) != LOWER(?)
-    """
-    candidate_rows = db.fetch_all(candidates_query, (muscle, equipment, current_exercise))
-    candidate_names = [row['exercise_name'] for row in candidate_rows]
-    
-    routine_exercises_query = """
-        SELECT exercise FROM user_selection WHERE routine = ?
-    """
-    routine_exercises = db.fetch_all(routine_exercises_query, (routine,))
-    routine_exercise_names_lower = {row['exercise'].lower() for row in routine_exercises}
-    
-    return [c for c in candidate_names if c.lower() not in routine_exercise_names_lower]
-
-
-def _perform_exercise_swap(db: DatabaseHandler, exercise_id: int, new_exercise: str):
-    db.execute_query(
-        "UPDATE user_selection SET exercise = ? WHERE id = ?",
-        (new_exercise, exercise_id)
-    )
-    
-    updated_row_result = db.fetch_one("""
-        SELECT 
-            us.id, us.routine, us.exercise, us.sets,
-            us.min_rep_range, us.max_rep_range, us.rir, us.rpe, us.weight,
-            e.primary_muscle_group, e.secondary_muscle_group,
-            e.tertiary_muscle_group, e.advanced_isolated_muscles,
-            e.utility, e.grips, e.stabilizers, e.synergists, e.equipment
-        FROM user_selection us
-        LEFT JOIN exercises e ON us.exercise = e.exercise_name
-        WHERE us.id = ?
-    """, (exercise_id,))
-    
-    updated_row: dict = dict(updated_row_result) if updated_row_result else {}
-    
-    if column_exists(db, 'user_selection', 'exercise_order'):
-        order_row = db.fetch_one(
-            "SELECT exercise_order FROM user_selection WHERE id = ?",
-            (exercise_id,)
-        )
-        if order_row and order_row.get('exercise_order') is not None:
-            updated_row['exercise_order'] = order_row['exercise_order']
-            
-    return updated_row
-
-
 @workout_plan_bp.route("/replace_exercise", methods=["POST"])
 def replace_exercise():
     """
@@ -1027,99 +914,25 @@ def replace_exercise():
         
         exercise_id = int(exercise_id)
         
-        with DatabaseHandler() as db:
-            current_row = _fetch_current_exercise_details(db, exercise_id)
-            
-            if not current_row:
-                return error_response("NOT_FOUND", "Exercise not found in workout plan", 404, reason="not_found")
-            
-            current_exercise = current_row['exercise']
-            routine = current_row['routine']
-            muscle = current_row['primary_muscle_group']
-            equipment = current_row['equipment']
-            
-            if not muscle or not equipment:
-                logger.warning(
-                    "Cannot replace exercise - missing metadata",
-                    extra={
-                        'exercise_id': exercise_id,
-                        'exercise': current_exercise,
-                        'muscle': muscle,
-                        'equipment': equipment
-                    }
-                )
-                return error_response("VALIDATION_ERROR", "Exercise is missing muscle group or equipment metadata", 400, reason="missing_metadata")
-            
-            valid_candidates = _build_replacement_candidates(db, routine, muscle, equipment, current_exercise)
-            
-            if not valid_candidates:
-                return error_response(
-                    "NO_CANDIDATES",
-                    f"No alternative exercises found for {muscle} with {equipment}",
-                    200,
-                    reason="no_candidates",
-                )
+        result = replacement_service.replace_exercise_for_selection(
+            exercise_id, strategy
+        )
 
-            new_exercise = suggest_replacement_exercise(current_exercise, muscle, equipment, valid_candidates, strategy)
+        return jsonify(success_response(
+            data=result,
+            message=(
+                f"Replaced {result['old_exercise']} with "
+                f"{result['new_exercise']}"
+            )
+        ))
 
-            if not new_exercise:
-                return error_response(
-                    "SELECTION_FAILED",
-                    "Failed to select replacement exercise",
-                    200,
-                    reason="selection_failed",
-                )
-            
-            duplicate_check = db.fetch_one(
-                "SELECT id FROM user_selection WHERE routine = ? AND LOWER(exercise) = LOWER(?)",
-                (routine, new_exercise)
-            )
-            
-            if duplicate_check:
-                remaining_candidates = [c for c in valid_candidates if c.lower() != new_exercise.lower()]
-                if remaining_candidates:
-                    new_exercise = suggest_replacement_exercise(current_exercise, muscle, equipment, remaining_candidates, "fallback")
-                    if not new_exercise:
-                        return error_response(
-                            "SELECTION_FAILED",
-                            "Failed to select replacement exercise",
-                            200,
-                            reason="selection_failed",
-                        )
-                else:
-                    return error_response(
-                        "DUPLICATE",
-                        "All candidate exercises are already in this routine",
-                        200,
-                        reason="duplicate",
-                    )
-            
-            updated_row = _perform_exercise_swap(db, exercise_id, new_exercise)
-            
-            logger.info(
-                "Exercise replaced successfully",
-                extra={
-                    'exercise_id': exercise_id,
-                    'routine': routine,
-                    'old_exercise': current_exercise,
-                    'new_exercise': new_exercise,
-                    'muscle': muscle,
-                    'equipment': equipment,
-                    'candidates_available': len(valid_candidates)
-                }
-            )
-            
-            remaining_options = len([c for c in valid_candidates if c.lower() != new_exercise.lower()])
-            
-            return jsonify(success_response(
-                data={
-                    "updated_row": updated_row,
-                    "old_exercise": current_exercise,
-                    "new_exercise": new_exercise,
-                    "remaining_options": remaining_options
-                },
-                message=f"Replaced {current_exercise} with {new_exercise}"
-            ))
+    except replacement_service.ExerciseReplacementError as e:
+        return error_response(
+            e.code,
+            e.message,
+            e.status_code,
+            reason=e.reason,
+        )
             
     except Exception as e:
         logger.exception(

--- a/tests/test_replace_exercise.py
+++ b/tests/test_replace_exercise.py
@@ -2,6 +2,52 @@
 Tests for the Replace/Swap Exercise feature.
 Tests the POST /replace_exercise endpoint functionality.
 """
+import subprocess
+import sys
+
+import pytest
+
+
+@pytest.mark.parametrize(
+    "imports",
+    [
+        "import routes.workout_plan; import utils.exercise_replacement",
+        "import utils.exercise_replacement; import routes.workout_plan",
+    ],
+)
+def test_replacement_modules_import_in_either_order(imports):
+    """The extracted service and compatibility route have no import cycle."""
+    completed = subprocess.run(
+        [sys.executable, "-c", imports],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+    assert completed.returncode == 0, completed.stderr
+
+
+def test_route_helper_imports_remain_compatible():
+    """The pre-extraction route helper paths remain valid aliases."""
+    from routes import workout_plan
+    from utils import exercise_replacement
+
+    assert (
+        workout_plan.suggest_replacement_exercise
+        is exercise_replacement.suggest_replacement_exercise
+    )
+    assert (
+        workout_plan._fetch_current_exercise_details
+        is exercise_replacement._fetch_current_exercise_details
+    )
+    assert (
+        workout_plan._build_replacement_candidates
+        is exercise_replacement._build_replacement_candidates
+    )
+    assert (
+        workout_plan._perform_exercise_swap
+        is exercise_replacement._perform_exercise_swap
+    )
 
 
 class TestReplaceExerciseEndpoint:
@@ -60,6 +106,105 @@ class TestReplaceExerciseEndpoint:
         assert data['ok'] is False
         assert 'error' in data
         assert data['error']['reason'] == 'no_candidates'
+
+    def test_replace_exercise_missing_metadata(
+        self, client, exercise_factory, workout_plan_factory
+    ):
+        """Missing catalog metadata keeps its exact validation contract."""
+        exercise = exercise_factory(
+            "Incomplete Exercise",
+            primary_muscle_group=None,
+            equipment="Barbell",
+        )
+        plan_id = workout_plan_factory(
+            exercise_name=exercise, routine="Test Routine"
+        )
+
+        response = client.post('/replace_exercise', json={"id": plan_id})
+
+        assert response.status_code == 400
+        data = response.get_json()
+        assert data['ok'] is False
+        assert data['error']['code'] == 'VALIDATION_ERROR'
+        assert data['error']['reason'] == 'missing_metadata'
+        assert data['error']['message'] == (
+            "Exercise is missing muscle group or equipment metadata"
+        )
+
+    def test_replace_exercise_selection_failed_stays_http_200(
+        self,
+        client,
+        exercise_factory,
+        workout_plan_factory,
+        monkeypatch,
+    ):
+        """Selection failure is a processable user outcome, not an HTTP error."""
+        from utils import exercise_replacement
+
+        current = exercise_factory(
+            "Current Press", primary_muscle_group="Chest", equipment="Barbell"
+        )
+        exercise_factory(
+            "Alternative Press",
+            primary_muscle_group="Chest",
+            equipment="Barbell",
+        )
+        plan_id = workout_plan_factory(exercise_name=current, routine="Press Day")
+        monkeypatch.setattr(
+            exercise_replacement,
+            "suggest_replacement_exercise",
+            lambda *args, **kwargs: None,
+        )
+
+        response = client.post('/replace_exercise', json={"id": plan_id})
+
+        assert response.status_code == 200
+        data = response.get_json()
+        assert data['ok'] is False
+        assert data['error']['code'] == 'SELECTION_FAILED'
+        assert data['error']['reason'] == 'selection_failed'
+        assert data['error']['message'] == "Failed to select replacement exercise"
+
+    def test_replace_exercise_duplicate_stays_http_200(
+        self,
+        client,
+        exercise_factory,
+        workout_plan_factory,
+        monkeypatch,
+    ):
+        """The defensive post-selection duplicate outcome remains HTTP 200."""
+        from utils import exercise_replacement
+
+        current = exercise_factory(
+            "Current Row", primary_muscle_group="Chest", equipment="Barbell"
+        )
+        duplicate = exercise_factory(
+            "Existing Row", primary_muscle_group="Chest", equipment="Barbell"
+        )
+        routine = "Duplicate Routine"
+        plan_id = workout_plan_factory(exercise_name=current, routine=routine)
+        workout_plan_factory(exercise_name=duplicate, routine=routine)
+        monkeypatch.setattr(
+            exercise_replacement,
+            "_build_replacement_candidates",
+            lambda *args, **kwargs: [duplicate],
+        )
+        monkeypatch.setattr(
+            exercise_replacement,
+            "suggest_replacement_exercise",
+            lambda *args, **kwargs: duplicate,
+        )
+
+        response = client.post('/replace_exercise', json={"id": plan_id})
+
+        assert response.status_code == 200
+        data = response.get_json()
+        assert data['ok'] is False
+        assert data['error']['code'] == 'DUPLICATE'
+        assert data['error']['reason'] == 'duplicate'
+        assert data['error']['message'] == (
+            "All candidate exercises are already in this routine"
+        )
     
     def test_replace_exercise_avoids_duplicates(self, client, exercise_factory, workout_plan_factory):
         """Test that replacement avoids exercises already in routine."""

--- a/utils/exercise_replacement.py
+++ b/utils/exercise_replacement.py
@@ -1,0 +1,300 @@
+"""Exercise-replacement selection and persistence service.
+
+Routes retain request parsing and response shaping.  This module owns the
+candidate query, case-insensitive routine de-duplication, selection/retry
+policy, and the exercise-name swap in ``user_selection``.
+"""
+from __future__ import annotations
+
+from typing import Any
+
+from utils.database import DatabaseHandler
+from utils.logger import get_logger
+
+logger = get_logger()
+
+
+class ExerciseReplacementError(Exception):
+    """A user-facing replacement outcome mapped by the HTTP route."""
+
+    def __init__(
+        self,
+        code: str,
+        message: str,
+        status_code: int,
+        reason: str,
+    ) -> None:
+        super().__init__(message)
+        self.code = code
+        self.message = message
+        self.status_code = status_code
+        self.reason = reason
+
+
+def suggest_replacement_exercise(
+    current_exercise: str,
+    muscle: str,
+    equipment: str,
+    candidates: list[str],
+    strategy: str = "fallback",
+):
+    """Suggest a replacement exercise from the candidate pool."""
+    import random
+
+    if not candidates:
+        return None
+
+    # AI strategy placeholder - for now, use heuristic ranking
+    # In the future, this could call an LLM or ML model to rank candidates
+    if strategy == "ai":
+        # Simple heuristic: prefer exercises with similar name patterns
+        # (e.g., "Barbell Bench Press" -> prefer other "Bench" or "Press" exercises)
+        current_words = set(current_exercise.lower().split())
+
+        def score_candidate(candidate):
+            candidate_words = set(candidate.lower().split())
+            # Count overlapping words (excluding common words like "the", "with")
+            common_words = {'the', 'with', 'a', 'an', 'and', 'or', 'for', 'to'}
+            meaningful_current = current_words - common_words
+            meaningful_candidate = candidate_words - common_words
+            overlap = len(meaningful_current & meaningful_candidate)
+            return overlap
+
+        # Score all candidates
+        scored = [(score_candidate(c), c) for c in candidates]
+        scored.sort(reverse=True, key=lambda x: x[0])
+
+        # Find the top score and all candidates with that score
+        top_score = scored[0][0]
+        top_candidates = [name for score, name in scored if score == top_score]
+
+        # If only one top candidate, also include next tier to add variety
+        # This prevents deterministic cycling between just 2 exercises
+        if len(top_candidates) == 1 and len(scored) > 1:
+            second_score = scored[1][0]
+            # Include second-tier candidates if they're close enough (within 1 point)
+            if top_score - second_score <= 1:
+                top_candidates.extend(
+                    [name for score, name in scored if score == second_score]
+                )
+
+        # Randomly pick from top candidates
+        return random.choice(top_candidates)
+
+    # Fallback: random selection
+    return random.choice(candidates)
+
+
+def _fetch_current_exercise_details(db: DatabaseHandler, exercise_id: int):
+    return db.fetch_one("""
+        SELECT
+            us.id, us.routine, us.exercise, us.sets,
+            us.min_rep_range, us.max_rep_range, us.rir, us.rpe, us.weight,
+            e.primary_muscle_group, e.equipment
+        FROM user_selection us
+        LEFT JOIN exercises e ON us.exercise = e.exercise_name
+        WHERE us.id = ?
+    """, (exercise_id,))
+
+
+def _build_replacement_candidates(
+    db: DatabaseHandler,
+    routine: str,
+    muscle: str,
+    equipment: str,
+    current_exercise: str,
+) -> list[str]:
+    candidates_query = """
+        SELECT exercise_name
+        FROM exercises
+        WHERE LOWER(primary_muscle_group) = LOWER(?)
+          AND LOWER(equipment) = LOWER(?)
+          AND LOWER(exercise_name) != LOWER(?)
+    """
+    candidate_rows = db.fetch_all(
+        candidates_query, (muscle, equipment, current_exercise)
+    )
+    candidate_names = [row['exercise_name'] for row in candidate_rows]
+
+    routine_exercises_query = """
+        SELECT exercise FROM user_selection WHERE routine = ?
+    """
+    routine_exercises = db.fetch_all(routine_exercises_query, (routine,))
+    routine_exercise_names_lower = {
+        row['exercise'].lower() for row in routine_exercises
+    }
+
+    return [
+        candidate
+        for candidate in candidate_names
+        if candidate.lower() not in routine_exercise_names_lower
+    ]
+
+
+def _column_exists(db: DatabaseHandler, table_name: str, column_name: str) -> bool:
+    columns = db.fetch_all(f"PRAGMA table_info({table_name})")
+    return any(column['name'] == column_name for column in columns)
+
+
+def _perform_exercise_swap(
+    db: DatabaseHandler, exercise_id: int, new_exercise: str
+) -> dict[str, Any]:
+    db.execute_query(
+        "UPDATE user_selection SET exercise = ? WHERE id = ?",
+        (new_exercise, exercise_id),
+    )
+
+    updated_row_result = db.fetch_one("""
+        SELECT
+            us.id, us.routine, us.exercise, us.sets,
+            us.min_rep_range, us.max_rep_range, us.rir, us.rpe, us.weight,
+            e.primary_muscle_group, e.secondary_muscle_group,
+            e.tertiary_muscle_group, e.advanced_isolated_muscles,
+            e.utility, e.grips, e.stabilizers, e.synergists, e.equipment
+        FROM user_selection us
+        LEFT JOIN exercises e ON us.exercise = e.exercise_name
+        WHERE us.id = ?
+    """, (exercise_id,))
+
+    updated_row: dict[str, Any] = (
+        dict(updated_row_result) if updated_row_result else {}
+    )
+
+    if _column_exists(db, 'user_selection', 'exercise_order'):
+        order_row = db.fetch_one(
+            "SELECT exercise_order FROM user_selection WHERE id = ?",
+            (exercise_id,),
+        )
+        if order_row and order_row.get('exercise_order') is not None:
+            updated_row['exercise_order'] = order_row['exercise_order']
+
+    return updated_row
+
+
+def replace_exercise_for_selection(
+    exercise_id: int, strategy: str = "fallback"
+) -> dict[str, Any]:
+    """Select and persist a replacement for one workout-plan row."""
+    with DatabaseHandler() as db:
+        current_row = _fetch_current_exercise_details(db, exercise_id)
+
+        if not current_row:
+            raise ExerciseReplacementError(
+                "NOT_FOUND",
+                "Exercise not found in workout plan",
+                404,
+                "not_found",
+            )
+
+        current_exercise = current_row['exercise']
+        routine = current_row['routine']
+        muscle = current_row['primary_muscle_group']
+        equipment = current_row['equipment']
+
+        if not muscle or not equipment:
+            logger.warning(
+                "Cannot replace exercise - missing metadata",
+                extra={
+                    'exercise_id': exercise_id,
+                    'exercise': current_exercise,
+                    'muscle': muscle,
+                    'equipment': equipment,
+                },
+            )
+            raise ExerciseReplacementError(
+                "VALIDATION_ERROR",
+                "Exercise is missing muscle group or equipment metadata",
+                400,
+                "missing_metadata",
+            )
+
+        valid_candidates = _build_replacement_candidates(
+            db, routine, muscle, equipment, current_exercise
+        )
+
+        if not valid_candidates:
+            raise ExerciseReplacementError(
+                "NO_CANDIDATES",
+                f"No alternative exercises found for {muscle} with {equipment}",
+                200,
+                "no_candidates",
+            )
+
+        new_exercise = suggest_replacement_exercise(
+            current_exercise,
+            muscle,
+            equipment,
+            valid_candidates,
+            strategy,
+        )
+
+        if not new_exercise:
+            raise ExerciseReplacementError(
+                "SELECTION_FAILED",
+                "Failed to select replacement exercise",
+                200,
+                "selection_failed",
+            )
+
+        duplicate_check = db.fetch_one(
+            "SELECT id FROM user_selection "
+            "WHERE routine = ? AND LOWER(exercise) = LOWER(?)",
+            (routine, new_exercise),
+        )
+
+        if duplicate_check:
+            remaining_candidates = [
+                candidate
+                for candidate in valid_candidates
+                if candidate.lower() != new_exercise.lower()
+            ]
+            if remaining_candidates:
+                new_exercise = suggest_replacement_exercise(
+                    current_exercise,
+                    muscle,
+                    equipment,
+                    remaining_candidates,
+                    "fallback",
+                )
+                if not new_exercise:
+                    raise ExerciseReplacementError(
+                        "SELECTION_FAILED",
+                        "Failed to select replacement exercise",
+                        200,
+                        "selection_failed",
+                    )
+            else:
+                raise ExerciseReplacementError(
+                    "DUPLICATE",
+                    "All candidate exercises are already in this routine",
+                    200,
+                    "duplicate",
+                )
+
+        updated_row = _perform_exercise_swap(db, exercise_id, new_exercise)
+
+        logger.info(
+            "Exercise replaced successfully",
+            extra={
+                'exercise_id': exercise_id,
+                'routine': routine,
+                'old_exercise': current_exercise,
+                'new_exercise': new_exercise,
+                'muscle': muscle,
+                'equipment': equipment,
+                'candidates_available': len(valid_candidates),
+            },
+        )
+
+        remaining_options = len([
+            candidate
+            for candidate in valid_candidates
+            if candidate.lower() != new_exercise.lower()
+        ])
+
+        return {
+            "updated_row": updated_row,
+            "old_exercise": current_exercise,
+            "new_exercise": new_exercise,
+            "remaining_options": remaining_options,
+        }


### PR DESCRIPTION
## Summary
- extract replace-exercise candidate queries, case-insensitive de-duplication, selection/retry policy, and swap persistence into `utils/exercise_replacement.py`
- reduce `POST /replace_exercise` to request parsing, service delegation, and response shaping
- retain the four former `routes.workout_plan` helper import paths as compatibility aliases
- characterize both import orders and the `missing_metadata`, `SELECTION_FAILED`, and `DUPLICATE` response contracts

## Behavior and migration notes
Behavior-preserving refactor only. No database schema or calculation changes, no endpoint migration, and no frontend migration is required. `POST /replace_exercise` keeps its URL, request body, success payload/message, error codes/messages/reasons, and status codes. In particular, `NO_CANDIDATES`, `DUPLICATE`, and `SELECTION_FAILED` remain HTTP 200 with `ok: false`. Existing route-level helper imports continue to resolve to the extracted implementations.

## Verification
- `.venv/Scripts/python.exe -m pytest tests/test_replace_exercise.py -q` — 17 passed
- `.venv/Scripts/python.exe -m pytest tests/test_workout_plan_routes.py tests/test_ui_flows.py -q` — 63 passed
- blocking flake8 rules on changed files — passed
- `py_compile` and both service/route import orders — passed
- pyright baseline diff — passed, 0 net-new diagnostics (baseline 186, current 175); no diagnostics in the new service or replacement tests
- `git diff --check` — passed

Full pytest and the plan-required Playwright specs (`replace-exercise-errors.spec.ts`, `workout-plan.spec.ts`) are delegated to CI as the authoritative isolated gate.