### PR TITLE
refactor(user-profile): extract estimator Cluster 5 bodymap helper (WP2.1f)

### DIFF
--- a/utils/_profile_estimator/bodymap.py
+++ b/utils/_profile_estimator/bodymap.py
@@ -1,0 +1,120 @@
+"""Cluster 5 — bodymap coverage state for the profile estimator.
+
+Per-muscle bodymap coverage-state helper extracted verbatim from
+:mod:`utils.profile_estimator` (WP2.1f, Deep Refactor Plan v3 Phase 2 — see
+``docs/user_profile/PROFILE_ESTIMATOR_CLUSTERS.md`` §2/§3). These names are
+re-exported by the :mod:`utils.profile_estimator` facade; import them from
+there, not from this internal module. Depends on the constants leaf, the
+core-math primitives, and the coverage leaf only — no ``strength_calibration``
+import (the estimator cycle stays held by the facade's function-local lazy
+imports).
+"""
+from __future__ import annotations
+
+from typing import Any, Optional
+
+from utils._profile_estimator.constants import (
+    BODYMAP_MUSCLE_KEYS,
+    KEY_LIFT_LABELS,
+    MUSCLE_TO_KEY_LIFT,
+)
+from utils._profile_estimator.core_math import (
+    epley_1rm,
+)
+from utils._profile_estimator.coverage import (
+    _is_lift_filled,
+)
+
+
+def muscle_coverage_state(
+    profile_lifts: list[dict[str, Any]],
+) -> dict[str, dict[str, Any]]:
+    """Per-muscle coverage state powering the Profile-page bodymap.
+
+    For each backend muscle key in :data:`BODYMAP_MUSCLE_KEYS`, return one
+    of four states:
+
+    * ``"measured"`` — the **first** lift in
+      :data:`MUSCLE_TO_KEY_LIFT[muscle]` is filled. The estimator will
+      use it directly (no cross-muscle penalty).
+    * ``"cross_muscle"`` — at least one chain entry is filled but the
+      first slot isn't, so the estimator borrows from a fallback lift
+      with the cross-factor penalty.
+    * ``"cold_start_only"`` — the chain has entries but none are filled.
+      Suggestions for this muscle fall back to the cold-start population
+      estimate (or the default if demographics are also missing).
+    * ``"not_assessed"`` — the chain is empty (e.g. ``Forearms``,
+      ``Neck``). The estimator never seeds suggestions for these muscles.
+
+    Each entry also exposes the ordered chain, the filled lifts (for
+    popover bodies), and a recommended improvement lift (the first
+    unfilled slug in the chain) so the JS layer can mount popovers
+    without re-querying the estimator.
+    """
+    lifts_by_key = {
+        row.get("lift_key"): row
+        for row in profile_lifts
+        if isinstance(row.get("lift_key"), str)
+    }
+
+    out: dict[str, dict[str, Any]] = {}
+    for muscle in BODYMAP_MUSCLE_KEYS:
+        chain = MUSCLE_TO_KEY_LIFT.get(muscle, [])
+        chain_entries: list[dict[str, Any]] = []
+        filled_entries: list[dict[str, Any]] = []
+        first_filled_idx: Optional[int] = None
+        for idx, slug in enumerate(chain):
+            label = KEY_LIFT_LABELS.get(slug, slug)
+            lift_row = lifts_by_key.get(slug)
+            is_filled = _is_lift_filled(lift_row)
+            entry: dict[str, Any] = {
+                "lift_key": slug,
+                "label": label,
+                "filled": is_filled,
+            }
+            if is_filled and lift_row is not None:
+                weight = float(lift_row.get("weight_kg") or 0)
+                reps = int(lift_row.get("reps") or 0)
+                entry["weight_kg"] = weight
+                entry["reps"] = reps
+                if not slug.startswith("bodyweight_") and weight > 0 and reps > 0:
+                    entry["estimated_1rm"] = round(epley_1rm(weight, reps), 1)
+                if first_filled_idx is None:
+                    first_filled_idx = idx
+                filled_entries.append(entry)
+            chain_entries.append(entry)
+
+        if not chain:
+            state = "not_assessed"
+        elif first_filled_idx == 0:
+            state = "measured"
+        elif first_filled_idx is not None:
+            state = "cross_muscle"
+        else:
+            state = "cold_start_only"
+
+        primary_slug: Optional[str] = chain[0] if chain else None
+        improvement_slug: Optional[str] = None
+        if state in {"cross_muscle", "cold_start_only"}:
+            for entry in chain_entries:
+                if not entry["filled"]:
+                    improvement_slug = entry["lift_key"]
+                    break
+
+        out[muscle] = {
+            "muscle": muscle,
+            "state": state,
+            "chain": chain_entries,
+            "filled": filled_entries,
+            "primary_lift_key": primary_slug,
+            "primary_lift_label": (
+                KEY_LIFT_LABELS.get(primary_slug, primary_slug) if primary_slug else None
+            ),
+            "improvement_lift_key": improvement_slug,
+            "improvement_lift_label": (
+                KEY_LIFT_LABELS.get(improvement_slug, improvement_slug)
+                if improvement_slug
+                else None
+            ),
+        }
+    return out

