### PR TITLE
refactor(weekly-summary): durable goldens + in-module helper extraction (WP2.3)

### DIFF
--- a/tests/goldens/weekly_summary_golden.json
+++ b/tests/goldens/weekly_summary_golden.json
@@ -1,0 +1,1112 @@
+{
+  "pattern_balanced": {
+    "pattern_coverage": {
+      "ideal_sets_range": {
+        "max": 24,
+        "min": 15
+      },
+      "per_routine": {
+        "Bal R": {
+          "hinge": 4,
+          "horizontal_pull": 4,
+          "horizontal_push": 4,
+          "squat": 4,
+          "vertical_pull": 3,
+          "vertical_push": 3
+        }
+      },
+      "sets_per_routine": {
+        "Bal R": 22
+      },
+      "total": {
+        "hinge": 4,
+        "horizontal_pull": 4,
+        "horizontal_push": 4,
+        "squat": 4,
+        "vertical_pull": 3,
+        "vertical_push": 3
+      },
+      "warnings": []
+    }
+  },
+  "pattern_infer": {
+    "pattern_coverage": {
+      "ideal_sets_range": {
+        "max": 24,
+        "min": 15
+      },
+      "per_routine": {
+        "Infer R": {
+          "core_dynamic": 3,
+          "hinge": 3,
+          "horizontal_pull": 6,
+          "horizontal_push": 3,
+          "lower_isolation": 3,
+          "other": 6,
+          "squat": 3,
+          "upper_isolation": 6,
+          "vertical_pull": 3
+        }
+      },
+      "sets_per_routine": {
+        "Infer R": 36
+      },
+      "total": {
+        "core_dynamic": 3,
+        "hinge": 3,
+        "horizontal_pull": 6,
+        "horizontal_push": 3,
+        "lower_isolation": 3,
+        "other": 6,
+        "squat": 3,
+        "upper_isolation": 6,
+        "vertical_pull": 3
+      },
+      "warnings": [
+        {
+          "description": "No Upper body vertical push (shoulders, triceps) exercises found. Consider adding exercises like overhead press, dips.",
+          "level": "high",
+          "message": "Missing vertical push exercises",
+          "type": "missing_pattern"
+        },
+        {
+          "description": "Consider reducing by 12 sets. High volume (24+ sets) may impair recovery.",
+          "level": "medium",
+          "message": "Routine 'Infer R' has 36 sets",
+          "type": "high_volume"
+        },
+        {
+          "description": "Pull volume (9 sets) exceeds push volume (3 sets). This is generally okay but ensure adequate chest/shoulder work.",
+          "level": "low",
+          "message": "Pull-dominant program",
+          "type": "push_pull_imbalance"
+        }
+      ]
+    }
+  },
+  "pattern_isolation_skew": {
+    "pattern_coverage": {
+      "ideal_sets_range": {
+        "max": 24,
+        "min": 15
+      },
+      "per_routine": {
+        "Iso R": {
+          "lower_isolation": 20,
+          "squat": 4,
+          "upper_isolation": 20
+        }
+      },
+      "sets_per_routine": {
+        "Iso R": 44
+      },
+      "total": {
+        "lower_isolation": 20,
+        "squat": 4,
+        "upper_isolation": 20
+      },
+      "warnings": [
+        {
+          "description": "No Lower body pull (hamstrings, glutes, back) exercises found. Consider adding exercises like deadlifts, hip thrusts.",
+          "level": "high",
+          "message": "Missing hinge exercises",
+          "type": "missing_pattern"
+        },
+        {
+          "description": "No Upper body horizontal push (chest, shoulders, triceps) exercises found. Consider adding exercises like bench press, push-ups.",
+          "level": "high",
+          "message": "Missing horizontal push exercises",
+          "type": "missing_pattern"
+        },
+        {
+          "description": "No Upper body horizontal pull (back, biceps) exercises found. Consider adding exercises like rows, face pulls.",
+          "level": "high",
+          "message": "Missing horizontal pull exercises",
+          "type": "missing_pattern"
+        },
+        {
+          "description": "No Upper body vertical push (shoulders, triceps) exercises found. Consider adding exercises like overhead press, dips.",
+          "level": "high",
+          "message": "Missing vertical push exercises",
+          "type": "missing_pattern"
+        },
+        {
+          "description": "No Upper body vertical pull (lats, biceps) exercises found. Consider adding exercises like pull-ups, lat pulldowns.",
+          "level": "high",
+          "message": "Missing vertical pull exercises",
+          "type": "missing_pattern"
+        },
+        {
+          "description": "Consider reducing by 20 sets. High volume (24+ sets) may impair recovery.",
+          "level": "medium",
+          "message": "Routine 'Iso R' has 44 sets",
+          "type": "high_volume"
+        },
+        {
+          "description": "Isolation work (40 sets) significantly exceeds compound work (4 sets). Consider balancing with more compound movements for better overall development.",
+          "level": "medium",
+          "message": "High isolation-to-compound ratio",
+          "type": "isolation_skew"
+        }
+      ]
+    }
+  },
+  "pattern_pull_dominant": {
+    "pattern_coverage": {
+      "ideal_sets_range": {
+        "max": 24,
+        "min": 15
+      },
+      "per_routine": {
+        "Pull R": {
+          "horizontal_pull": 10,
+          "horizontal_push": 4,
+          "vertical_pull": 8
+        }
+      },
+      "sets_per_routine": {
+        "Pull R": 22
+      },
+      "total": {
+        "horizontal_pull": 10,
+        "horizontal_push": 4,
+        "vertical_pull": 8
+      },
+      "warnings": [
+        {
+          "description": "No Lower body push (quads, glutes) exercises found. Consider adding exercises like squats, leg press.",
+          "level": "high",
+          "message": "Missing squat exercises",
+          "type": "missing_pattern"
+        },
+        {
+          "description": "No Lower body pull (hamstrings, glutes, back) exercises found. Consider adding exercises like deadlifts, hip thrusts.",
+          "level": "high",
+          "message": "Missing hinge exercises",
+          "type": "missing_pattern"
+        },
+        {
+          "description": "No Upper body vertical push (shoulders, triceps) exercises found. Consider adding exercises like overhead press, dips.",
+          "level": "high",
+          "message": "Missing vertical push exercises",
+          "type": "missing_pattern"
+        },
+        {
+          "description": "Pull volume (18 sets) exceeds push volume (4 sets). This is generally okay but ensure adequate chest/shoulder work.",
+          "level": "low",
+          "message": "Pull-dominant program",
+          "type": "push_pull_imbalance"
+        }
+      ]
+    }
+  },
+  "pattern_push_dominant": {
+    "pattern_coverage": {
+      "ideal_sets_range": {
+        "max": 24,
+        "min": 15
+      },
+      "per_routine": {
+        "Push R": {
+          "horizontal_pull": 4,
+          "horizontal_push": 10,
+          "vertical_push": 8
+        }
+      },
+      "sets_per_routine": {
+        "Push R": 22
+      },
+      "total": {
+        "horizontal_pull": 4,
+        "horizontal_push": 10,
+        "vertical_push": 8
+      },
+      "warnings": [
+        {
+          "description": "No Lower body push (quads, glutes) exercises found. Consider adding exercises like squats, leg press.",
+          "level": "high",
+          "message": "Missing squat exercises",
+          "type": "missing_pattern"
+        },
+        {
+          "description": "No Lower body pull (hamstrings, glutes, back) exercises found. Consider adding exercises like deadlifts, hip thrusts.",
+          "level": "high",
+          "message": "Missing hinge exercises",
+          "type": "missing_pattern"
+        },
+        {
+          "description": "No Upper body vertical pull (lats, biceps) exercises found. Consider adding exercises like pull-ups, lat pulldowns.",
+          "level": "high",
+          "message": "Missing vertical pull exercises",
+          "type": "missing_pattern"
+        },
+        {
+          "description": "Push volume (18 sets) exceeds pull volume (4 sets) by more than 50%. Consider adding more pulling exercises for shoulder health.",
+          "level": "medium",
+          "message": "Push-dominant program",
+          "type": "push_pull_imbalance"
+        }
+      ]
+    }
+  },
+  "pattern_volume_boundaries": {
+    "pattern_coverage": {
+      "ideal_sets_range": {
+        "max": 24,
+        "min": 15
+      },
+      "per_routine": {
+        "Vol 14": {
+          "horizontal_push": 14
+        },
+        "Vol 15": {
+          "horizontal_push": 15
+        },
+        "Vol 24": {
+          "horizontal_push": 24
+        },
+        "Vol 25": {
+          "horizontal_push": 25
+        }
+      },
+      "sets_per_routine": {
+        "Vol 14": 14,
+        "Vol 15": 15,
+        "Vol 24": 24,
+        "Vol 25": 25
+      },
+      "total": {
+        "horizontal_push": 78
+      },
+      "warnings": [
+        {
+          "description": "No Lower body push (quads, glutes) exercises found. Consider adding exercises like squats, leg press.",
+          "level": "high",
+          "message": "Missing squat exercises",
+          "type": "missing_pattern"
+        },
+        {
+          "description": "No Lower body pull (hamstrings, glutes, back) exercises found. Consider adding exercises like deadlifts, hip thrusts.",
+          "level": "high",
+          "message": "Missing hinge exercises",
+          "type": "missing_pattern"
+        },
+        {
+          "description": "No Upper body horizontal pull (back, biceps) exercises found. Consider adding exercises like rows, face pulls.",
+          "level": "high",
+          "message": "Missing horizontal pull exercises",
+          "type": "missing_pattern"
+        },
+        {
+          "description": "No Upper body vertical push (shoulders, triceps) exercises found. Consider adding exercises like overhead press, dips.",
+          "level": "high",
+          "message": "Missing vertical push exercises",
+          "type": "missing_pattern"
+        },
+        {
+          "description": "No Upper body vertical pull (lats, biceps) exercises found. Consider adding exercises like pull-ups, lat pulldowns.",
+          "level": "high",
+          "message": "Missing vertical pull exercises",
+          "type": "missing_pattern"
+        },
+        {
+          "description": "Consider adding 1 more sets. Target is 15-24 sets per session for optimal results.",
+          "level": "medium",
+          "message": "Routine 'Vol 14' has only 14 sets",
+          "type": "low_volume"
+        },
+        {
+          "description": "Consider reducing by 1 sets. High volume (24+ sets) may impair recovery.",
+          "level": "medium",
+          "message": "Routine 'Vol 25' has 25 sets",
+          "type": "high_volume"
+        }
+      ]
+    }
+  },
+  "weekly_main": {
+    "exercise_categories": [
+      {
+        "category": "Mechanic",
+        "subcategory": "Compound",
+        "total_exercises": 4
+      },
+      {
+        "category": "Mechanic",
+        "subcategory": "Isolated",
+        "total_exercises": 7
+      },
+      {
+        "category": "Utility",
+        "subcategory": "Auxiliary",
+        "total_exercises": 7
+      },
+      {
+        "category": "Utility",
+        "subcategory": "Basic",
+        "total_exercises": 4
+      },
+      {
+        "category": "Force",
+        "subcategory": "Pull",
+        "total_exercises": 6
+      },
+      {
+        "category": "Force",
+        "subcategory": "Push",
+        "total_exercises": 5
+      },
+      {
+        "category": "Difficulty",
+        "subcategory": "Beginner",
+        "total_exercises": 7
+      },
+      {
+        "category": "Difficulty",
+        "subcategory": "Intermediate",
+        "total_exercises": 4
+      }
+    ],
+    "isolated_muscles": [
+      {
+        "exercise_count": 1,
+        "isolated_muscle": "anterior-deltoid",
+        "total_reps": 90.0,
+        "total_sets": 10,
+        "total_volume": 7200.0
+      },
+      {
+        "exercise_count": 1,
+        "isolated_muscle": "upper-pectoralis",
+        "total_reps": 90.0,
+        "total_sets": 10,
+        "total_volume": 7200.0
+      }
+    ],
+    "pattern_coverage": {
+      "ideal_sets_range": {
+        "max": 24,
+        "min": 15
+      },
+      "per_routine": {
+        "": {
+          "lower_isolation": 6
+        },
+        "Freq A": {
+          "upper_isolation": 2
+        },
+        "Freq B": {
+          "upper_isolation": 2
+        },
+        "Legs A": {
+          "squat": 8
+        },
+        "Pull A": {
+          "horizontal_pull": 6,
+          "upper_isolation": 4
+        },
+        "Push A": {
+          "horizontal_push": 10,
+          "upper_isolation": 5
+        },
+        "Push B": {
+          "horizontal_push": 15
+        }
+      },
+      "sets_per_routine": {
+        "": 6,
+        "Freq A": 2,
+        "Freq B": 2,
+        "Legs A": 8,
+        "Pull A": 10,
+        "Push A": 15,
+        "Push B": 15
+      },
+      "total": {
+        "horizontal_pull": 6,
+        "horizontal_push": 25,
+        "lower_isolation": 6,
+        "squat": 8,
+        "upper_isolation": 13
+      },
+      "warnings": [
+        {
+          "description": "No Lower body pull (hamstrings, glutes, back) exercises found. Consider adding exercises like deadlifts, hip thrusts.",
+          "level": "high",
+          "message": "Missing hinge exercises",
+          "type": "missing_pattern"
+        },
+        {
+          "description": "No Upper body vertical push (shoulders, triceps) exercises found. Consider adding exercises like overhead press, dips.",
+          "level": "high",
+          "message": "Missing vertical push exercises",
+          "type": "missing_pattern"
+        },
+        {
+          "description": "No Upper body vertical pull (lats, biceps) exercises found. Consider adding exercises like pull-ups, lat pulldowns.",
+          "level": "high",
+          "message": "Missing vertical pull exercises",
+          "type": "missing_pattern"
+        },
+        {
+          "description": "Consider adding 9 more sets. Target is 15-24 sets per session for optimal results.",
+          "level": "medium",
+          "message": "Routine '' has only 6 sets",
+          "type": "low_volume"
+        },
+        {
+          "description": "Consider adding 13 more sets. Target is 15-24 sets per session for optimal results.",
+          "level": "medium",
+          "message": "Routine 'Freq A' has only 2 sets",
+          "type": "low_volume"
+        },
+        {
+          "description": "Consider adding 13 more sets. Target is 15-24 sets per session for optimal results.",
+          "level": "medium",
+          "message": "Routine 'Freq B' has only 2 sets",
+          "type": "low_volume"
+        },
+        {
+          "description": "Consider adding 7 more sets. Target is 15-24 sets per session for optimal results.",
+          "level": "medium",
+          "message": "Routine 'Legs A' has only 8 sets",
+          "type": "low_volume"
+        },
+        {
+          "description": "Consider adding 5 more sets. Target is 15-24 sets per session for optimal results.",
+          "level": "medium",
+          "message": "Routine 'Pull A' has only 10 sets",
+          "type": "low_volume"
+        },
+        {
+          "description": "Push volume (25 sets) exceeds pull volume (6 sets) by more than 50%. Consider adding more pulling exercises for shoulder health.",
+          "level": "medium",
+          "message": "Push-dominant program",
+          "type": "push_pull_imbalance"
+        }
+      ]
+    },
+    "weekly_summary": {
+      "effective_direct": {
+        "Biceps": {
+          "avg_sets_per_session": 3.4,
+          "contribution_mode": "direct",
+          "counting_mode": "effective",
+          "effective_weekly_sets": 3.4,
+          "frequency": 1,
+          "max_sets_per_session": 3.4,
+          "raw_total_reps": 36.0,
+          "raw_total_volume": 720.0,
+          "raw_weekly_sets": 4.0,
+          "sets_per_session": 3.4,
+          "status": "low",
+          "total_reps": 30.6,
+          "total_volume": 612.0,
+          "volume_class": "low-volume",
+          "weekly_sets": 3.4
+        },
+        "Calves": {
+          "avg_sets_per_session": 0.0,
+          "contribution_mode": "direct",
+          "counting_mode": "effective",
+          "effective_weekly_sets": 5.1,
+          "frequency": 0,
+          "max_sets_per_session": 0.0,
+          "raw_total_reps": 54.0,
+          "raw_total_volume": 2700.0,
+          "raw_weekly_sets": 6.0,
+          "sets_per_session": 0.85,
+          "status": "low",
+          "total_reps": 45.9,
+          "total_volume": 2295.0,
+          "volume_class": "low-volume",
+          "weekly_sets": 5.1
+        },
+        "Chest": {
+          "avg_sets_per_session": 10.62,
+          "contribution_mode": "direct",
+          "counting_mode": "effective",
+          "effective_weekly_sets": 21.25,
+          "frequency": 2,
+          "max_sets_per_session": 12.75,
+          "raw_total_reps": 225.0,
+          "raw_total_volume": 16650.0,
+          "raw_weekly_sets": 25.0,
+          "sets_per_session": 10.62,
+          "status": "high",
+          "total_reps": 191.25,
+          "total_volume": 14152.5,
+          "volume_class": "high-volume",
+          "weekly_sets": 21.25
+        },
+        "Forearms": {
+          "avg_sets_per_session": 0.0,
+          "contribution_mode": "direct",
+          "counting_mode": "effective",
+          "effective_weekly_sets": 0.77,
+          "frequency": 0,
+          "max_sets_per_session": 0.77,
+          "raw_total_reps": 70.0,
+          "raw_total_volume": 700.0,
+          "raw_weekly_sets": 2.0,
+          "sets_per_session": 0.13,
+          "status": "low",
+          "total_reps": 26.95,
+          "total_volume": 269.5,
+          "volume_class": "low-volume",
+          "weekly_sets": 0.77
+        },
+        "Quadriceps": {
+          "avg_sets_per_session": 6.8,
+          "contribution_mode": "direct",
+          "counting_mode": "effective",
+          "effective_weekly_sets": 6.8,
+          "frequency": 1,
+          "max_sets_per_session": 6.8,
+          "raw_total_reps": 72.0,
+          "raw_total_volume": 7200.0,
+          "raw_weekly_sets": 8.0,
+          "sets_per_session": 6.8,
+          "status": "low",
+          "total_reps": 61.2,
+          "total_volume": 6120.0,
+          "volume_class": "low-volume",
+          "weekly_sets": 6.8
+        },
+        "Rear-Shoulder": {
+          "avg_sets_per_session": 1.7,
+          "contribution_mode": "direct",
+          "counting_mode": "effective",
+          "effective_weekly_sets": 1.7,
+          "frequency": 1,
+          "max_sets_per_session": 1.7,
+          "raw_total_reps": 18.0,
+          "raw_total_volume": 180.0,
+          "raw_weekly_sets": 2.0,
+          "sets_per_session": 1.7,
+          "status": "low",
+          "total_reps": 15.3,
+          "total_volume": 153.0,
+          "volume_class": "low-volume",
+          "weekly_sets": 1.7
+        },
+        "Triceps": {
+          "avg_sets_per_session": 4.25,
+          "contribution_mode": "direct",
+          "counting_mode": "effective",
+          "effective_weekly_sets": 4.25,
+          "frequency": 1,
+          "max_sets_per_session": 4.25,
+          "raw_total_reps": 45.0,
+          "raw_total_volume": 1350.0,
+          "raw_weekly_sets": 5.0,
+          "sets_per_session": 4.25,
+          "status": "low",
+          "total_reps": 38.25,
+          "total_volume": 1147.5,
+          "volume_class": "low-volume",
+          "weekly_sets": 4.25
+        },
+        "Upper Back": {
+          "avg_sets_per_session": 5.1,
+          "contribution_mode": "direct",
+          "counting_mode": "effective",
+          "effective_weekly_sets": 5.1,
+          "frequency": 1,
+          "max_sets_per_session": 5.1,
+          "raw_total_reps": 54.0,
+          "raw_total_volume": 3240.0,
+          "raw_weekly_sets": 6.0,
+          "sets_per_session": 5.1,
+          "status": "low",
+          "total_reps": 45.9,
+          "total_volume": 2754.0,
+          "volume_class": "low-volume",
+          "weekly_sets": 5.1
+        }
+      },
+      "effective_total": {
+        "Biceps": {
+          "avg_sets_per_session": 5.95,
+          "contribution_mode": "total",
+          "counting_mode": "effective",
+          "effective_weekly_sets": 5.95,
+          "frequency": 1,
+          "max_sets_per_session": 5.95,
+          "raw_total_reps": 63.0,
+          "raw_total_volume": 2340.0,
+          "raw_weekly_sets": 7.0,
+          "sets_per_session": 5.95,
+          "status": "low",
+          "total_reps": 53.55,
+          "total_volume": 1989.0,
+          "volume_class": "low-volume",
+          "weekly_sets": 5.95
+        },
+        "Calves": {
+          "avg_sets_per_session": 0.0,
+          "contribution_mode": "total",
+          "counting_mode": "effective",
+          "effective_weekly_sets": 5.1,
+          "frequency": 0,
+          "max_sets_per_session": 0.0,
+          "raw_total_reps": 54.0,
+          "raw_total_volume": 2700.0,
+          "raw_weekly_sets": 6.0,
+          "sets_per_session": 0.85,
+          "status": "low",
+          "total_reps": 45.9,
+          "total_volume": 2295.0,
+          "volume_class": "low-volume",
+          "weekly_sets": 5.1
+        },
+        "Chest": {
+          "avg_sets_per_session": 10.62,
+          "contribution_mode": "total",
+          "counting_mode": "effective",
+          "effective_weekly_sets": 21.25,
+          "frequency": 2,
+          "max_sets_per_session": 12.75,
+          "raw_total_reps": 225.0,
+          "raw_total_volume": 16650.0,
+          "raw_weekly_sets": 25.0,
+          "sets_per_session": 10.62,
+          "status": "high",
+          "total_reps": 191.25,
+          "total_volume": 14152.5,
+          "volume_class": "high-volume",
+          "weekly_sets": 21.25
+        },
+        "Forearms": {
+          "avg_sets_per_session": 0.0,
+          "contribution_mode": "total",
+          "counting_mode": "effective",
+          "effective_weekly_sets": 0.77,
+          "frequency": 0,
+          "max_sets_per_session": 0.77,
+          "raw_total_reps": 70.0,
+          "raw_total_volume": 700.0,
+          "raw_weekly_sets": 2.0,
+          "sets_per_session": 0.13,
+          "status": "low",
+          "total_reps": 26.95,
+          "total_volume": 269.5,
+          "volume_class": "low-volume",
+          "weekly_sets": 0.77
+        },
+        "Front-Shoulder": {
+          "avg_sets_per_session": 2.12,
+          "contribution_mode": "total",
+          "counting_mode": "effective",
+          "effective_weekly_sets": 2.12,
+          "frequency": 1,
+          "max_sets_per_session": 2.12,
+          "raw_total_reps": 22.5,
+          "raw_total_volume": 1800.0,
+          "raw_weekly_sets": 2.5,
+          "sets_per_session": 2.12,
+          "status": "low",
+          "total_reps": 19.12,
+          "total_volume": 1530.0,
+          "volume_class": "low-volume",
+          "weekly_sets": 2.12
+        },
+        "Gluteus Maximus": {
+          "avg_sets_per_session": 3.4,
+          "contribution_mode": "total",
+          "counting_mode": "effective",
+          "effective_weekly_sets": 3.4,
+          "frequency": 1,
+          "max_sets_per_session": 3.4,
+          "raw_total_reps": 36.0,
+          "raw_total_volume": 3600.0,
+          "raw_weekly_sets": 4.0,
+          "sets_per_session": 3.4,
+          "status": "low",
+          "total_reps": 30.6,
+          "total_volume": 3060.0,
+          "volume_class": "low-volume",
+          "weekly_sets": 3.4
+        },
+        "Quadriceps": {
+          "avg_sets_per_session": 6.8,
+          "contribution_mode": "total",
+          "counting_mode": "effective",
+          "effective_weekly_sets": 6.8,
+          "frequency": 1,
+          "max_sets_per_session": 6.8,
+          "raw_total_reps": 72.0,
+          "raw_total_volume": 7200.0,
+          "raw_weekly_sets": 8.0,
+          "sets_per_session": 6.8,
+          "status": "low",
+          "total_reps": 61.2,
+          "total_volume": 6120.0,
+          "volume_class": "low-volume",
+          "weekly_sets": 6.8
+        },
+        "Rear-Shoulder": {
+          "avg_sets_per_session": 1.7,
+          "contribution_mode": "total",
+          "counting_mode": "effective",
+          "effective_weekly_sets": 1.7,
+          "frequency": 1,
+          "max_sets_per_session": 1.7,
+          "raw_total_reps": 18.0,
+          "raw_total_volume": 180.0,
+          "raw_weekly_sets": 2.0,
+          "sets_per_session": 1.7,
+          "status": "low",
+          "total_reps": 15.3,
+          "total_volume": 153.0,
+          "volume_class": "low-volume",
+          "weekly_sets": 1.7
+        },
+        "Triceps": {
+          "avg_sets_per_session": 8.5,
+          "contribution_mode": "total",
+          "counting_mode": "effective",
+          "effective_weekly_sets": 8.5,
+          "frequency": 1,
+          "max_sets_per_session": 8.5,
+          "raw_total_reps": 90.0,
+          "raw_total_volume": 4950.0,
+          "raw_weekly_sets": 10.0,
+          "sets_per_session": 8.5,
+          "status": "low",
+          "total_reps": 76.5,
+          "total_volume": 4207.5,
+          "volume_class": "low-volume",
+          "weekly_sets": 8.5
+        },
+        "Upper Back": {
+          "avg_sets_per_session": 5.1,
+          "contribution_mode": "total",
+          "counting_mode": "effective",
+          "effective_weekly_sets": 5.1,
+          "frequency": 1,
+          "max_sets_per_session": 5.1,
+          "raw_total_reps": 54.0,
+          "raw_total_volume": 3240.0,
+          "raw_weekly_sets": 6.0,
+          "sets_per_session": 5.1,
+          "status": "low",
+          "total_reps": 45.9,
+          "total_volume": 2754.0,
+          "volume_class": "low-volume",
+          "weekly_sets": 5.1
+        }
+      },
+      "raw_direct": {
+        "Biceps": {
+          "avg_sets_per_session": 3.4,
+          "contribution_mode": "direct",
+          "counting_mode": "raw",
+          "effective_weekly_sets": 3.4,
+          "frequency": 1,
+          "max_sets_per_session": 3.4,
+          "raw_total_reps": 36.0,
+          "raw_total_volume": 720.0,
+          "raw_weekly_sets": 4.0,
+          "sets_per_session": 4.0,
+          "status": "low",
+          "total_reps": 30.6,
+          "total_volume": 612.0,
+          "volume_class": "low-volume",
+          "weekly_sets": 4.0
+        },
+        "Calves": {
+          "avg_sets_per_session": 0.0,
+          "contribution_mode": "direct",
+          "counting_mode": "raw",
+          "effective_weekly_sets": 5.1,
+          "frequency": 0,
+          "max_sets_per_session": 0.0,
+          "raw_total_reps": 54.0,
+          "raw_total_volume": 2700.0,
+          "raw_weekly_sets": 6.0,
+          "sets_per_session": 1.0,
+          "status": "low",
+          "total_reps": 45.9,
+          "total_volume": 2295.0,
+          "volume_class": "low-volume",
+          "weekly_sets": 6.0
+        },
+        "Chest": {
+          "avg_sets_per_session": 10.62,
+          "contribution_mode": "direct",
+          "counting_mode": "raw",
+          "effective_weekly_sets": 21.25,
+          "frequency": 2,
+          "max_sets_per_session": 12.75,
+          "raw_total_reps": 225.0,
+          "raw_total_volume": 16650.0,
+          "raw_weekly_sets": 25.0,
+          "sets_per_session": 12.5,
+          "status": "high",
+          "total_reps": 191.25,
+          "total_volume": 14152.5,
+          "volume_class": "high-volume",
+          "weekly_sets": 25.0
+        },
+        "Forearms": {
+          "avg_sets_per_session": 0.0,
+          "contribution_mode": "direct",
+          "counting_mode": "raw",
+          "effective_weekly_sets": 0.77,
+          "frequency": 0,
+          "max_sets_per_session": 0.77,
+          "raw_total_reps": 70.0,
+          "raw_total_volume": 700.0,
+          "raw_weekly_sets": 2.0,
+          "sets_per_session": 0.33,
+          "status": "low",
+          "total_reps": 26.95,
+          "total_volume": 269.5,
+          "volume_class": "low-volume",
+          "weekly_sets": 2.0
+        },
+        "Quadriceps": {
+          "avg_sets_per_session": 6.8,
+          "contribution_mode": "direct",
+          "counting_mode": "raw",
+          "effective_weekly_sets": 6.8,
+          "frequency": 1,
+          "max_sets_per_session": 6.8,
+          "raw_total_reps": 72.0,
+          "raw_total_volume": 7200.0,
+          "raw_weekly_sets": 8.0,
+          "sets_per_session": 8.0,
+          "status": "low",
+          "total_reps": 61.2,
+          "total_volume": 6120.0,
+          "volume_class": "low-volume",
+          "weekly_sets": 8.0
+        },
+        "Rear-Shoulder": {
+          "avg_sets_per_session": 1.7,
+          "contribution_mode": "direct",
+          "counting_mode": "raw",
+          "effective_weekly_sets": 1.7,
+          "frequency": 1,
+          "max_sets_per_session": 1.7,
+          "raw_total_reps": 18.0,
+          "raw_total_volume": 180.0,
+          "raw_weekly_sets": 2.0,
+          "sets_per_session": 2.0,
+          "status": "low",
+          "total_reps": 15.3,
+          "total_volume": 153.0,
+          "volume_class": "low-volume",
+          "weekly_sets": 2.0
+        },
+        "Triceps": {
+          "avg_sets_per_session": 4.25,
+          "contribution_mode": "direct",
+          "counting_mode": "raw",
+          "effective_weekly_sets": 4.25,
+          "frequency": 1,
+          "max_sets_per_session": 4.25,
+          "raw_total_reps": 45.0,
+          "raw_total_volume": 1350.0,
+          "raw_weekly_sets": 5.0,
+          "sets_per_session": 5.0,
+          "status": "low",
+          "total_reps": 38.25,
+          "total_volume": 1147.5,
+          "volume_class": "low-volume",
+          "weekly_sets": 5.0
+        },
+        "Upper Back": {
+          "avg_sets_per_session": 5.1,
+          "contribution_mode": "direct",
+          "counting_mode": "raw",
+          "effective_weekly_sets": 5.1,
+          "frequency": 1,
+          "max_sets_per_session": 5.1,
+          "raw_total_reps": 54.0,
+          "raw_total_volume": 3240.0,
+          "raw_weekly_sets": 6.0,
+          "sets_per_session": 6.0,
+          "status": "low",
+          "total_reps": 45.9,
+          "total_volume": 2754.0,
+          "volume_class": "low-volume",
+          "weekly_sets": 6.0
+        }
+      },
+      "raw_total": {
+        "Biceps": {
+          "avg_sets_per_session": 5.95,
+          "contribution_mode": "total",
+          "counting_mode": "raw",
+          "effective_weekly_sets": 5.95,
+          "frequency": 1,
+          "max_sets_per_session": 5.95,
+          "raw_total_reps": 63.0,
+          "raw_total_volume": 2340.0,
+          "raw_weekly_sets": 7.0,
+          "sets_per_session": 7.0,
+          "status": "low",
+          "total_reps": 53.55,
+          "total_volume": 1989.0,
+          "volume_class": "low-volume",
+          "weekly_sets": 7.0
+        },
+        "Calves": {
+          "avg_sets_per_session": 0.0,
+          "contribution_mode": "total",
+          "counting_mode": "raw",
+          "effective_weekly_sets": 5.1,
+          "frequency": 0,
+          "max_sets_per_session": 0.0,
+          "raw_total_reps": 54.0,
+          "raw_total_volume": 2700.0,
+          "raw_weekly_sets": 6.0,
+          "sets_per_session": 1.0,
+          "status": "low",
+          "total_reps": 45.9,
+          "total_volume": 2295.0,
+          "volume_class": "low-volume",
+          "weekly_sets": 6.0
+        },
+        "Chest": {
+          "avg_sets_per_session": 10.62,
+          "contribution_mode": "total",
+          "counting_mode": "raw",
+          "effective_weekly_sets": 21.25,
+          "frequency": 2,
+          "max_sets_per_session": 12.75,
+          "raw_total_reps": 225.0,
+          "raw_total_volume": 16650.0,
+          "raw_weekly_sets": 25.0,
+          "sets_per_session": 12.5,
+          "status": "high",
+          "total_reps": 191.25,
+          "total_volume": 14152.5,
+          "volume_class": "high-volume",
+          "weekly_sets": 25.0
+        },
+        "Forearms": {
+          "avg_sets_per_session": 0.0,
+          "contribution_mode": "total",
+          "counting_mode": "raw",
+          "effective_weekly_sets": 0.77,
+          "frequency": 0,
+          "max_sets_per_session": 0.77,
+          "raw_total_reps": 70.0,
+          "raw_total_volume": 700.0,
+          "raw_weekly_sets": 2.0,
+          "sets_per_session": 0.33,
+          "status": "low",
+          "total_reps": 26.95,
+          "total_volume": 269.5,
+          "volume_class": "low-volume",
+          "weekly_sets": 2.0
+        },
+        "Front-Shoulder": {
+          "avg_sets_per_session": 2.12,
+          "contribution_mode": "total",
+          "counting_mode": "raw",
+          "effective_weekly_sets": 2.12,
+          "frequency": 1,
+          "max_sets_per_session": 2.12,
+          "raw_total_reps": 22.5,
+          "raw_total_volume": 1800.0,
+          "raw_weekly_sets": 2.5,
+          "sets_per_session": 2.5,
+          "status": "low",
+          "total_reps": 19.12,
+          "total_volume": 1530.0,
+          "volume_class": "low-volume",
+          "weekly_sets": 2.5
+        },
+        "Gluteus Maximus": {
+          "avg_sets_per_session": 3.4,
+          "contribution_mode": "total",
+          "counting_mode": "raw",
+          "effective_weekly_sets": 3.4,
+          "frequency": 1,
+          "max_sets_per_session": 3.4,
+          "raw_total_reps": 36.0,
+          "raw_total_volume": 3600.0,
+          "raw_weekly_sets": 4.0,
+          "sets_per_session": 4.0,
+          "status": "low",
+          "total_reps": 30.6,
+          "total_volume": 3060.0,
+          "volume_class": "low-volume",
+          "weekly_sets": 4.0
+        },
+        "Quadriceps": {
+          "avg_sets_per_session": 6.8,
+          "contribution_mode": "total",
+          "counting_mode": "raw",
+          "effective_weekly_sets": 6.8,
+          "frequency": 1,
+          "max_sets_per_session": 6.8,
+          "raw_total_reps": 72.0,
+          "raw_total_volume": 7200.0,
+          "raw_weekly_sets": 8.0,
+          "sets_per_session": 8.0,
+          "status": "low",
+          "total_reps": 61.2,
+          "total_volume": 6120.0,
+          "volume_class": "low-volume",
+          "weekly_sets": 8.0
+        },
+        "Rear-Shoulder": {
+          "avg_sets_per_session": 1.7,
+          "contribution_mode": "total",
+          "counting_mode": "raw",
+          "effective_weekly_sets": 1.7,
+          "frequency": 1,
+          "max_sets_per_session": 1.7,
+          "raw_total_reps": 18.0,
+          "raw_total_volume": 180.0,
+          "raw_weekly_sets": 2.0,
+          "sets_per_session": 2.0,
+          "status": "low",
+          "total_reps": 15.3,
+          "total_volume": 153.0,
+          "volume_class": "low-volume",
+          "weekly_sets": 2.0
+        },
+        "Triceps": {
+          "avg_sets_per_session": 8.5,
+          "contribution_mode": "total",
+          "counting_mode": "raw",
+          "effective_weekly_sets": 8.5,
+          "frequency": 1,
+          "max_sets_per_session": 8.5,
+          "raw_total_reps": 90.0,
+          "raw_total_volume": 4950.0,
+          "raw_weekly_sets": 10.0,
+          "sets_per_session": 10.0,
+          "status": "low",
+          "total_reps": 76.5,
+          "total_volume": 4207.5,
+          "volume_class": "medium-volume",
+          "weekly_sets": 10.0
+        },
+        "Upper Back": {
+          "avg_sets_per_session": 5.1,
+          "contribution_mode": "total",
+          "counting_mode": "raw",
+          "effective_weekly_sets": 5.1,
+          "frequency": 1,
+          "max_sets_per_session": 5.1,
+          "raw_total_reps": 54.0,
+          "raw_total_volume": 3240.0,
+          "raw_weekly_sets": 6.0,
+          "sets_per_session": 6.0,
+          "status": "low",
+          "total_reps": 45.9,
+          "total_volume": 2754.0,
+          "volume_class": "low-volume",
+          "weekly_sets": 6.0
+        }
+      }
+    }
+  }
+}

