### PR TITLE
fix(exports): keep Excel export read-only (WPB.3)

### DIFF
--- a/docs/REFACTOR_PLAN.md
+++ b/docs/REFACTOR_PLAN.md
@@ -147,7 +147,7 @@ All ten decisions recorded with the owner on 2026-07-04.
 |---|---|---|
 | OD1 | Is plan weight `0` valid for bodyweight/assisted exercises? | **Allow 0 kg.** Behavior-change WP: fix the falsy-check family (`exercise_manager.py` weight, plus order=0 in remove/reorder), rewrite `test_add_exercise_missing_weight` accordingly. |
 | OD2 | What are canonical server bounds for plan/log updates? | **Add sanity bounds.** Behavior-change WP: define and enforce server-side limits (weight ≥0 with sane cap, RIR 0–10, min-reps ≤ max-reps) on add/update paths; new tests; docs then become true. |
-| OD3 | Should export-to-log mutate `exercise_order`, and should that endpoint remain GET? | **Fix it.** Behavior-change WP: export-to-log stops mutating `exercise_order`; endpoint moves to POST. WP1.8 still extracts the current behavior first, preserved; the fix lands as its own PR after. |
+| OD3 | Should `GET /export_to_excel` mutate `exercise_order` while assembling a workbook? | **Fix it.** Behavior-change WP: remove the hidden `recalculate_exercise_order` write from Excel export after WP1.8 extracts it. `/export_to_workout_log` was already POST-only and all repository callers already used POST, so no method or frontend migration is needed. |
 | OD4 | Null routines: dropped from weekly frequency or bucketed as `Unassigned`? | **Unify as `Unassigned`.** Behavior-change WP on a protected calc zone: weekly summary gains an Unassigned bucket matching session summary. Golden fixtures (WP2.3) must land first; product-risk review required. |
 | OD5 | Is the novice branch in `_calculate_weight_increment` a no-op below 20 kg intentionally? | **Make experience matter.** Behavior-change WP on a protected zone: experienced lifters get +5 kg below 20 kg too. Regression tests on both experience levels around the 20 kg boundary. |
 | OD6 | Remove/deprecate the five frontend-unreferenced HTTP endpoints? | **Remove them.** Contract-removal WP: delete `/get_routine_options`, `/get_user_selection`, `/get_exercise_details/<id>`, `/get_filtered_exercises`, `/get_unique_values/<table>/<column>` plus their tests, with migration notes. Sequence AFTER WP1.1/WP1.2 (the last one is in scope there). |