--- a/utils/profile_estimator.py
+++ b/utils/profile_estimator.py
@@ -117,6 +117,11 @@ from utils._profile_estimator.cohort import (  # noqa: F401
 )
 
 
+from utils._profile_estimator.bodymap import (  # noqa: F401
+    muscle_coverage_state,
+)
+
+
 def estimate_for_exercise(exercise_name: str, *, db: DatabaseHandler) -> dict[str, Any]:
     try:
         if not exercise_name or not exercise_name.strip():
@@ -525,97 +530,3 @@ def _estimate_from_cold_start(
             equipment=exercise_row.get("equipment"),
         ),
     }
-
-
-def muscle_coverage_state(
-    profile_lifts: list[dict[str, Any]],
-) -> dict[str, dict[str, Any]]:
-    """Per-muscle coverage state powering the Profile-page bodymap.
-
-    For each backend muscle key in :data:`BODYMAP_MUSCLE_KEYS`, return one
-    of four states:
-
-    * ``"measured"`` — the **first** lift in
-      :data:`MUSCLE_TO_KEY_LIFT[muscle]` is filled. The estimator will
-      use it directly (no cross-muscle penalty).
-    * ``"cross_muscle"`` — at least one chain entry is filled but the
-      first slot isn't, so the estimator borrows from a fallback lift
-      with the cross-factor penalty.
-    * ``"cold_start_only"`` — the chain has entries but none are filled.
-      Suggestions for this muscle fall back to the cold-start population
-      estimate (or the default if demographics are also missing).
-    * ``"not_assessed"`` — the chain is empty (e.g. ``Forearms``,
-      ``Neck``). The estimator never seeds suggestions for these muscles.
-
-    Each entry also exposes the ordered chain, the filled lifts (for
-    popover bodies), and a recommended improvement lift (the first
-    unfilled slug in the chain) so the JS layer can mount popovers
-    without re-querying the estimator.
-    """
-    lifts_by_key = {
-        row.get("lift_key"): row
-        for row in profile_lifts
-        if isinstance(row.get("lift_key"), str)
-    }
-
-    out: dict[str, dict[str, Any]] = {}
-    for muscle in BODYMAP_MUSCLE_KEYS:
-        chain = MUSCLE_TO_KEY_LIFT.get(muscle, [])
-        chain_entries: list[dict[str, Any]] = []
-        filled_entries: list[dict[str, Any]] = []
-        first_filled_idx: Optional[int] = None
-        for idx, slug in enumerate(chain):
-            label = KEY_LIFT_LABELS.get(slug, slug)
-            lift_row = lifts_by_key.get(slug)
-            is_filled = _is_lift_filled(lift_row)
-            entry: dict[str, Any] = {
-                "lift_key": slug,
-                "label": label,
-                "filled": is_filled,
-            }
-            if is_filled and lift_row is not None:
-                weight = float(lift_row.get("weight_kg") or 0)
-                reps = int(lift_row.get("reps") or 0)
-                entry["weight_kg"] = weight
-                entry["reps"] = reps
-                if not slug.startswith("bodyweight_") and weight > 0 and reps > 0:
-                    entry["estimated_1rm"] = round(epley_1rm(weight, reps), 1)
-                if first_filled_idx is None:
-                    first_filled_idx = idx
-                filled_entries.append(entry)
-            chain_entries.append(entry)
-
-        if not chain:
-            state = "not_assessed"
-        elif first_filled_idx == 0:
-            state = "measured"
-        elif first_filled_idx is not None:
-            state = "cross_muscle"
-        else:
-            state = "cold_start_only"
-
-        primary_slug: Optional[str] = chain[0] if chain else None
-        improvement_slug: Optional[str] = None
-        if state in {"cross_muscle", "cold_start_only"}:
-            for entry in chain_entries:
-                if not entry["filled"]:
-                    improvement_slug = entry["lift_key"]
-                    break
-
-        out[muscle] = {
-            "muscle": muscle,
-            "state": state,
-            "chain": chain_entries,
-            "filled": filled_entries,
-            "primary_lift_key": primary_slug,
-            "primary_lift_label": (
-                KEY_LIFT_LABELS.get(primary_slug, primary_slug) if primary_slug else None
-            ),
-            "improvement_lift_key": improvement_slug,
-            "improvement_lift_label": (
-                KEY_LIFT_LABELS.get(improvement_slug, improvement_slug)
-                if improvement_slug
-                else None
-            ),
-        }
-    return out