--- a/tests/test_weekly_summary_golden.py
+++ b/tests/test_weekly_summary_golden.py
@@ -1,0 +1,315 @@
+"""Durable golden fixtures for the weekly-summary protected calculation zone (WP2.3).
+
+These goldens pin the EXACT current output of the load-bearing public calculations in
+``utils/weekly_summary.py`` so the WP2.3 in-module helper extraction (and any future touch
+to this protected calc zone) is guarded by an equality test rather than a hand-checked PR
+diff. The golden is generated from current behavior and checked into
+``tests/goldens/weekly_summary_golden.json``.
+
+Regenerate intentionally (only when a behavior change is authorized and reviewed) with::
+
+    GENERATE_GOLDEN=1 .venv/Scripts/python.exe -m pytest \
+        tests/test_weekly_summary_golden.py -q
+
+Coverage is deliberately broad (see the product-risk review for WP2.3):
+
+* Effective-vs-Raw side-by-side shape across the full ``counting_mode`` x
+  ``contribution_mode`` matrix.
+* Muscle contribution weighting (primary 1.0 / secondary 0.5 / tertiary 0.25).
+* Frequency's ``>= 1.0`` threshold locked ABOVE and BELOW, where the per-routine total
+  accumulates across multiple exercises BEFORE the threshold test (M5).
+* Falsy-routine ("null routine") behavior (OD4, DEFERRED): a muscle sourced only from a
+  falsy routine contributes volume but drops out of frequency / session counts (M2). The
+  schema is ``routine TEXT NOT NULL``, so the reachable falsy case is the empty string
+  ``''`` — exactly what ``if routine:`` and pattern coverage's ``.get('routine', ...)``
+  branch on. This golden LOCKS that drop-from-frequency behavior; it must NOT be "fixed"
+  into a WPB.4 ``Unassigned`` bucket here.
+* DIRECT_ONLY is per-contribution, not per-muscle: a muscle that is secondary in one
+  exercise and primary in another is credited only via its primary instance (S3).
+* Pattern coverage: the empty-pattern ``_infer_pattern`` fallback branches (M3), and the
+  global warning verdicts — push-dominant / pull-dominant / balanced / isolation-skew and
+  the strict 15/24 volume boundaries — each locked in their own reseeded DB state (M4/S1/S2),
+  because pattern coverage takes no mode toggles and a warning is one verdict per DB state.
+"""
+from __future__ import annotations
+
+import json
+import os
+from pathlib import Path
+
+import pytest
+
+from utils.effective_sets import CountingMode, ContributionMode
+from utils.weekly_summary import (
+    calculate_exercise_categories,
+    calculate_isolated_muscles_stats,
+    calculate_pattern_coverage,
+    calculate_weekly_summary,
+)
+
+GOLDEN_PATH = Path(__file__).parent / "goldens" / "weekly_summary_golden.json"
+
+
+# ---------------------------------------------------------------------------
+# Seed helpers
+# ---------------------------------------------------------------------------
+def _reset(db) -> None:
+    """Wipe the tables the summary calcs read, in FK-safe order."""
+    for table in ("workout_log", "user_selection", "exercise_isolated_muscles", "exercises"):
+        db.execute_query(f"DELETE FROM {table}")
+
+
+def _add_ex(
+    db,
+    name,
+    primary=None,
+    secondary=None,
+    tertiary=None,
+    mechanic=None,
+    utility=None,
+    force=None,
+    difficulty=None,
+    pattern=None,
+    subpattern=None,
+) -> None:
+    db.execute_query(
+        """
+        INSERT INTO exercises (
+            exercise_name, primary_muscle_group, secondary_muscle_group,
+            tertiary_muscle_group, mechanic, utility, force, difficulty,
+            movement_pattern, movement_subpattern
+        ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+        """,
+        (name, primary, secondary, tertiary, mechanic, utility, force, difficulty, pattern, subpattern),
+    )
+
+
+def _add_sel(db, routine, exercise, sets, min_rep, max_rep, rir, weight) -> None:
+    db.execute_query(
+        """
+        INSERT INTO user_selection (
+            routine, exercise, sets, min_rep_range, max_rep_range, rir, rpe, weight
+        ) VALUES (?, ?, ?, ?, ?, ?, NULL, ?)
+        """,
+        (routine, exercise, sets, min_rep, max_rep, rir, weight),
+    )
+
+
+def _add_iso(db, exercise, muscle) -> None:
+    db.execute_query(
+        "INSERT INTO exercise_isolated_muscles (exercise_name, muscle) VALUES (?, ?)",
+        (exercise, muscle),
+    )
+
+
+# ---------------------------------------------------------------------------
+# Scenario seeds
+# ---------------------------------------------------------------------------
+def _seed_weekly_main(db) -> None:
+    """Rich seed exercising weekly-summary across every load-bearing branch."""
+    _add_ex(db, "Bench Press", "Chest", "Triceps", "Front-Shoulder", "Compound", "Basic", "Push", "Intermediate", "horizontal_push")
+    _add_ex(db, "Incline Press", "Chest", None, None, "Compound", "Basic", "Push", "Intermediate", "horizontal_push")
+    _add_ex(db, "Back Squat", "Quadriceps", "Gluteus Maximus", None, "Compound", "Basic", "Push", "Intermediate", "squat")
+    _add_ex(db, "Barbell Row", "Upper Back", "Biceps", None, "Compound", "Basic", "Pull", "Intermediate", "horizontal_pull")
+    _add_ex(db, "Biceps Curl", "Biceps", None, None, "Isolated", "Auxiliary", "Pull", "Beginner", "upper_isolation", "bicep_curl")
+    _add_ex(db, "Calf Raise", "Calves", None, None, "Isolated", "Auxiliary", "Push", "Beginner", "lower_isolation")
+    _add_ex(db, "Triceps Pushdown", "Triceps", None, None, "Isolated", "Auxiliary", "Push", "Beginner", "upper_isolation")
+    _add_ex(db, "Rear Delt A", "Rear-Shoulder", None, None, "Isolated", "Auxiliary", "Pull", "Beginner", "upper_isolation")
+    _add_ex(db, "Rear Delt B", "Rear-Shoulder", None, None, "Isolated", "Auxiliary", "Pull", "Beginner", "upper_isolation")
+    _add_ex(db, "Forearm A", "Forearms", None, None, "Isolated", "Auxiliary", "Pull", "Beginner", "upper_isolation")
+    _add_ex(db, "Forearm B", "Forearms", None, None, "Isolated", "Auxiliary", "Pull", "Beginner", "upper_isolation")
+
+    # Chest across two routines -> frequency 2. Triceps secondary here (S3).
+    _add_sel(db, "Push A", "Bench Press", 10, 8, 10, 2, 80.0)
+    _add_sel(db, "Push B", "Incline Press", 15, 8, 10, 2, 70.0)
+    # Triceps primary here; in DIRECT_ONLY only this instance credits Triceps (S3).
+    _add_sel(db, "Push A", "Triceps Pushdown", 5, 8, 10, 2, 30.0)
+    _add_sel(db, "Legs A", "Back Squat", 8, 8, 10, 2, 100.0)
+    _add_sel(db, "Pull A", "Barbell Row", 6, 8, 10, 2, 60.0)
+    _add_sel(db, "Pull A", "Biceps Curl", 4, 8, 10, 2, 20.0)
+    # Falsy (empty-string) routine: Calves sourced ONLY here -> volume but no frequency (M2/OD4).
+    _add_sel(db, "", "Calf Raise", 6, 8, 10, 2, 50.0)
+    # Frequency accumulation ABOVE threshold: two 0.85 contributions sum to 1.7 >= 1.0 (M5).
+    _add_sel(db, "Freq A", "Rear Delt A", 1, 8, 10, 2, 10.0)
+    _add_sel(db, "Freq A", "Rear Delt B", 1, 8, 10, 2, 10.0)
+    # Frequency accumulation BELOW threshold: two 0.385 contributions sum to 0.77 < 1.0 (M5).
+    _add_sel(db, "Freq B", "Forearm A", 1, 30, 40, 8, 10.0)
+    _add_sel(db, "Freq B", "Forearm B", 1, 30, 40, 8, 10.0)
+
+    _add_iso(db, "Bench Press", "anterior-deltoid")
+    _add_iso(db, "Bench Press", "upper-pectoralis")
+
+
+def _seed_pattern_infer(db) -> None:
+    """Empty movement_pattern rows spanning every _infer_pattern outcome (M3)."""
+    rows = [
+        # (exercise, primary_muscle, mechanic, expected inference)
+        ("Infer Quad", "Quadriceps", "Compound"),        # 'quad' -> squat
+        ("Infer Glute", "Gluteus Maximus", "Compound"),  # 'glute' (not quad) -> hinge
+        ("Infer Chest", "Chest", "Compound"),            # 'chest' -> horizontal_push
+        ("Infer Lat C", "Latissimus Dorsi", "Compound"),  # 'lat' + compound -> vertical_pull
+        ("Infer Lat I", "Latissimus Dorsi", "Isolated"),   # 'lat' + non-compound -> horizontal_pull
+        ("Infer Back I", "Upper Back", "Isolated"),        # 'back' + non-compound -> horizontal_pull
+        ("Infer Bicep", "Biceps", "Isolated"),           # 'bicep' -> upper_isolation
+        ("Infer Tricep", "Triceps", "Isolated"),         # 'tricep' -> upper_isolation
+        ("Infer Calf", "Calves", "Isolated"),            # 'calf' -> lower_isolation
+        ("Infer Ham", "Hamstrings", "Isolated"),         # 'hamstring' -> lower_isolation
+        ("Infer Core", "Abs/Core", "Isolated"),          # 'core'/'abs' -> core_dynamic
+        ("Infer Other", "Neck", "Isolated"),             # no match -> other
+    ]
+    for name, primary, mechanic in rows:
+        _add_ex(db, name, primary, mechanic=mechanic, pattern=None)
+        _add_sel(db, "Infer R", name, 3, 8, 10, 2, 20.0)
+
+
+def _seed_pattern_push_dominant(db) -> None:
+    """push/pull ratio > 1.5 -> 'Push-dominant program' (M4)."""
+    _add_ex(db, "PD Bench", "Chest", mechanic="Compound", pattern="horizontal_push")
+    _add_ex(db, "PD OHP", "Front-Shoulder", mechanic="Compound", pattern="vertical_push")
+    _add_ex(db, "PD Row", "Upper Back", mechanic="Compound", pattern="horizontal_pull")
+    _add_sel(db, "Push R", "PD Bench", 10, 8, 10, 2, 80.0)
+    _add_sel(db, "Push R", "PD OHP", 8, 8, 10, 2, 50.0)
+    _add_sel(db, "Push R", "PD Row", 4, 8, 10, 2, 60.0)
+
+
+def _seed_pattern_pull_dominant(db) -> None:
+    """push/pull ratio < 0.67 -> 'Pull-dominant program' (M4)."""
+    _add_ex(db, "PL Row", "Upper Back", mechanic="Compound", pattern="horizontal_pull")
+    _add_ex(db, "PL Pulldown", "Latissimus Dorsi", mechanic="Compound", pattern="vertical_pull")
+    _add_ex(db, "PL Bench", "Chest", mechanic="Compound", pattern="horizontal_push")
+    _add_sel(db, "Pull R", "PL Row", 10, 8, 10, 2, 60.0)
+    _add_sel(db, "Pull R", "PL Pulldown", 8, 8, 10, 2, 55.0)
+    _add_sel(db, "Pull R", "PL Bench", 4, 8, 10, 2, 80.0)
+
+
+def _seed_pattern_balanced(db) -> None:
+    """All six core patterns present, balanced push/pull, no isolation -> zero warnings."""
+    specs = [
+        ("Bal Squat", "Quadriceps", "squat", 4),
+        ("Bal Hinge", "Hamstrings", "hinge", 4),
+        ("Bal HPush", "Chest", "horizontal_push", 4),
+        ("Bal HPull", "Upper Back", "horizontal_pull", 4),
+        ("Bal VPush", "Front-Shoulder", "vertical_push", 3),
+        ("Bal VPull", "Latissimus Dorsi", "vertical_pull", 3),
+    ]
+    for name, primary, pattern, sets in specs:
+        _add_ex(db, name, primary, mechanic="Compound", pattern=pattern)
+        _add_sel(db, "Bal R", name, sets, 8, 10, 2, 60.0)
+
+
+def _seed_pattern_isolation_skew(db) -> None:
+    """isolation > 1.5 x compound -> 'High isolation-to-compound ratio' (M4)."""
+    _add_ex(db, "IS Curl", "Biceps", mechanic="Isolated", pattern="upper_isolation")
+    _add_ex(db, "IS LegCurl", "Hamstrings", mechanic="Isolated", pattern="lower_isolation")
+    _add_ex(db, "IS Squat", "Quadriceps", mechanic="Compound", pattern="squat")
+    _add_sel(db, "Iso R", "IS Curl", 20, 8, 10, 2, 20.0)
+    _add_sel(db, "Iso R", "IS LegCurl", 20, 8, 10, 2, 40.0)
+    _add_sel(db, "Iso R", "IS Squat", 4, 8, 10, 2, 100.0)
+
+
+def _seed_pattern_volume_boundaries(db) -> None:
+    """Strict 15/24 volume boundaries and >=2 volume-warning routines (S1/S2)."""
+    _add_ex(db, "Vol Push", "Chest", mechanic="Compound", pattern="horizontal_push")
+    # ORDER BY us.routine -> Vol 14, Vol 15, Vol 24, Vol 25.
+    _add_sel(db, "Vol 14", "Vol Push", 14, 8, 10, 2, 80.0)  # < 15 -> low_volume
+    _add_sel(db, "Vol 15", "Vol Push", 15, 8, 10, 2, 80.0)  # boundary -> no warning
+    _add_sel(db, "Vol 24", "Vol Push", 24, 8, 10, 2, 80.0)  # boundary -> no warning
+    _add_sel(db, "Vol 25", "Vol Push", 25, 8, 10, 2, 80.0)  # > 24 -> high_volume
+
+
+# ---------------------------------------------------------------------------
+# Output collection + canonicalization
+# ---------------------------------------------------------------------------
+_MODE_MATRIX = [
+    ("effective_total", CountingMode.EFFECTIVE, ContributionMode.TOTAL),
+    ("raw_total", CountingMode.RAW, ContributionMode.TOTAL),
+    ("effective_direct", CountingMode.EFFECTIVE, ContributionMode.DIRECT_ONLY),
+    ("raw_direct", CountingMode.RAW, ContributionMode.DIRECT_ONLY),
+]
+
+
+def _collect(db) -> dict:
+    """Build the full result tree the golden pins."""
+    results: dict = {}
+
+    _reset(db)
+    _seed_weekly_main(db)
+    weekly = {}
+    for key, counting, contribution in _MODE_MATRIX:
+        weekly[key] = calculate_weekly_summary(
+            counting_mode=counting, contribution_mode=contribution
+        )
+    results["weekly_main"] = {
+        "weekly_summary": weekly,
+        "pattern_coverage": calculate_pattern_coverage(),
+        "exercise_categories": calculate_exercise_categories(),
+        "isolated_muscles": calculate_isolated_muscles_stats(),
+    }
+
+    pattern_scenarios = [
+        ("pattern_infer", _seed_pattern_infer),
+        ("pattern_push_dominant", _seed_pattern_push_dominant),
+        ("pattern_pull_dominant", _seed_pattern_pull_dominant),
+        ("pattern_balanced", _seed_pattern_balanced),
+        ("pattern_isolation_skew", _seed_pattern_isolation_skew),
+        ("pattern_volume_boundaries", _seed_pattern_volume_boundaries),
+    ]
+    for name, seed in pattern_scenarios:
+        _reset(db)
+        seed(db)
+        results[name] = {"pattern_coverage": calculate_pattern_coverage()}
+
+    return results
+
+
+def _canonical(obj):
+    """Normalize to the JSON value space so comparison is order- and key-type stable.
+
+    Mirrors ``json.dumps`` key coercion (e.g. an empty-string vs None routine key) and
+    turns tuples into lists, so ``_canonical(fresh) == json.loads(golden)`` compares
+    exactly what is persisted. round(x, 2) floats round-trip through JSON unchanged.
+    """
+    if isinstance(obj, dict):
+        out = {}
+        for key, value in obj.items():
+            if key is None:
+                skey = "null"
+            elif isinstance(key, bool):
+                skey = "true" if key else "false"
+            elif isinstance(key, str):
+                skey = key
+            else:
+                skey = str(key)
+            out[skey] = _canonical(value)
+        return out
+    if isinstance(obj, (list, tuple)):
+        return [_canonical(v) for v in obj]
+    return obj
+
+
+# ---------------------------------------------------------------------------
+# The golden test
+# ---------------------------------------------------------------------------
+@pytest.mark.usefixtures("clean_db")
+def test_weekly_summary_golden(db_handler):
+    """Weekly-summary + pattern-coverage output must match the checked-in golden exactly.
+
+    This is the WP2.3 guard: any drift in the protected weekly-summary calc zone (effective
+    vs raw shape, frequency counts, rounding, mode toggles, warning order, falsy-routine
+    behavior) fails here. Do not regenerate the golden to make a drift pass without an
+    authorized, product-risk-reviewed behavior change.
+    """
+    fresh = _canonical(_collect(db_handler))
+
+    if os.environ.get("GENERATE_GOLDEN") == "1":
+        GOLDEN_PATH.parent.mkdir(parents=True, exist_ok=True)
+        GOLDEN_PATH.write_text(
+            json.dumps(fresh, indent=2, sort_keys=True) + "\n", encoding="utf-8"
+        )
+        pytest.skip("Regenerated golden fixture (GENERATE_GOLDEN=1).")
+
+    assert GOLDEN_PATH.exists(), (
+        f"Missing golden fixture {GOLDEN_PATH}. Regenerate with GENERATE_GOLDEN=1."
+    )
+    expected = json.loads(GOLDEN_PATH.read_text(encoding="utf-8"))
+    assert fresh == expected

