### PR TITLE
refactor(workout-plan): extract superset service (WP1.4)

### DIFF
--- a/routes/workout_plan.py
+++ b/routes/workout_plan.py
@@ -9,9 +9,9 @@ from utils.exercise_manager import (
 from utils.errors import success_response, error_response
 from utils.exercise_media import resolve_exercise_media_path
 from utils import exercise_replacement as replacement_service
+from utils import supersets as superset_service
 from utils.logger import get_logger
 from utils.filter_values import fetch_filter_values
-from utils.constants import ANTAGONIST_PAIRS
 from utils.plan_generator import GENERATOR_ROUTINE_PROGRAMS, generate_starter_plan
 from utils.volume_progress import get_volume_progress
 from utils.workout_validation import UNSET, validate_workout_bounds
@@ -25,6 +25,10 @@ suggest_replacement_exercise = replacement_service.suggest_replacement_exercise
 _fetch_current_exercise_details = replacement_service._fetch_current_exercise_details
 _build_replacement_candidates = replacement_service._build_replacement_candidates
 _perform_exercise_swap = replacement_service._perform_exercise_swap
+_validate_superset_link_request = superset_service._validate_superset_link_request
+_apply_superset_link = superset_service._apply_superset_link
+_group_exercises_by_routine = superset_service._group_exercises_by_routine
+_find_antagonist_pairings = superset_service._find_antagonist_pairings
 
 def fetch_unique_values(column):
     """Backward-compatible route-level alias for the extracted contract."""
@@ -946,82 +950,6 @@ def replace_exercise():
 # SUPERSET ENDPOINTS
 # =============================================================================
 
-def _validate_superset_link_request(db: DatabaseHandler, exercise_ids: list):
-    # Check if superset_group column exists
-    if not column_exists(db, 'user_selection', 'superset_group'):
-        return None, (
-            "INTERNAL_ERROR",
-            "Superset feature not available - database migration required",
-            500
-        )
-    
-    # Fetch both exercises
-    exercises = db.fetch_all(
-        "SELECT id, routine, exercise, superset_group FROM user_selection WHERE id IN (?, ?)",
-        tuple(exercise_ids)
-    )
-    
-    if len(exercises) != 2:
-        return None, (
-            "NOT_FOUND",
-            "One or both exercises not found",
-            404
-        )
-    
-    ex1, ex2 = exercises[0], exercises[1]
-    
-    # Validate same routine
-    if ex1['routine'] != ex2['routine']:
-        return None, (
-            "VALIDATION_ERROR",
-            f"Supersets must be within the same routine. '{ex1['exercise']}' is in '{ex1['routine']}' but '{ex2['exercise']}' is in '{ex2['routine']}'",
-            400
-        )
-    
-    # Validate neither is already in a superset
-    if ex1.get('superset_group'):
-        return None, (
-            "VALIDATION_ERROR",
-            f"'{ex1['exercise']}' is already in a superset. Unlink it first.",
-            400
-        )
-    if ex2.get('superset_group'):
-        return None, (
-            "VALIDATION_ERROR",
-            f"'{ex2['exercise']}' is already in a superset. Unlink it first.",
-            400
-        )
-        
-    return exercises, None
-
-
-def _apply_superset_link(db: DatabaseHandler, exercise_ids: list, routine_name: str):
-    import time
-    superset_group = f"SS-{routine_name}-{int(time.time())}"
-    
-    # Update both exercises with the superset group
-    db.execute_query(
-        "UPDATE user_selection SET superset_group = ? WHERE id IN (?, ?)",
-        (superset_group, exercise_ids[0], exercise_ids[1])
-    )
-    
-    # Fetch updated exercises with full metadata
-    updated_exercises = db.fetch_all("""
-        SELECT 
-            us.id, us.routine, us.exercise, us.sets,
-            us.min_rep_range, us.max_rep_range, us.rir, us.rpe, us.weight,
-            us.superset_group,
-            e.primary_muscle_group, e.secondary_muscle_group,
-            e.tertiary_muscle_group, e.advanced_isolated_muscles,
-            e.utility, e.grips, e.stabilizers, e.synergists
-        FROM user_selection us
-        LEFT JOIN exercises e ON us.exercise = e.exercise_name
-        WHERE us.id IN (?, ?)
-    """, tuple(exercise_ids))
-    
-    return superset_group, updated_exercises
-
-
 @workout_plan_bp.route("/api/superset/link", methods=["POST"])
 def link_superset():
     """
@@ -1060,33 +988,21 @@ def link_superset():
         except (ValueError, TypeError):
             return error_response("VALIDATION_ERROR", "Invalid exercise IDs", 400)
         
-        with DatabaseHandler() as db:
-            exercises, error = _validate_superset_link_request(db, exercise_ids)
-            if error:
-                return error_response(*error)
-            
-            ex1, ex2 = exercises[0], exercises[1]
-            routine_name = ex1['routine']
-            
-            superset_group, updated_exercises = _apply_superset_link(db, exercise_ids, routine_name)
-            
-            logger.info(
-                "Superset created",
-                extra={
-                    'superset_group': superset_group,
-                    'routine': routine_name,
-                    'exercise_1': ex1['exercise'],
-                    'exercise_2': ex2['exercise']
-                }
-            )
-            
-            return jsonify(success_response(
-                data={
-                    "superset_group": superset_group,
-                    "exercises": [dict(ex) for ex in updated_exercises]
-                },
-                message=f"Linked '{ex1['exercise']}' and '{ex2['exercise']}' as superset"
-            ))
+        result = superset_service.link_superset(exercise_ids)
+
+        return jsonify(success_response(
+            data={
+                "superset_group": result['superset_group'],
+                "exercises": result['exercises'],
+            },
+            message=(
+                f"Linked '{result['exercise_1_name']}' and "
+                f"'{result['exercise_2_name']}' as superset"
+            ),
+        ))
+
+    except superset_service.SupersetServiceError as e:
+        return error_response(e.code, e.message, e.status_code)
             
     except Exception as e:
         logger.exception("Error creating superset")
@@ -1120,71 +1036,18 @@ def unlink_superset():
                 400
             )
         
-        with DatabaseHandler() as db:
-            # Check if superset_group column exists
-            if not column_exists(db, 'user_selection', 'superset_group'):
-                return error_response(
-                    "INTERNAL_ERROR",
-                    "Superset feature not available - database migration required",
-                    500
-                )
-            
-            unlinked_ids = []
-            
-            if exercise_id:
-                # Get the superset group for this exercise
-                exercise = db.fetch_one(
-                    "SELECT id, exercise, superset_group FROM user_selection WHERE id = ?",
-                    (int(exercise_id),)
-                )
-                
-                if not exercise:
-                    return error_response("NOT_FOUND", "Exercise not found", 404)
-                
-                if not exercise.get('superset_group'):
-                    return error_response(
-                        "VALIDATION_ERROR",
-                        f"'{exercise['exercise']}' is not in a superset",
-                        400
-                    )
-                
-                superset_group = exercise['superset_group']
-            
-            # Get all exercises in the superset group
-            superset_exercises = db.fetch_all(
-                "SELECT id, exercise FROM user_selection WHERE superset_group = ?",
-                (superset_group,)
-            )
-            
-            if not superset_exercises:
-                return error_response(
-                    "NOT_FOUND",
-                    f"No exercises found with superset group '{superset_group}'",
-                    404
-                )
-            
-            # Unlink all exercises in the superset
-            db.execute_query(
-                "UPDATE user_selection SET superset_group = NULL WHERE superset_group = ?",
-                (superset_group,)
-            )
-            
-            unlinked_ids = [ex['id'] for ex in superset_exercises]
-            unlinked_names = [ex['exercise'] for ex in superset_exercises]
-            
-            logger.info(
-                "Superset unlinked",
-                extra={
-                    'superset_group': superset_group,
-                    'unlinked_ids': unlinked_ids,
-                    'exercises': unlinked_names
-                }
-            )
-            
-            return jsonify(success_response(
-                data={"unlinked_ids": unlinked_ids},
-                message=f"Unlinked superset: {', '.join(unlinked_names)}"
-            ))
+        result = superset_service.unlink_superset(
+            exercise_id=exercise_id,
+            superset_group=superset_group,
+        )
+
+        return jsonify(success_response(
+            data={"unlinked_ids": result['unlinked_ids']},
+            message=f"Unlinked superset: {', '.join(result['unlinked_names'])}",
+        ))
+
+    except superset_service.SupersetServiceError as e:
+        return error_response(e.code, e.message, e.status_code)
             
     except Exception as e:
         logger.exception("Error unlinking superset")
@@ -1412,76 +1275,6 @@ def get_execution_style_options():
 
 # ==================== Phase 3: Superset Auto-Suggestion ====================
 
-def _group_exercises_by_routine(exercises: list) -> dict:
-    routines = {}
-    for ex in exercises:
-        r = ex['routine']
-        if r not in routines:
-            routines[r] = []
-        routines[r].append(ex)
-    return routines
-
-
-def _find_antagonist_pairings(routine_name: str, routine_exercises: list) -> list:
-    suggestions = []
-    
-    # Skip exercises already in supersets
-    available = [
-        ex for ex in routine_exercises 
-        if not ex.get('superset_group')
-    ]
-    
-    paired = set()
-    
-    for i, ex1 in enumerate(available):
-        if ex1['id'] in paired:
-            continue
-        
-        muscle1 = (ex1.get('primary_muscle_group') or '').lower()
-        if not muscle1:
-            continue
-        
-        best_partner = None
-        best_reason = None
-        
-        for j, ex2 in enumerate(available):
-            if i == j or ex2['id'] in paired:
-                continue
-            
-            muscle2 = (ex2.get('primary_muscle_group') or '').lower()
-            if not muscle2:
-                continue
-            
-            # Check for antagonist pairing
-            antagonists = ANTAGONIST_PAIRS.get(muscle1, [])
-            if muscle2 in antagonists or any(m in muscle2 for m in antagonists):
-                # Calculate pairing score
-                best_partner = ex2
-                best_reason = f"Antagonist pair: {muscle1.title()} / {muscle2.title()} - allows one muscle to rest while the other works"
-                break
-        
-        if best_partner:
-            suggestions.append({
-                "routine": routine_name,
-                "exercise_1": {
-                    "id": ex1['id'],
-                    "name": ex1['exercise'],
-                    "muscle": muscle1.title()
-                },
-                "exercise_2": {
-                    "id": best_partner['id'],
-                    "name": best_partner['exercise'],
-                    "muscle": (best_partner.get('primary_muscle_group') or '').title()
-                },
-                "reason": best_reason,
-                "benefit": "Saves time without compromising performance"
-            })
-            paired.add(ex1['id'])
-            paired.add(best_partner['id'])
-            
-    return suggestions
-
-
 @workout_plan_bp.route("/api/superset/suggest", methods=["GET"])
 def suggest_supersets():
     """
@@ -1498,48 +1291,8 @@ def suggest_supersets():
     try:
         routine = request.args.get('routine')
         
-        with DatabaseHandler() as db:
-            # Fetch current workout plan
-            query = """
-                SELECT 
-                    us.id, us.routine, us.exercise, us.superset_group,
-                    e.primary_muscle_group, e.secondary_muscle_group
-                FROM user_selection us
-                LEFT JOIN exercises e ON us.exercise = e.exercise_name
-            """
-            params = []
-            
-            if routine:
-                query += " WHERE us.routine = ?"
-                params.append(routine)
-            
-            query += " ORDER BY us.routine, us.exercise_order"
-            
-            exercises = db.fetch_all(query, params if params else None)
-            
-            if not exercises:
-                return jsonify(success_response(
-                    data={"suggestions": [], "message": "No exercises found in workout plan"}
-                ))
-            
-            routines = _group_exercises_by_routine(exercises)
-            suggestions = []
-            
-            for routine_name, routine_exercises in routines.items():
-                suggestions.extend(_find_antagonist_pairings(routine_name, routine_exercises))
-            
-            logger.info(
-                "Superset suggestions generated",
-                extra={
-                    'routine_filter': routine,
-                    'suggestion_count': len(suggestions)
-                }
-            )
-            
-            return jsonify(success_response(data={
-                "suggestions": suggestions,
-                "total_pairs": len(suggestions)
-            }))
+        result = superset_service.get_superset_suggestions(routine)
+        return jsonify(success_response(data=result))
             
     except Exception as e:
         logger.exception("Error generating superset suggestions")

--- a/routes/workout_plan.py
+++ b/routes/workout_plan.py
@@ -29,6 +29,7 @@ _validate_superset_link_request = superset_service._validate_superset_link_reque
 _apply_superset_link = superset_service._apply_superset_link
 _group_exercises_by_routine = superset_service._group_exercises_by_routine
 _find_antagonist_pairings = superset_service._find_antagonist_pairings
+unlink_partner_for_removal = superset_service.unlink_partner_for_removal
 
 def fetch_unique_values(column):
     """Backward-compatible route-level alias for the extracted contract."""
@@ -289,19 +290,10 @@ def remove_exercise():
                 return error_response("NOT_FOUND", f"Exercise with ID {exercise_id} not found", 404)
             
             # If exercise is part of a superset, unlink the partner exercise
+            # through this handler (partner-null, then delete below).
             if exercise_info and exercise_info.get('superset_group'):
-                superset_group = exercise_info['superset_group']
-                # Set superset_group to NULL for the partner exercise(s)
-                db_handler.execute_query(
-                    "UPDATE user_selection SET superset_group = NULL WHERE superset_group = ? AND id != ?",
-                    (superset_group, int(exercise_id))
-                )
-                logger.info(
-                    "Unlinked partner exercise from superset due to removal",
-                    extra={
-                        'superset_group': superset_group,
-                        'removed_exercise_id': exercise_id
-                    }
+                superset_service.unlink_partner_for_removal(
+                    db_handler, exercise_id, exercise_info['superset_group']
                 )
             
             # Delete related workout logs to avoid foreign key constraint error

--- a/tests/test_superset_service.py
+++ b/tests/test_superset_service.py
@@ -1,4 +1,5 @@
 """Characterization coverage for the WP1.4 superset service boundary."""
+import logging
 import subprocess
 import sys
 import time
@@ -41,6 +42,98 @@ def test_route_helper_imports_remain_compatible():
         workout_plan._find_antagonist_pairings
         is supersets._find_antagonist_pairings
     )
+    assert (
+        workout_plan.unlink_partner_for_removal
+        is supersets.unlink_partner_for_removal
+    )
+
+
+def _link_pair(clean_db, workout_plan_factory, exercise_factory, group):
+    first = exercise_factory("Removal First")
+    second = exercise_factory("Removal Second")
+    first_id = workout_plan_factory(exercise_name=first, routine="R")
+    second_id = workout_plan_factory(exercise_name=second, routine="R")
+    clean_db.execute_query(
+        "UPDATE user_selection SET superset_group = ? WHERE id IN (?, ?)",
+        (group, first_id, second_id),
+    )
+    return first_id, second_id
+
+
+def test_unlink_partner_for_removal_nulls_only_the_partner(
+    clean_db, workout_plan_factory, exercise_factory
+):
+    """Partner is nulled; the removed row keeps its group (id != ? guard)."""
+    from utils.database import DatabaseHandler
+    from utils.supersets import unlink_partner_for_removal
+
+    removed_id, partner_id = _link_pair(
+        clean_db, workout_plan_factory, exercise_factory, "SS-R-1"
+    )
+
+    with DatabaseHandler() as db:
+        # Raw string id characterizes the route's permissive int() coercion.
+        unlink_partner_for_removal(db, str(removed_id), "SS-R-1")
+
+    partner = clean_db.fetch_one(
+        "SELECT superset_group FROM user_selection WHERE id = ?", (partner_id,)
+    )
+    removed = clean_db.fetch_one(
+        "SELECT superset_group FROM user_selection WHERE id = ?", (removed_id,)
+    )
+    assert partner["superset_group"] is None
+    assert removed["superset_group"] == "SS-R-1"
+
+
+def test_unlink_partner_for_removal_uses_passed_handler(
+    clean_db, workout_plan_factory, exercise_factory
+):
+    """The write flows through the caller's handler and auto-commits there.
+
+    ``remove_exercise`` runs partner-unlink, log-delete, and exercise-delete
+    in one ``DatabaseHandler``; each ``execute_query`` commits (commit=True).
+    A separate connection therefore sees the null before the block exits.
+    """
+    from utils.database import DatabaseHandler
+    from utils.supersets import unlink_partner_for_removal
+
+    removed_id, partner_id = _link_pair(
+        clean_db, workout_plan_factory, exercise_factory, "SS-R-2"
+    )
+
+    with DatabaseHandler() as db:
+        unlink_partner_for_removal(db, removed_id, "SS-R-2")
+        # Still inside the caller's context: a distinct handler already sees it.
+        early = clean_db.fetch_one(
+            "SELECT superset_group FROM user_selection WHERE id = ?",
+            (partner_id,),
+        )
+        assert early["superset_group"] is None
+
+
+def test_unlink_partner_for_removal_logs_removal(
+    clean_db, workout_plan_factory, exercise_factory, caplog
+):
+    """Preserve the removal log message and the raw removed_exercise_id."""
+    from utils.database import DatabaseHandler
+    from utils.supersets import unlink_partner_for_removal
+
+    removed_id, _partner_id = _link_pair(
+        clean_db, workout_plan_factory, exercise_factory, "SS-R-3"
+    )
+
+    with caplog.at_level(logging.INFO, logger="hypertrophy_toolbox"):
+        with DatabaseHandler() as db:
+            unlink_partner_for_removal(db, str(removed_id), "SS-R-3")
+
+    record = next(
+        rec
+        for rec in caplog.records
+        if rec.message == "Unlinked partner exercise from superset due to removal"
+    )
+    assert record.superset_group == "SS-R-3"
+    # Raw value is logged unchanged, not the int()-coerced SQL param.
+    assert record.removed_exercise_id == str(removed_id)
 
 
 def test_link_preserves_timestamp_id_and_database_row_order(

--- a/tests/test_superset_service.py
+++ b/tests/test_superset_service.py
@@ -1,0 +1,143 @@
+"""Characterization coverage for the WP1.4 superset service boundary."""
+import subprocess
+import sys
+import time
+
+import pytest
+
+
+@pytest.mark.parametrize(
+    "imports",
+    [
+        "import routes.workout_plan; import utils.supersets",
+        "import utils.supersets; import routes.workout_plan",
+    ],
+)
+def test_superset_modules_import_in_either_order(imports):
+    completed = subprocess.run(
+        [sys.executable, "-c", imports],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+    assert completed.returncode == 0, completed.stderr
+
+
+def test_route_helper_imports_remain_compatible():
+    from routes import workout_plan
+    from utils import supersets
+
+    assert (
+        workout_plan._validate_superset_link_request
+        is supersets._validate_superset_link_request
+    )
+    assert workout_plan._apply_superset_link is supersets._apply_superset_link
+    assert (
+        workout_plan._group_exercises_by_routine
+        is supersets._group_exercises_by_routine
+    )
+    assert (
+        workout_plan._find_antagonist_pairings
+        is supersets._find_antagonist_pairings
+    )
+
+
+def test_link_preserves_timestamp_id_and_database_row_order(
+    client,
+    exercise_factory,
+    workout_plan_factory,
+    monkeypatch,
+):
+    first = exercise_factory("First Exercise")
+    second = exercise_factory("Second Exercise")
+    first_id = workout_plan_factory(exercise_name=first, routine="A")
+    second_id = workout_plan_factory(exercise_name=second, routine="A")
+    monkeypatch.setattr(time, "time", lambda: 1_700_000_000.9)
+
+    response = client.post(
+        "/api/superset/link",
+        # Reversed input characterizes the historical unordered SQL result.
+        json={"exercise_ids": [str(second_id), float(first_id)]},
+    )
+
+    assert response.status_code == 200
+    payload = response.get_json()
+    assert payload['data']['superset_group'] == "SS-A-1700000000"
+    assert [row['id'] for row in payload['data']['exercises']] == [
+        first_id,
+        second_id,
+    ]
+    assert payload['message'] == (
+        "Linked 'First Exercise' and 'Second Exercise' as superset"
+    )
+
+
+def test_unlink_invalid_truthy_exercise_id_keeps_generic_500(client):
+    """The endpoint historically lets int() failure reach its generic catch."""
+    response = client.post(
+        "/api/superset/unlink", json={"exercise_id": "not-an-integer"}
+    )
+
+    assert response.status_code == 500
+    payload = response.get_json()
+    assert payload['error']['code'] == "INTERNAL_ERROR"
+    assert payload['error']['message'] == "Failed to unlink superset"
+
+
+def test_antagonist_pairing_preserves_first_match_and_pair_order():
+    from utils.supersets import _find_antagonist_pairings
+
+    exercises = [
+        {
+            "id": 1,
+            "exercise": "Chest One",
+            "primary_muscle_group": "Chest",
+            "superset_group": None,
+        },
+        {
+            "id": 2,
+            "exercise": "Back One",
+            "primary_muscle_group": "Upper Back",
+            "superset_group": None,
+        },
+        {
+            "id": 3,
+            "exercise": "Back Two",
+            "primary_muscle_group": "Latissimus Dorsi",
+            "superset_group": None,
+        },
+        {
+            "id": 4,
+            "exercise": "Chest Two",
+            "primary_muscle_group": "Chest",
+            "superset_group": None,
+        },
+        {
+            "id": 5,
+            "exercise": "Excluded Chest",
+            "primary_muscle_group": "Chest",
+            "superset_group": "SS-existing",
+        },
+    ]
+
+    suggestions = _find_antagonist_pairings("A", exercises)
+
+    assert [
+        (item['exercise_1']['id'], item['exercise_2']['id'])
+        for item in suggestions
+    ] == [(1, 2), (3, 4)]
+    assert suggestions[0] == {
+        "routine": "A",
+        "exercise_1": {"id": 1, "name": "Chest One", "muscle": "Chest"},
+        "exercise_2": {
+            "id": 2,
+            "name": "Back One",
+            "muscle": "Upper Back",
+        },
+        "reason": (
+            "Antagonist pair: Chest / Upper Back - allows one muscle to rest "
+            "while the other works"
+        ),
+        "benefit": "Saves time without compromising performance",
+    }

--- a/utils/supersets.py
+++ b/utils/supersets.py
@@ -223,6 +223,31 @@ def unlink_superset(
         }
 
 
+def unlink_partner_for_removal(
+    db: DatabaseHandler, exercise_id: Any, superset_group: Any
+) -> None:
+    """Unlink the surviving partner(s) when a supersetted exercise is removed.
+
+    Unlike :func:`unlink_superset`, this reuses the caller's ``DatabaseHandler``
+    rather than opening its own: ``remove_exercise`` performs the partner-null,
+    log-delete, and exercise-delete through one handler so they share its
+    connection and write lock. It nulls every group member except the exercise
+    being removed (``id != ?``); that row is deleted by the caller next.
+    """
+    db.execute_query(
+        "UPDATE user_selection SET superset_group = NULL "
+        "WHERE superset_group = ? AND id != ?",
+        (superset_group, int(exercise_id)),
+    )
+    logger.info(
+        "Unlinked partner exercise from superset due to removal",
+        extra={
+            'superset_group': superset_group,
+            'removed_exercise_id': exercise_id,
+        },
+    )
+
+
 def _group_exercises_by_routine(exercises: list) -> dict:
     routines = {}
     for exercise in exercises:

--- a/utils/supersets.py
+++ b/utils/supersets.py
@@ -1,0 +1,355 @@
+"""Superset validation, persistence, and antagonist suggestions.
+
+The workout-plan routes retain HTTP parsing and response-envelope shaping;
+this module owns superset domain rules and all related database access.
+"""
+from __future__ import annotations
+
+from typing import Any, cast
+
+from utils.constants import ANTAGONIST_PAIRS
+from utils.database import DatabaseHandler
+from utils.logger import get_logger
+
+logger = get_logger()
+
+
+class SupersetServiceError(Exception):
+    """A user-facing service outcome mapped by the HTTP route."""
+
+    def __init__(self, code: str, message: str, status_code: int) -> None:
+        super().__init__(message)
+        self.code = code
+        self.message = message
+        self.status_code = status_code
+
+
+def _column_exists(
+    db: DatabaseHandler, table_name: str, column_name: str
+) -> bool:
+    columns = db.fetch_all(f"PRAGMA table_info({table_name})")
+    return any(column['name'] == column_name for column in columns)
+
+
+def _validate_superset_link_request(
+    db: DatabaseHandler, exercise_ids: list
+):
+    # Check if superset_group column exists
+    if not _column_exists(db, 'user_selection', 'superset_group'):
+        return None, (
+            "INTERNAL_ERROR",
+            "Superset feature not available - database migration required",
+            500,
+        )
+
+    # Fetch both exercises. Deliberately no ORDER BY: preserve the historical
+    # row ordering used for routine/name selection and response messages.
+    exercises = db.fetch_all(
+        "SELECT id, routine, exercise, superset_group "
+        "FROM user_selection WHERE id IN (?, ?)",
+        tuple(exercise_ids),
+    )
+
+    if len(exercises) != 2:
+        return None, (
+            "NOT_FOUND",
+            "One or both exercises not found",
+            404,
+        )
+
+    ex1, ex2 = exercises[0], exercises[1]
+
+    # Validate same routine
+    if ex1['routine'] != ex2['routine']:
+        return None, (
+            "VALIDATION_ERROR",
+            f"Supersets must be within the same routine. "
+            f"'{ex1['exercise']}' is in '{ex1['routine']}' but "
+            f"'{ex2['exercise']}' is in '{ex2['routine']}'",
+            400,
+        )
+
+    # Validate neither is already in a superset
+    if ex1.get('superset_group'):
+        return None, (
+            "VALIDATION_ERROR",
+            f"'{ex1['exercise']}' is already in a superset. Unlink it first.",
+            400,
+        )
+    if ex2.get('superset_group'):
+        return None, (
+            "VALIDATION_ERROR",
+            f"'{ex2['exercise']}' is already in a superset. Unlink it first.",
+            400,
+        )
+
+    return exercises, None
+
+
+def _apply_superset_link(
+    db: DatabaseHandler, exercise_ids: list, routine_name: str
+):
+    import time
+
+    superset_group = f"SS-{routine_name}-{int(time.time())}"
+
+    # Update both exercises with the superset group
+    db.execute_query(
+        "UPDATE user_selection SET superset_group = ? WHERE id IN (?, ?)",
+        (superset_group, exercise_ids[0], exercise_ids[1]),
+    )
+
+    # Fetch updated exercises with full metadata. Deliberately no ORDER BY.
+    updated_exercises = db.fetch_all("""
+        SELECT
+            us.id, us.routine, us.exercise, us.sets,
+            us.min_rep_range, us.max_rep_range, us.rir, us.rpe, us.weight,
+            us.superset_group,
+            e.primary_muscle_group, e.secondary_muscle_group,
+            e.tertiary_muscle_group, e.advanced_isolated_muscles,
+            e.utility, e.grips, e.stabilizers, e.synergists
+        FROM user_selection us
+        LEFT JOIN exercises e ON us.exercise = e.exercise_name
+        WHERE us.id IN (?, ?)
+    """, tuple(exercise_ids))
+
+    return superset_group, updated_exercises
+
+
+def link_superset(exercise_ids: list[int]) -> dict[str, Any]:
+    """Validate and persist a two-exercise superset."""
+    with DatabaseHandler() as db:
+        exercises, error = _validate_superset_link_request(db, exercise_ids)
+        if error:
+            raise SupersetServiceError(*error)
+
+        validated_exercises = cast(list[dict[str, Any]], exercises)
+        ex1, ex2 = validated_exercises[0], validated_exercises[1]
+        routine_name = ex1['routine']
+
+        superset_group, updated_exercises = _apply_superset_link(
+            db, exercise_ids, routine_name
+        )
+
+        logger.info(
+            "Superset created",
+            extra={
+                'superset_group': superset_group,
+                'routine': routine_name,
+                'exercise_1': ex1['exercise'],
+                'exercise_2': ex2['exercise'],
+            },
+        )
+
+        return {
+            "superset_group": superset_group,
+            "exercises": [dict(exercise) for exercise in updated_exercises],
+            "exercise_1_name": ex1['exercise'],
+            "exercise_2_name": ex2['exercise'],
+        }
+
+
+def unlink_superset(
+    exercise_id: Any = None, superset_group: Any = None
+) -> dict[str, Any]:
+    """Unlink every exercise in the resolved superset group."""
+    with DatabaseHandler() as db:
+        # Check if superset_group column exists
+        if not _column_exists(db, 'user_selection', 'superset_group'):
+            raise SupersetServiceError(
+                "INTERNAL_ERROR",
+                "Superset feature not available - database migration required",
+                500,
+            )
+
+        if exercise_id:
+            # Keep historical coercion: invalid truthy values raise and become
+            # the route's generic 500 rather than a validation response.
+            exercise = db.fetch_one(
+                "SELECT id, exercise, superset_group "
+                "FROM user_selection WHERE id = ?",
+                (int(exercise_id),),
+            )
+
+            if not exercise:
+                raise SupersetServiceError(
+                    "NOT_FOUND", "Exercise not found", 404
+                )
+
+            if not exercise.get('superset_group'):
+                raise SupersetServiceError(
+                    "VALIDATION_ERROR",
+                    f"'{exercise['exercise']}' is not in a superset",
+                    400,
+                )
+
+            superset_group = exercise['superset_group']
+
+        # Get all exercises in the superset group. Deliberately no ORDER BY:
+        # output ID/name and message order remain database-defined as before.
+        superset_exercises = db.fetch_all(
+            "SELECT id, exercise FROM user_selection WHERE superset_group = ?",
+            (superset_group,),
+        )
+
+        if not superset_exercises:
+            raise SupersetServiceError(
+                "NOT_FOUND",
+                f"No exercises found with superset group '{superset_group}'",
+                404,
+            )
+
+        db.execute_query(
+            "UPDATE user_selection SET superset_group = NULL "
+            "WHERE superset_group = ?",
+            (superset_group,),
+        )
+
+        unlinked_ids = [exercise['id'] for exercise in superset_exercises]
+        unlinked_names = [exercise['exercise'] for exercise in superset_exercises]
+
+        logger.info(
+            "Superset unlinked",
+            extra={
+                'superset_group': superset_group,
+                'unlinked_ids': unlinked_ids,
+                'exercises': unlinked_names,
+            },
+        )
+
+        return {
+            "unlinked_ids": unlinked_ids,
+            "unlinked_names": unlinked_names,
+        }
+
+
+def _group_exercises_by_routine(exercises: list) -> dict:
+    routines = {}
+    for exercise in exercises:
+        routine = exercise['routine']
+        if routine not in routines:
+            routines[routine] = []
+        routines[routine].append(exercise)
+    return routines
+
+
+def _find_antagonist_pairings(
+    routine_name: str, routine_exercises: list
+) -> list:
+    suggestions = []
+
+    # Skip exercises already in supersets
+    available = [
+        exercise
+        for exercise in routine_exercises
+        if not exercise.get('superset_group')
+    ]
+
+    paired = set()
+
+    for index, exercise_1 in enumerate(available):
+        if exercise_1['id'] in paired:
+            continue
+
+        muscle_1 = (
+            exercise_1.get('primary_muscle_group') or ''
+        ).lower()
+        if not muscle_1:
+            continue
+
+        best_partner = None
+        best_reason = None
+
+        for partner_index, exercise_2 in enumerate(available):
+            if index == partner_index or exercise_2['id'] in paired:
+                continue
+
+            muscle_2 = (
+                exercise_2.get('primary_muscle_group') or ''
+            ).lower()
+            if not muscle_2:
+                continue
+
+            # Check for antagonist pairing
+            antagonists = ANTAGONIST_PAIRS.get(muscle_1, [])
+            if muscle_2 in antagonists or any(
+                antagonist in muscle_2 for antagonist in antagonists
+            ):
+                best_partner = exercise_2
+                best_reason = (
+                    f"Antagonist pair: {muscle_1.title()} / "
+                    f"{muscle_2.title()} - allows one muscle to rest while "
+                    "the other works"
+                )
+                break
+
+        if best_partner:
+            suggestions.append({
+                "routine": routine_name,
+                "exercise_1": {
+                    "id": exercise_1['id'],
+                    "name": exercise_1['exercise'],
+                    "muscle": muscle_1.title(),
+                },
+                "exercise_2": {
+                    "id": best_partner['id'],
+                    "name": best_partner['exercise'],
+                    "muscle": (
+                        best_partner.get('primary_muscle_group') or ''
+                    ).title(),
+                },
+                "reason": best_reason,
+                "benefit": "Saves time without compromising performance",
+            })
+            paired.add(exercise_1['id'])
+            paired.add(best_partner['id'])
+
+    return suggestions
+
+
+def get_superset_suggestions(routine: Any = None) -> dict[str, Any]:
+    """Return antagonist-pair suggestions, optionally for one routine."""
+    with DatabaseHandler() as db:
+        query = """
+            SELECT
+                us.id, us.routine, us.exercise, us.superset_group,
+                e.primary_muscle_group, e.secondary_muscle_group
+            FROM user_selection us
+            LEFT JOIN exercises e ON us.exercise = e.exercise_name
+        """
+        params = []
+
+        if routine:
+            query += " WHERE us.routine = ?"
+            params.append(routine)
+
+        query += " ORDER BY us.routine, us.exercise_order"
+
+        exercises = db.fetch_all(query, params if params else None)
+
+        if not exercises:
+            return {
+                "suggestions": [],
+                "message": "No exercises found in workout plan",
+            }
+
+        routines = _group_exercises_by_routine(exercises)
+        suggestions = []
+
+        for routine_name, routine_exercises in routines.items():
+            suggestions.extend(
+                _find_antagonist_pairings(routine_name, routine_exercises)
+            )
+
+        logger.info(
+            "Superset suggestions generated",
+            extra={
+                'routine_filter': routine,
+                'suggestion_count': len(suggestions),
+            },
+        )
+
+        return {
+            "suggestions": suggestions,
+            "total_pairs": len(suggestions),
+        }


### PR DESCRIPTION
## Summary
- extract superset link validation, timestamp ID generation, persistence, and unlink orchestration into `utils/supersets.py`
- move workout-plan querying, routine grouping, and first-match antagonist suggestions into the service
- reduce the three superset endpoints to HTTP parsing/coercion, service delegation, and response-envelope shaping
- retain the four former route helper import paths as compatibility aliases and characterize both import orders

## Behavior and migration notes
Behavior-preserving refactor only. No database schema, endpoint, request, response, or frontend migration is required.

The extraction intentionally preserves:
- `SS-<routine>-<int(time.time())>` group IDs
- database-defined row/name order from the existing no-`ORDER BY` link/unlink queries
- exact validation codes, messages, statuses, success messages, and response payloads
- permissive `int()` coercion for link IDs, including numeric strings/floats
- the historical generic HTTP 500 for a truthy, non-integer unlink `exercise_id`
- exercise-ID precedence when both unlink selectors are supplied
- routine/exercise ordering and first-eligible antagonist pairing
- exclusion of already-supersetted exercises and the empty-plan suggestion payload

Existing `routes.workout_plan` helper imports remain identity aliases to the extracted implementations.

## Verification
- focused pytest (`test_superset_service.py`, `test_superset.py`, `test_phase3_features.py`, `test_workout_plan_routes.py`) — **109 passed**
- full pytest — **1726 passed in 271.96s**
- Chromium E2E (`superset-edge-cases.spec.ts`, `workout-plan.spec.ts`, `api-integration.spec.ts`) — **105 passed in 1.7m**
- blocking flake8 rules on changed files — passed
- `py_compile` and both service/route import orders — passed
- pyright baseline gate — passed, **0 net-new diagnostics** (baseline 186, current 175; zero diagnostics in new service/tests)
- `git diff --check` — passed