@@ -249,8 +249,11 @@ per the sign-off checklist.
 **Status at `main` @ `cbd5a25` (2026-07-05):** WPB.1 (#103), WPB.2 (#107),
 WPB.5 (#101), WPB.7 (#102), WPB.8 (#104), and WPB.9 are shipped. WPB.9's job
 landed in #100 and became required after ten consecutive green PRs (#100–#109),
-without renaming or removing an existing context. WPB.3, WPB.4, and WPB.6 remain
-prerequisite-gated.
+without renaming or removing an existing context. At that baseline, WPB.3, WPB.4,
+and WPB.6 remained prerequisite-gated.
+
+**Current update (2026-07-07):** WP1.8 landed in #122; WPB.3 is implemented in #128
+and awaiting review/CI. WPB.4 and WPB.6 remain prerequisite-gated.
 
 ### WPB.1 (OD1) Allow plan weight 0 for bodyweight/assisted exercises
 
@@ -272,13 +275,17 @@ prerequisite-gated.
   WP1.1 if concurrent — the allowlist/validator module is the natural home.
 - Gate: plan/log pytest families plus `workout-plan.spec.ts` and `workout-log.spec.ts`.
 
-### WPB.3 (OD3) Export-to-log stops mutating order; endpoint becomes POST
+### WPB.3 (OD3) Excel export stops mutating exercise order
 
-- Export-to-log no longer writes `exercise_order`; the endpoint moves GET → POST.
-- Update the frontend caller(s) in the same PR; this is an API-shape change — migration
-  notes mandatory.
-- Prerequisite: **WP1.8 first** (extracts current behavior preserved); this fix lands
-  as its own PR after.
+- Remove the `recalculate_exercise_order` write from `GET /export_to_excel`; workbook
+  assembly becomes read-only even when stored order values are duplicate or `NULL`.
+- `/export_to_workout_log` was already POST-only, and both live frontend callers plus
+  active pytest/E2E callers already used POST. Pin that contract in tests; no method or
+  frontend migration is required.
+- Migration note: startup `initialize_exercise_order()` still initializes `NULL` values.
+  It does not repair duplicate non-NULL order values; those remain unchanged until an
+  explicit reorder operation.
+- Prerequisite: **WP1.8 first** (landed in #122). Implementation: #128 (in review).
 - Gate: export pytest family plus the export/workout-log E2E paths.
 
 ### WPB.4 (OD4) Weekly summary `Unassigned` bucket for null routines
@@ -515,7 +522,7 @@ all endpoint URLs and response envelopes unless an OD-approved contract WP says 
 
 - Move mapping tables, dataframe transforms, query construction, sheet assembly, and
   export-to-log persistence into utils modules.
-- Preserve the exercise-order side effect pending OD3.
+- Preserve `GET /export_to_excel`'s exercise-order side effect pending OD3.
 - Gate: export pytest plus plan export/download and workout-log import flows.
 
 `routes/user_profile.py` needs no extraction WP: its handlers are already thin; the file's

--- a/tests/test_exports.py
+++ b/tests/test_exports.py
@@ -342,6 +342,38 @@ class TestExportsEndpoints:
         assert data['status'] == 'success'
         assert 'message' in data
 
+    def test_export_to_workout_log_rejects_get(self, client, sample_workout_plan):
+        """Importing a plan is a write operation and must remain POST-only."""
+        response = client.get('/export_to_workout_log')
+
+        assert response.status_code == 405
+
+    def test_export_to_workout_log_preserves_exercise_order(
+        self, client, sample_workout_plan
+    ):
+        """Importing a plan must not repair or otherwise rewrite plan ordering."""
+        from utils.database import DatabaseHandler
+
+        with DatabaseHandler() as db:
+            db.execute_query("UPDATE user_selection SET exercise_order = NULL")
+            before_rows = db.fetch_all(
+                "SELECT id, exercise_order FROM user_selection ORDER BY id"
+            )
+            before_snapshot = [
+                (row["id"], row["exercise_order"]) for row in before_rows
+            ]
+
+        response = client.post('/export_to_workout_log')
+
+        assert response.status_code == 200
+        with DatabaseHandler() as db:
+            after_rows = db.fetch_all(
+                "SELECT id, exercise_order FROM user_selection ORDER BY id"
+            )
+        assert [
+            (row["id"], row["exercise_order"]) for row in after_rows
+        ] == before_snapshot
+
     @pytest.mark.parametrize(
         ("weight", "rir", "minimum", "maximum"),
         [(0, 0, 8, 8), (1000, 10, 8, 12)],
@@ -523,137 +555,20 @@ class TestExportErrorHandling:
         assert int(response.headers.get('Content-Length', '0')) > 0
 
 
-class TestExportNPlusOneRecalculation:
-    """Test N+1 UPDATE loop fixes and atomic exercise_order recalculations."""
-    
-    def test_recalculate_exercise_order_success(self, client, clean_database):
-        """Test success path with multiple rows needing recalculation."""
+class TestExcelExportReadOnlyContract:
+    """Regression coverage for OD3's read-only Excel export contract."""
+
+    def test_export_to_excel_preserves_exercise_order(self, client, clean_database):
+        """Excel export must preserve duplicate and NULL ordering values exactly."""
         from utils.database import DatabaseHandler
-        
-        # Setup rows with missing exercise_order
-        with DatabaseHandler() as db:
-            db.execute_query("INSERT OR IGNORE INTO exercises (exercise_name, primary_muscle_group) VALUES ('Squat', 'Legs')")
-            db.execute_query("INSERT OR IGNORE INTO exercises (exercise_name, primary_muscle_group) VALUES ('Bench Press', 'Chest')")
-            db.execute_query("INSERT OR IGNORE INTO exercises (exercise_name, primary_muscle_group) VALUES ('Deadlift', 'Back')")
-            db.execute_query("INSERT INTO user_selection (routine, exercise, sets, min_rep_range, max_rep_range, weight) VALUES ('A', 'Squat', 3, 8, 12, 100)")
-            db.execute_query("INSERT INTO user_selection (routine, exercise, sets, min_rep_range, max_rep_range, weight) VALUES ('A', 'Bench Press', 3, 8, 12, 100)")
-            db.execute_query("INSERT INTO user_selection (routine, exercise, sets, min_rep_range, max_rep_range, weight) VALUES ('B', 'Deadlift', 3, 8, 12, 100)")
-        
-        # Trigger export, which should recalculate
-        response = client.get('/export_to_excel')
-        assert response.status_code == 200
-        
-        # Verify the database state has updated exercise_order values
-        with DatabaseHandler() as db:
-            rows = db.fetch_all("SELECT routine, exercise, exercise_order FROM user_selection ORDER BY exercise_order")
-            
-            assert len(rows) == 3
-            # Should be ordered 1, 2, 3 and no NULLs
-            orders = [r['exercise_order'] for r in rows]
-            assert all(o is not None for o in orders)
-            assert sorted(orders) == [1, 2, 3]
-
-    def test_recalculate_exercise_order_atomic_failure(self, client, clean_database, caplog):
-        """Test real SQLite rollback semantics if atomic batch mode fails."""
-        import logging
-        from utils.database import DatabaseHandler
-        from routes.workout_plan import column_exists
-        
-        # Setup rows
-        with DatabaseHandler() as db:
-            db.execute_query("INSERT OR IGNORE INTO exercises (exercise_name, primary_muscle_group) VALUES ('Squat', 'Legs')")
-            db.execute_query("INSERT OR IGNORE INTO exercises (exercise_name, primary_muscle_group) VALUES ('Bench Press', 'Chest')")
-            db.execute_query("INSERT OR IGNORE INTO exercises (exercise_name, primary_muscle_group) VALUES ('Deadlift', 'Back')")
-            db.execute_query("INSERT INTO user_selection (routine, exercise, sets, min_rep_range, max_rep_range, weight) VALUES ('A', 'Squat', 3, 8, 12, 100)")
-            db.execute_query("INSERT INTO user_selection (routine, exercise, sets, min_rep_range, max_rep_range, weight) VALUES ('A', 'Bench Press', 3, 8, 12, 100)")
-            db.execute_query("INSERT INTO user_selection (routine, exercise, sets, min_rep_range, max_rep_range, weight) VALUES ('B', 'Deadlift', 3, 8, 12, 100)")
-
-            assert column_exists(db, "user_selection", "exercise_order"), (
-                "exercise_order column missing - schema regression"
-            )
-            before_rows = db.fetch_all(
-                "SELECT id, exercise_order FROM user_selection ORDER BY id"
-            )
-            before_snapshot = [(row["id"], row["exercise_order"]) for row in before_rows]
-
-            db.execute_query("DROP TRIGGER IF EXISTS fail_exercise_order_mid_batch")
-            db.execute_query("""
-                CREATE TRIGGER fail_exercise_order_mid_batch
-                BEFORE UPDATE OF exercise_order ON user_selection
-                WHEN NEW.exercise_order = 2
-                BEGIN
-                    SELECT RAISE(ABORT, 'simulated mid-batch failure');
-                END
-            """)
-
-        caplog.set_level(logging.ERROR, logger="hypertrophy_toolbox")
-
-        try:
-            # Trigger export. Production catches the recalc failure and still returns the workbook.
-            response = client.get('/export_to_excel')
-            assert response.status_code == 200
-            assert response.mimetype == 'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet'
-
-            # The first attempted UPDATE must be rolled back after the trigger aborts the batch.
-            with DatabaseHandler() as db:
-                after_rows = db.fetch_all(
-                    "SELECT id, exercise_order FROM user_selection ORDER BY id"
-                )
-                after_snapshot = [(row["id"], row["exercise_order"]) for row in after_rows]
-        finally:
-            with DatabaseHandler() as db:
-                db.execute_query("DROP TRIGGER IF EXISTS fail_exercise_order_mid_batch")
-
-        assert after_snapshot == before_snapshot
-        assert any(
-            "Error performing batch update for exercise_order" in record.getMessage()
-            and record.levelno >= logging.ERROR
-            for record in caplog.records
-        )
-
-    def test_recalculate_exercise_order_null_initialization(self, client, clean_database):
-        """Rows with NULL exercise_order are initialized sequentially during export."""
-        from utils.database import DatabaseHandler
-        from routes.workout_plan import column_exists
-
-        with DatabaseHandler() as db:
-            db.execute_query("INSERT OR IGNORE INTO exercises (exercise_name, primary_muscle_group) VALUES ('Squat', 'Legs')")
-            db.execute_query("INSERT OR IGNORE INTO exercises (exercise_name, primary_muscle_group) VALUES ('Bench Press', 'Chest')")
-            db.execute_query("INSERT OR IGNORE INTO exercises (exercise_name, primary_muscle_group) VALUES ('Deadlift', 'Back')")
-            db.execute_query("INSERT INTO user_selection (routine, exercise, sets, min_rep_range, max_rep_range, weight, exercise_order) VALUES ('B', 'Deadlift', 3, 8, 12, 100, NULL)")
-            db.execute_query("INSERT INTO user_selection (routine, exercise, sets, min_rep_range, max_rep_range, weight, exercise_order) VALUES ('A', 'Squat', 3, 8, 12, 100, NULL)")
-            db.execute_query("INSERT INTO user_selection (routine, exercise, sets, min_rep_range, max_rep_range, weight, exercise_order) VALUES ('A', 'Bench Press', 3, 8, 12, 100, NULL)")
-
-            assert column_exists(db, "user_selection", "exercise_order"), (
-                "exercise_order column missing - schema regression"
-            )
-
-        response = client.get('/export_to_excel')
-        assert response.status_code == 200
-
-        with DatabaseHandler() as db:
-            rows = db.fetch_all(
-                "SELECT routine, exercise, exercise_order FROM user_selection ORDER BY routine, exercise, id"
-            )
-
-        assert [row["exercise_order"] for row in rows] == [1, 2, 3]
-
-    def test_recalculate_exercise_order_no_op(self, client, clean_database):
-        """Already sequential exercise_order values are left unchanged during export."""
-        from utils.database import DatabaseHandler
-        from routes.workout_plan import column_exists
 
         with DatabaseHandler() as db:
             db.execute_query("INSERT OR IGNORE INTO exercises (exercise_name, primary_muscle_group) VALUES ('Bench Press', 'Chest')")
             db.execute_query("INSERT OR IGNORE INTO exercises (exercise_name, primary_muscle_group) VALUES ('Squat', 'Legs')")
             db.execute_query("INSERT OR IGNORE INTO exercises (exercise_name, primary_muscle_group) VALUES ('Deadlift', 'Back')")
             db.execute_query("INSERT INTO user_selection (routine, exercise, sets, min_rep_range, max_rep_range, weight, exercise_order) VALUES ('A', 'Bench Press', 3, 8, 12, 100, 1)")
-            db.execute_query("INSERT INTO user_selection (routine, exercise, sets, min_rep_range, max_rep_range, weight, exercise_order) VALUES ('A', 'Squat', 3, 8, 12, 100, 2)")
-            db.execute_query("INSERT INTO user_selection (routine, exercise, sets, min_rep_range, max_rep_range, weight, exercise_order) VALUES ('B', 'Deadlift', 3, 8, 12, 100, 3)")
-
-            assert column_exists(db, "user_selection", "exercise_order"), (
-                "exercise_order column missing - schema regression"
-            )
+            db.execute_query("INSERT INTO user_selection (routine, exercise, sets, min_rep_range, max_rep_range, weight, exercise_order) VALUES ('A', 'Squat', 3, 8, 12, 100, 1)")
+            db.execute_query("INSERT INTO user_selection (routine, exercise, sets, min_rep_range, max_rep_range, weight, exercise_order) VALUES ('B', 'Deadlift', 3, 8, 12, 100, NULL)")
             before_rows = db.fetch_all(
                 "SELECT id, exercise_order FROM user_selection ORDER BY id"
             )

--- a/utils/export_service.py
+++ b/utils/export_service.py
@@ -241,50 +241,6 @@ def reorder_and_rename_columns(data, column_config, view_mode='simple'):
     return reordered_data
 
 
-def recalculate_exercise_order(db):
-    """Check dataset state and recalculate sequential order if needed."""
-    if not _column_exists(db, 'user_selection', 'exercise_order'):
-        return
-
-    # Check current state of exercise_order
-    total_check = db.fetch_one("SELECT COUNT(*) as count FROM user_selection")
-    order_check = db.fetch_one("SELECT COUNT(DISTINCT exercise_order) as distinct_count, COUNT(*) as total_count FROM user_selection WHERE exercise_order IS NOT NULL")
-
-    # Recalculate if all values are the same (like all "1") or NULL
-    needs_recalc = False
-    if total_check and total_check['count'] > 0:
-        if order_check and order_check['distinct_count'] == 1:
-            logger.info(f"All exercise_order values are the same ({order_check['distinct_count']} distinct). Recalculating...")
-            needs_recalc = True
-        elif order_check and order_check['total_count'] < total_check['count']:
-            logger.info(f"Some exercise_order values are NULL. Initializing...")
-            needs_recalc = True
-
-    if needs_recalc:
-        logger.info(f"Recalculating exercise_order for {total_check['count']} rows")
-        ordered_rows = db.fetch_all("""
-            SELECT id FROM user_selection
-            ORDER BY routine, exercise, id
-        """)
-        logger.info(f"Found {len(ordered_rows)} rows to update")
-
-        # Semantic change: N+1 update loop changed to atomic batch.
-        # This changes behavior from partial-success logging per-row to all-or-nothing batch update.
-        batch_params = [(index, row['id']) for index, row in enumerate(ordered_rows, start=1)]
-        try:
-            db.executemany(
-                "UPDATE user_selection SET exercise_order = ? WHERE id = ?",
-                batch_params
-            )
-            updated_count = len(batch_params)
-        except Exception as e:
-            logger.error(f"Error performing batch update for exercise_order: {e}")
-            updated_count = 0
-
-        verify = db.fetch_one("SELECT COUNT(DISTINCT exercise_order) as distinct_count FROM user_selection WHERE exercise_order IS NOT NULL")
-        logger.info(f"exercise_order recalculated: {updated_count} rows updated, {verify['distinct_count'] if verify else 0} distinct values")
-
-
 def build_export_query(db):
     """Build the SQL query for the user selection export based on available columns."""
     has_superset = _column_exists(db, 'user_selection', 'superset_group')
@@ -412,9 +368,8 @@ def fetch_all_sheets(db, view_mode):
 
 
 def collect_excel_sheets(view_mode):
-    """Recalculate exercise order (side effect, pending OD3) and assemble all sheets."""
+    """Assemble all Excel sheets without mutating the exported data."""
     with DatabaseHandler() as db:
-        recalculate_exercise_order(db)
         return fetch_all_sheets(db, view_mode)
 
 


### PR DESCRIPTION
## Summary
- remove the hidden `exercise_order` repair/write from `GET /export_to_excel`
- keep workbook assembly read-only even when stored order values are duplicate or `NULL`
- pin plan-to-log import as POST-only and verify that it also preserves `exercise_order`

## Migration notes
This is the owner-approved WPB.3 / OD3 behavior-contract change.

- `GET /export_to_excel` no longer rewrites `user_selection.exercise_order`. Callers that relied on an Excel download to repair legacy/degenerate ordering must instead use the explicit startup/order-management paths.
- `/export_to_workout_log` is POST-only; GET returns HTTP 405. Repository history shows this route and both live frontend callers were already POST before WPB.3, so no frontend code migration was necessary. The caller inventory covers `static/js/modules/exports.js`, `static/js/modules/workout-log.js`, and active E2E/API consumers.
- Success/error envelopes, workbook shape, import deduplication, validation, and status codes are otherwise unchanged.
- No database schema or calculation changes.

## Test coverage
- `python -m pytest tests/test_exports.py -q` — 52 passed
- `python -m pytest tests/test_exports.py tests/test_ui_flows.py tests/test_workout_log_routes.py -q` — 127 passed
- `python -m pytest tests/ -q` — 1713 passed
- `npx playwright test e2e/workout-plan.spec.ts e2e/workout-log.spec.ts e2e/api-integration.spec.ts --project=chromium --reporter=line` — 116 passed
- blocking flake8 selection on changed files — passed
- `npx pyright@1.1.410 utils/export_service.py tests/test_exports.py` — 0 errors
- import smoke for `routes.exports` and `utils.export_service` — passed
- `git diff --check` — passed

`data/database.db` was not modified or staged.