--- a/utils/weekly_summary.py
+++ b/utils/weekly_summary.py
@@ -2,7 +2,7 @@
 from __future__ import annotations
 
 from collections import defaultdict
-from typing import Any, Dict, List, Optional
+from typing import Any, Dict, List, Optional, Tuple
 
 from utils.database import DatabaseHandler
 from utils.volume_classifier import get_volume_class
@@ -26,55 +26,43 @@ EFFECTIVE_STATUS_MAP = {
 logger = get_logger()
 
 
-def calculate_weekly_summary(
-    method: Optional[str] = None,
-    counting_mode: CountingMode = CountingMode.EFFECTIVE,
-    contribution_mode: ContributionMode = ContributionMode.TOTAL,
-) -> Dict[str, Dict[str, Any]]:
-    """Aggregate weighted weekly set counts per muscle group with effective sets.
+_WEEKLY_PLAN_QUERY = """
+    SELECT
+        us.routine,
+        us.sets,
+        us.min_rep_range,
+        us.max_rep_range,
+        us.weight,
+        us.rir,
+        us.rpe,
+        e.primary_muscle_group,
+        e.secondary_muscle_group,
+        e.tertiary_muscle_group
+    FROM user_selection us
+    JOIN exercises e ON us.exercise = e.exercise_name
+"""
 
-    Args:
-        method: Optional summary mode retained for backwards compatibility. Current
-            implementation ignores the value but accepts inputs like "Total" so
-            existing callers do not raise ``TypeError``.
-        counting_mode: RAW or EFFECTIVE set counting mode.
-        contribution_mode: DIRECT_ONLY or TOTAL muscle contribution mode.
-        
-    Returns:
-        Dictionary mapping muscle groups to their volume statistics including:
-        - weekly_sets: Total (effective or raw) sets for the week
-        - raw_weekly_sets: Always the raw set count (for reference)
-        - effective_weekly_sets: Always the effective set count
-        - sets_per_session: Average sets per training session
-        - frequency: Number of sessions where muscle got >= 1.0 effective sets
-        - status: Volume classification (low/medium/high/excessive)
-        - volume_class: CSS class for UI styling
-        - total_reps: Weighted rep total
-        - total_volume: Weighted volume (sets * reps * weight)
+
+def _aggregate_weekly_volumes(
+    rows: List[Dict[str, Any]],
+    contribution_mode: ContributionMode,
+) -> Tuple[
+    Dict[str, Dict[str, float]],
+    Dict[str, Dict[str, float]],
+    Dict[str, Dict[str, float]],
+]:
+    """Accumulate effective/raw per-muscle totals and per-routine session contributions.
+
+    Effective totals are always computed with effective-mode weighting; the counting
+    mode only changes which aggregate is later presented as the primary metric.
     """
-    _ = method  # Method handled implicitly; provided for API compatibility.
-    query = """
-        SELECT
-            us.routine,
-            us.sets,
-            us.min_rep_range,
-            us.max_rep_range,
-            us.weight,
-            us.rir,
-            us.rpe,
-            e.primary_muscle_group,
-            e.secondary_muscle_group,
-            e.tertiary_muscle_group
-        FROM user_selection us
-        JOIN exercises e ON us.exercise = e.exercise_name
-    """
-
-    with DatabaseHandler() as db:
-        rows = db.fetch_all(query)
-
     # Track both effective and raw totals
-    effective_totals = defaultdict(lambda: {'sets': 0.0, 'reps': 0.0, 'volume': 0.0})
-    raw_totals = defaultdict(lambda: {'sets': 0.0, 'reps': 0.0, 'volume': 0.0})
+    effective_totals: Dict[str, Dict[str, float]] = defaultdict(
+        lambda: {'sets': 0.0, 'reps': 0.0, 'volume': 0.0}
+    )
+    raw_totals: Dict[str, Dict[str, float]] = defaultdict(
+        lambda: {'sets': 0.0, 'reps': 0.0, 'volume': 0.0}
+    )
     sessions_by_muscle: Dict[str, Dict[str, float]] = defaultdict(lambda: defaultdict(float))
 
     for row in rows:
@@ -85,11 +73,11 @@ def calculate_weekly_summary(
         rir = row.get('rir')
         rpe = row.get('rpe')
         load = row.get('weight') or 0
-        
+
         avg_reps = 0.0
         if min_rep is not None and max_rep is not None:
             avg_reps = (min_rep + max_rep) / 2.0
-        
+
         # Effective totals are always computed with effective-mode weighting.
         # The counting_mode toggle only changes which aggregate is presented
         # as the primary `weekly_sets` metric.
@@ -105,106 +93,164 @@ def calculate_weekly_summary(
             counting_mode=CountingMode.EFFECTIVE,
             contribution_mode=contribution_mode,
         )
-        
+
         # Aggregate per-muscle contributions
         contributions = [
             (row.get('primary_muscle_group'), MUSCLE_CONTRIBUTION_WEIGHTS['primary']),
             (row.get('secondary_muscle_group'), MUSCLE_CONTRIBUTION_WEIGHTS['secondary']),
             (row.get('tertiary_muscle_group'), MUSCLE_CONTRIBUTION_WEIGHTS['tertiary']),
         ]
-        
+
         for muscle, weight_factor in contributions:
             if not muscle:
                 continue
-                
+
             # Skip secondary/tertiary in direct-only mode
             if contribution_mode == ContributionMode.DIRECT_ONLY:
                 if weight_factor != MUSCLE_CONTRIBUTION_WEIGHTS['primary']:
                     continue
                 weight_factor = 1.0  # Full credit for primary in direct mode
-            
+
             # Get effective contribution for this muscle
             eff_contribution = eff_result.muscle_contributions.get(muscle, 0.0)
-            
+
             # Raw calculations (always use standard weighting)
             raw_weighted_sets = sets * weight_factor
             raw_weighted_reps = raw_weighted_sets * avg_reps
             raw_weighted_volume = raw_weighted_reps * load
-            
+
             # Effective calculations
             eff_weighted_reps = eff_contribution * avg_reps
             eff_weighted_volume = eff_weighted_reps * load
-            
+
             # Update effective totals
             eff_bucket = effective_totals[muscle]
             eff_bucket['sets'] += eff_contribution
             eff_bucket['reps'] += eff_weighted_reps
             eff_bucket['volume'] += eff_weighted_volume
-            
+
             # Update raw totals (preserve for display/debugging)
             raw_bucket = raw_totals[muscle]
             raw_bucket['sets'] += raw_weighted_sets
             raw_bucket['reps'] += raw_weighted_reps
             raw_bucket['volume'] += raw_weighted_volume
-            
+
             # Track session contributions for frequency calculation
             if routine:
                 sessions_by_muscle[muscle][routine] += eff_contribution
 
-    global_sessions = {row.get('routine') for row in rows if row.get('routine')}
+    return effective_totals, raw_totals, sessions_by_muscle
+
+
+def _build_weekly_summary_output(
+    effective_totals: Dict[str, Dict[str, float]],
+    raw_totals: Dict[str, Dict[str, float]],
+    sessions_by_muscle: Dict[str, Dict[str, float]],
+    global_sessions: set,
+    counting_mode: CountingMode,
+    contribution_mode: ContributionMode,
+) -> Dict[str, Dict[str, Any]]:
+    """Assemble the per-muscle summary rows from the accumulated totals."""
     summary: Dict[str, Dict[str, Any]] = {}
-    
+
     for muscle in set(effective_totals.keys()) | set(raw_totals.keys()):
         eff_aggregates = effective_totals[muscle]
         raw_aggregates = raw_totals[muscle]
-        
+
         weekly_eff_sets = eff_aggregates['sets']
         weekly_raw_sets = raw_aggregates['sets']
-        
+
         # Use effective sets as the primary metric (or raw if in RAW mode)
         if counting_mode == CountingMode.RAW:
             weekly_sets = weekly_raw_sets
         else:
             weekly_sets = weekly_eff_sets
-        
+
         # Calculate frequency: sessions where muscle got >= 1.0 effective sets
         muscle_sessions = sessions_by_muscle.get(muscle, {})
         frequency = sum(1 for eff_sets in muscle_sessions.values() if eff_sets >= 1.0)
-        
+
         # Fallback session count for backward compatibility
         session_count = frequency if frequency > 0 else (len(global_sessions) or 1)
         sets_per_session = weekly_sets / session_count if session_count else weekly_sets
-        
+
         # Use effective-sets-based classification
         volume_class_str = get_weekly_volume_class(weekly_eff_sets)
         legacy_volume_class = get_volume_class(weekly_sets)
-        
+
         summary[muscle] = {
             # Primary metrics (mode-dependent)
             'weekly_sets': round(weekly_sets, 2),
             'sets_per_session': round(sets_per_session, 2),
             'status': EFFECTIVE_STATUS_MAP.get(volume_class_str, 'low'),
             'volume_class': legacy_volume_class,  # Keep legacy CSS class
-            
+
             # Always-available metrics
             'raw_weekly_sets': round(weekly_raw_sets, 2),
             'effective_weekly_sets': round(weekly_eff_sets, 2),
             'frequency': frequency,
             'avg_sets_per_session': round(weekly_eff_sets / frequency, 2) if frequency > 0 else 0.0,
             'max_sets_per_session': round(max(muscle_sessions.values()), 2) if muscle_sessions else 0.0,
-            
+
             # Volume totals
             'total_reps': round(eff_aggregates['reps'], 2),
             'total_volume': round(eff_aggregates['volume'], 2),
             'raw_total_reps': round(raw_aggregates['reps'], 2),
             'raw_total_volume': round(raw_aggregates['volume'], 2),
-            
+
             # Mode indicators
             'counting_mode': counting_mode.value,
             'contribution_mode': contribution_mode.value,
         }
 
     return dict(sorted(summary.items()))
+
+
+def calculate_weekly_summary(
+    method: Optional[str] = None,
+    counting_mode: CountingMode = CountingMode.EFFECTIVE,
+    contribution_mode: ContributionMode = ContributionMode.TOTAL,
+) -> Dict[str, Dict[str, Any]]:
+    """Aggregate weighted weekly set counts per muscle group with effective sets.
+
+    Args:
+        method: Optional summary mode retained for backwards compatibility. Current
+            implementation ignores the value but accepts inputs like "Total" so
+            existing callers do not raise ``TypeError``.
+        counting_mode: RAW or EFFECTIVE set counting mode.
+        contribution_mode: DIRECT_ONLY or TOTAL muscle contribution mode.
+
+    Returns:
+        Dictionary mapping muscle groups to their volume statistics including:
+        - weekly_sets: Total (effective or raw) sets for the week
+        - raw_weekly_sets: Always the raw set count (for reference)
+        - effective_weekly_sets: Always the effective set count
+        - sets_per_session: Average sets per training session
+        - frequency: Number of sessions where muscle got >= 1.0 effective sets
+        - status: Volume classification (low/medium/high/excessive)
+        - volume_class: CSS class for UI styling
+        - total_reps: Weighted rep total
+        - total_volume: Weighted volume (sets * reps * weight)
+    """
+    _ = method  # Method handled implicitly; provided for API compatibility.
+
+    with DatabaseHandler() as db:
+        rows = db.fetch_all(_WEEKLY_PLAN_QUERY)
+
+    effective_totals, raw_totals, sessions_by_muscle = _aggregate_weekly_volumes(
+        rows, contribution_mode
+    )
+
+    global_sessions = {row.get('routine') for row in rows if row.get('routine')}
+
+    return _build_weekly_summary_output(
+        effective_totals,
+        raw_totals,
+        sessions_by_muscle,
+        global_sessions,
+        counting_mode,
+        contribution_mode,
+    )
 
 
 def calculate_exercise_categories() -> List[Dict[str, Any]]:
@@ -262,7 +308,7 @@ def calculate_isolated_muscles_stats() -> List[Dict[str, Any]]:
     Assumes tables: user_selection us, exercises e, exercise_isolated_muscles eim.
     """
     query = """
-    SELECT 
+    SELECT
         eim.muscle                          AS isolated_muscle,
         COUNT(DISTINCT us.exercise)         AS exercise_count,
         SUM(us.sets)                        AS total_sets,
@@ -282,96 +328,95 @@ def calculate_isolated_muscles_stats() -> List[Dict[str, Any]]:
         return []
 
 
-def calculate_pattern_coverage() -> Dict[str, Any]:
-    """
-    Analyze movement pattern coverage in the current workout plan.
-    
-    Returns:
-        Dictionary containing:
-        - per_routine: Dict mapping routine names to pattern coverage stats
-        - total: Aggregated pattern coverage across all routines
-        - warnings: List of actionable warnings about missing or imbalanced patterns
-        - sets_per_routine: Total sets per routine with min/max warnings
-    """
-    # Query to get exercise patterns with their sets per routine
-    query = """
-        SELECT
-            us.routine,
-            us.exercise,
-            us.sets,
-            e.movement_pattern,
-            e.movement_subpattern,
-            e.primary_muscle_group,
-            e.mechanic
-        FROM user_selection us
-        JOIN exercises e ON us.exercise = e.exercise_name
-        ORDER BY us.routine
-    """
-    
-    try:
-        with DatabaseHandler() as db:
-            rows = db.fetch_all(query)
-    except Exception as e:
-        logger.exception("Error calculating pattern coverage: %s", e)
-        return {"per_routine": {}, "total": {}, "warnings": [], "sets_per_routine": {}}
-    
-    # Core movement patterns that should be present in a balanced program
-    CORE_PATTERNS = {
-        "squat": "Lower body push (quads, glutes)",
-        "hinge": "Lower body pull (hamstrings, glutes, back)",
-        "horizontal_push": "Upper body horizontal push (chest, shoulders, triceps)",
-        "horizontal_pull": "Upper body horizontal pull (back, biceps)",
-        "vertical_push": "Upper body vertical push (shoulders, triceps)",
-        "vertical_pull": "Upper body vertical pull (lats, biceps)",
-    }
-    
+_PATTERN_COVERAGE_QUERY = """
+    SELECT
+        us.routine,
+        us.exercise,
+        us.sets,
+        e.movement_pattern,
+        e.movement_subpattern,
+        e.primary_muscle_group,
+        e.mechanic
+    FROM user_selection us
+    JOIN exercises e ON us.exercise = e.exercise_name
+    ORDER BY us.routine
+"""
+
+# Core movement patterns that should be present in a balanced program
+_CORE_PATTERNS = {
+    "squat": "Lower body push (quads, glutes)",
+    "hinge": "Lower body pull (hamstrings, glutes, back)",
+    "horizontal_push": "Upper body horizontal push (chest, shoulders, triceps)",
+    "horizontal_pull": "Upper body horizontal pull (back, biceps)",
+    "vertical_push": "Upper body vertical push (shoulders, triceps)",
+    "vertical_pull": "Upper body vertical pull (lats, biceps)",
+}
+
+# Session set-count guidance (ideal: 15-24 sets per routine)
+MIN_SETS = 15
+MAX_SETS = 24
+
+
+def _infer_pattern(mechanic: Optional[str], primary_muscle: Optional[str]) -> str:
+    """Classify a movement pattern from mechanic/muscle when none is stored."""
+    mechanic = (mechanic or '').lower()
+    primary_muscle = (primary_muscle or '').lower()
+
+    # Infer pattern from muscle group
+    if 'quad' in primary_muscle or 'glute' in primary_muscle:
+        return 'squat' if 'quad' in primary_muscle else 'hinge'
+    if 'chest' in primary_muscle:
+        return 'horizontal_push'
+    if 'lat' in primary_muscle or 'back' in primary_muscle:
+        if mechanic == 'compound':
+            return 'vertical_pull'
+        return 'horizontal_pull'
+    if 'bicep' in primary_muscle or 'tricep' in primary_muscle:
+        return 'upper_isolation'
+    if 'calf' in primary_muscle or 'hamstring' in primary_muscle:
+        return 'lower_isolation'
+    if 'core' in primary_muscle or 'abs' in primary_muscle:
+        return 'core_dynamic'
+    return 'other'
+
+
+def _tally_patterns(
+    rows: List[Dict[str, Any]],
+) -> Tuple[Dict[str, Dict[str, int]], Dict[str, int], Dict[str, int]]:
+    """Sum sets per movement pattern, both per routine and across the whole plan."""
     # Track patterns per routine
     per_routine: Dict[str, Dict[str, int]] = defaultdict(lambda: defaultdict(int))
     total_patterns: Dict[str, int] = defaultdict(int)
     sets_per_routine: Dict[str, int] = defaultdict(int)
-    
+
     for row in rows:
         routine = row.get('routine', 'Unknown')
         sets = row.get('sets', 0) or 0
         pattern = row.get('movement_pattern', '')
-        
+
         sets_per_routine[routine] += sets
-        
+
         if pattern:
             per_routine[routine][pattern] += sets
             total_patterns[pattern] += sets
         else:
             # Fallback: classify by mechanic/muscle if no pattern stored
-            mechanic = (row.get('mechanic') or '').lower()
-            primary_muscle = (row.get('primary_muscle_group') or '').lower()
-            
-            # Infer pattern from muscle group
-            if 'quad' in primary_muscle or 'glute' in primary_muscle:
-                inferred = 'squat' if 'quad' in primary_muscle else 'hinge'
-            elif 'chest' in primary_muscle:
-                inferred = 'horizontal_push'
-            elif 'lat' in primary_muscle or 'back' in primary_muscle:
-                if mechanic == 'compound':
-                    inferred = 'vertical_pull'
-                else:
-                    inferred = 'horizontal_pull'
-            elif 'bicep' in primary_muscle or 'tricep' in primary_muscle:
-                inferred = 'upper_isolation'
-            elif 'calf' in primary_muscle or 'hamstring' in primary_muscle:
-                inferred = 'lower_isolation'
-            elif 'core' in primary_muscle or 'abs' in primary_muscle:
-                inferred = 'core_dynamic'
-            else:
-                inferred = 'other'
-            
+            inferred = _infer_pattern(row.get('mechanic'), row.get('primary_muscle_group'))
             per_routine[routine][inferred] += sets
             total_patterns[inferred] += sets
-    
-    # Generate warnings
+
+    return per_routine, total_patterns, sets_per_routine
+
+
+def _build_pattern_warnings(
+    total_patterns: Dict[str, int],
+    sets_per_routine: Dict[str, int],
+) -> List[Dict[str, str]]:
+    """Generate actionable warnings about missing or imbalanced patterns."""
     warnings: List[Dict[str, str]] = []
-    
+
     # Check for missing core patterns
-    for pattern, description in CORE_PATTERNS.items():
+    for pattern, description in _CORE_PATTERNS.items():
         if total_patterns.get(pattern, 0) == 0:
             warnings.append({
                 "level": "high",
@@ -385,11 +430,8 @@ def calculate_pattern_coverage() -> Dict[str, Any]:
                               f"{'overhead press, dips' if pattern == 'vertical_push' else ''}"
                               f"{'pull-ups, lat pulldowns' if pattern == 'vertical_pull' else ''}.",
             })
-    
+
     # Check sets per routine (ideal: 15-24)
-    MIN_SETS = 15
-    MAX_SETS = 24
-    
     for routine, total_sets in sets_per_routine.items():
         if total_sets < MIN_SETS:
             warnings.append({
@@ -407,14 +449,14 @@ def calculate_pattern_coverage() -> Dict[str, Any]:
                 "description": f"Consider reducing by {total_sets - MAX_SETS} sets. "
                               f"High volume ({MAX_SETS}+ sets) may impair recovery.",
             })
-    
+
     # Check for isolation skew (too much isolation vs compound)
     total_isolation = total_patterns.get('upper_isolation', 0) + total_patterns.get('lower_isolation', 0)
     total_compound = sum(
-        total_patterns.get(p, 0) 
+        total_patterns.get(p, 0)
         for p in ['squat', 'hinge', 'horizontal_push', 'horizontal_pull', 'vertical_push', 'vertical_pull']
     )
-    
+
     if total_compound > 0 and total_isolation > total_compound * 1.5:
         warnings.append({
             "level": "medium",
@@ -424,11 +466,11 @@ def calculate_pattern_coverage() -> Dict[str, Any]:
                           f"compound work ({total_compound} sets). Consider balancing with more "
                           f"compound movements for better overall development.",
         })
-    
+
     # Check for push/pull imbalance
     total_push = total_patterns.get('horizontal_push', 0) + total_patterns.get('vertical_push', 0)
     total_pull = total_patterns.get('horizontal_pull', 0) + total_patterns.get('vertical_pull', 0)
-    
+
     if total_push > 0 and total_pull > 0:
         ratio = total_push / total_pull if total_pull > 0 else float('inf')
         if ratio > 1.5:
@@ -447,7 +489,31 @@ def calculate_pattern_coverage() -> Dict[str, Any]:
                 "description": f"Pull volume ({total_pull} sets) exceeds push volume ({total_push} sets). "
                               f"This is generally okay but ensure adequate chest/shoulder work.",
             })
-    
+
+    return warnings
+
+
+def calculate_pattern_coverage() -> Dict[str, Any]:
+    """
+    Analyze movement pattern coverage in the current workout plan.
+
+    Returns:
+        Dictionary containing:
+        - per_routine: Dict mapping routine names to pattern coverage stats
+        - total: Aggregated pattern coverage across all routines
+        - warnings: List of actionable warnings about missing or imbalanced patterns
+        - sets_per_routine: Total sets per routine with min/max warnings
+    """
+    try:
+        with DatabaseHandler() as db:
+            rows = db.fetch_all(_PATTERN_COVERAGE_QUERY)
+    except Exception as e:
+        logger.exception("Error calculating pattern coverage: %s", e)
+        return {"per_routine": {}, "total": {}, "warnings": [], "sets_per_routine": {}}
+
+    per_routine, total_patterns, sets_per_routine = _tally_patterns(rows)
+    warnings = _build_pattern_warnings(total_patterns, sets_per_routine)
+
     return {
         "per_routine": dict(per_routine),
         "total": dict(total_patterns),


### PR DESCRIPTION
## WP2.3 — Weekly-summary decomposition with durable golden fixtures

Deep Refactor Plan v3, Phase 2. `utils/weekly_summary.py` is a **protected calculation zone** (CLAUDE.md §1 refactor invariant). This lands the golden fixtures **first**, then does a behavior-preserving in-module helper extraction — the two-phase order the plan mandates.

### Scope
- **Phase A (commit `63941a8`)** — durable, checked-in golden fixtures. `tests/test_weekly_summary_golden.py` seeds deterministic, hermetic scenarios and canonicalizes the load-bearing public calcs into `tests/goldens/weekly_summary_golden.json`. Regenerate intentionally with `GENERATE_GOLDEN=1`.
- **Phase B (commit `950283f`)** — behavior-preserving extraction of private helpers **within** `utils/weekly_summary.py` (NOT a package split), modeled on `utils/session_summary.py`.

### Golden-equality proof (zero calc drift)
The Phase A golden was generated from **pre-extraction** behavior and committed. After the Phase B extraction it passes **unchanged**, proving the refactor is output-identical. It pins, per scenario:
- Effective-vs-Raw side-by-side shape across the full `counting_mode` × `contribution_mode` matrix.
- Muscle contribution weighting (primary 1.0 / secondary 0.5 / tertiary 0.25).
- Frequency `>= 1.0` threshold **above and below**, accumulated per-routine across multiple exercises before the test.
- DIRECT_ONLY is **per-contribution**, not per-muscle (a muscle secondary in one exercise, primary in another).
- Pattern coverage: every `_infer_pattern` fallback branch, and the global warning verdicts (push-dominant / pull-dominant / balanced / isolation-skew / strict 15/24 volume boundaries), each in its own reseeded DB state.

### OD4 deferred — null-routine behavior preserved
The schema is `routine TEXT NOT NULL`, so the reachable falsy-routine case is the empty string `''` (what `if routine:` / pattern coverage's `.get('routine', 'Unknown')` branch on). **Current behavior is locked, not changed:** a muscle sourced only from a falsy routine contributes volume but drops out of frequency and `global_sessions`. **No "Unassigned" bucket is introduced** — that is WPB.4 (OD4), which is now unblocked by these goldens but requires its own product-risk review. The golden's `Calves` case (weekly_sets 5.1, frequency 0) is the explicit lock.

### Invariant / shape preservation
- Public surface unchanged: `EFFECTIVE_STATUS_MAP`, `calculate_weekly_summary`, `calculate_exercise_categories`, `calculate_isolated_muscles_stats`, `calculate_pattern_coverage` — same signatures, response shapes, and `/api/pattern_coverage` output.
- Mechanical move only: no reordering of aggregation, no cleanup-while-here, no consolidation with `session_summary.py` (intentionally independent — CLAUDE.md §5; it still imports only `EFFECTIVE_STATUS_MAP`). `row.get('routine', 'Unknown')` kept verbatim.
- No DB schema or API response-shape change.

### Product-risk review
Ran the `product-risk-reviewer` (mandated for this protected-calc WP) on Plan v1 → **APPROVE-WITH-CHANGES**. All MUST-FIX (M1–M5) and SHOULD-FIX (S1–S3) golden-coverage gaps were folded into the seed before writing any extraction code (null-routine `None`/`''` pattern bucket, muscle sourced only from a null routine, multi-branch `_infer_pattern`, reseeded push/pull/balanced/skew states, frequency accumulation across the threshold, ≥2 volume-warning routines, exact 15/24 boundaries, DIRECT_ONLY per-contribution).

### Migration note
No behavior change and no migration required — this is a pure internal refactor of a protected calc zone, guarded by a new golden-equality test. Effective sets remain informational only.

### Verification
- **pytest: 1711 passed** (1710 baseline + the new golden test), 0 failures.
- Golden equality test green after Phase B (the drift guard).
- flake8 blocking set (`E9,F63,F7,F82,F811,E711,E712,F401`): **0**.
- pyright `@1.1.410` baseline diff: **PASS — 0 net-new** (current 175 ≤ baseline 186; no baseline edit).
- E2E (Chromium): `summary-pages.spec.ts` **20/20**, `api-integration.spec.ts` **57/57**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)