### PR DESCRIPTION
## Scope — mechanical move (WP2.1f, last leaf)

Moves `muscle_coverage_state` (Cluster 5) verbatim from the `utils.profile_estimator` facade into a new private `utils/_profile_estimator/bodymap.py`, per Deep Refactor Plan v3 Phase 2 (`docs/user_profile/PROFILE_ESTIMATOR_CLUSTERS.md` §2/§3/§4). This is the **last leaf**; orchestration (`estimate_for_exercise`, `_lookup_*`, `_estimate_from_*`) now stays in the facade.

Behavior-preserving: no estimator-priority, math, response-shape, typing, or cleanup changes.

## Identity / import-order proof

The facade re-exports `muscle_coverage_state` (`# noqa: F401`), keeping the public `utils.profile_estimator` surface and every consumer unchanged. `test_profile_estimator_contract.py` asserts the supported export surface, the production-consumer import subset (`routes/user_profile.py`, `utils/strength_calibration.py`), and `epley_1rm` / `match_direct_lift_key` object identity in **both** import orders — all green.

Byte-identity verified in-script: the moved function body is byte-identical to HEAD (LF-normalized), and the facade remainder equals HEAD minus the moved block plus **only** the new import block.

## Dependency proof — coverage import is direct, not via facade

`bodymap.py` imports only:
- constants leaf: `BODYMAP_MUSCLE_KEYS`, `KEY_LIFT_LABELS`, `MUSCLE_TO_KEY_LIFT`
- `core_math`: `epley_1rm`
- coverage leaf: `_is_lift_filled` — imported **directly** from `utils._profile_estimator.coverage`, **not** via the facade, so no facade↔bodymap cycle is introduced.

## Lazy-cycle preservation

`bodymap.py` takes **no** module-level `strength_calibration` import. The `profile_estimator ⇄ strength_calibration` cycle remains held solely by the facade's two function-local lazy imports (`_lookup_related_learned_calibration`, `_lookup_learned_calibration`).

## pyright — no baseline edit

`muscle_coverage_state` is `None`-guarded throughout and carried **zero** pyright diagnostics in the facade, so relocating it produced **0 net-new** diagnostics. The baseline gate passes with no edit (current 175 ≤ baseline 186; the delta is the known CI-only entries that don't reproduce under the junction venv).

## Verification

- Contract + focused estimator/calibration suites: **206 passed**
- Full pytest: **1710 passed / 0 failed**
- Blocking flake8 (`E9,F63,F7,F82,F811,E711,E712,F401`): **0**
- pyright baseline gate: **PASS, 0 net-new**

## Migration note

None; behavior and public imports preserved.

🤖 Generated with [Claude Code](https://claude.com/claude-code)