### PR TITLE
refactor(db): centralize schema initialization

### DIFF
--- a/app.py
+++ b/app.py
@@ -1,28 +1,20 @@
 
 from flask import Flask, jsonify, request, make_response, g
-from utils.db_initializer import initialize_database
-from utils.database import (
-    DatabaseHandler,
-    add_body_composition_snapshots_table,
-    add_fatigue_context_settings_table,
-    add_progression_goals_table,
-    add_strength_calibration_tables,
-    add_user_profile_tables,
-    add_volume_tracking_tables,
-)
+from utils.database import DatabaseHandler
 from utils.auto_backup import create_startup_backup, describe_snapshot
+from utils.schema_registry import drop_all_owned_tables, run_all_initializers
 from routes.workout_log import workout_log_bp
 from routes.weekly_summary import weekly_summary_bp
 from routes.session_summary import session_summary_bp
 from routes.exports import exports_bp
 from routes.filters import filters_bp
-from routes.workout_plan import workout_plan_bp, initialize_exercise_order
+from routes.workout_plan import workout_plan_bp
 from routes.main import main_bp
 from routes.progression_plan import progression_plan_bp
 from routes.user_profile import user_profile_bp
 from routes.body_composition import body_composition_bp
 from routes.volume_splitter import volume_splitter_bp
-from routes.program_backup import program_backup_bp, init_backup_tables
+from routes.program_backup import program_backup_bp
 from routes.fatigue import fatigue_bp
 from datetime import datetime
 from werkzeug.middleware.proxy_fix import ProxyFix
@@ -57,25 +49,7 @@ add_request_id_middleware(app)
 register_error_handlers(app)
 
 # Initialize the database
-logger.info("Initializing database...")
-initialize_database()
-logger.info("Adding progression goals table...")
-add_progression_goals_table()
-logger.info("Adding volume tracking tables...")
-add_volume_tracking_tables()
-logger.info("Adding user profile tables...")
-add_user_profile_tables()
-logger.info("Adding body composition snapshots table...")
-add_body_composition_snapshots_table()
-logger.info("Adding strength calibration tables...")
-add_strength_calibration_tables()
-logger.info("Adding fatigue context settings table...")
-add_fatigue_context_settings_table()
-logger.info("Initializing exercise order...")
-initialize_exercise_order()
-logger.info("Initializing backup tables...")
-init_backup_tables()
-logger.info("Database initialization complete")
+run_all_initializers(force_base=False)
 
 # Snapshot the live DB to data/auto_backup/ so a wipe or corruption has a recovery point.
 create_startup_backup()
@@ -176,48 +150,11 @@ def erase_data():
         snapshot_path = create_startup_backup()
         # Drop ALL tables including backup tables (full reset)
         with DatabaseHandler() as db:
-            tables = [
-                'program_backup_items',  # Drop child table first (FK constraint)
-                'program_backups',        # Then parent backup table
-                'ignored_calibration_transfers',
-                'exercise_transfer_ratios',
-                'learned_strength_calibrations',
-                'user_calibration_settings',
-                'fatigue_context_settings',
-                'user_profile_preferences',
-                'user_profile_lifts',
-                'user_profile',
-                'body_composition_snapshots',
-                'user_selection',
-                'progression_goals',
-                'muscle_volumes',
-                'volume_plans',
-                'workout_log'
-            ]
-
-            for table in tables:
-                db.execute_query(f"DROP TABLE IF EXISTS {table}")
+            drop_all_owned_tables(db)
 
         # Reinitialize database - force=True to bypass the initialization guard
         # since we just dropped the tables
-        logger.info("Reinitializing database...")
-        initialize_database(force=True)
-        logger.info("Adding progression goals table...")
-        add_progression_goals_table()
-        logger.info("Adding volume tracking tables...")
-        add_volume_tracking_tables()
-        logger.info("Adding user profile tables...")
-        add_user_profile_tables()
-        logger.info("Adding body composition snapshots table...")
-        add_body_composition_snapshots_table()
-        logger.info("Adding strength calibration tables...")
-        add_strength_calibration_tables()
-        logger.info("Adding fatigue context settings table...")
-        add_fatigue_context_settings_table()
-        logger.info("Initializing exercise order...")
-        initialize_exercise_order()
-        logger.info("Reinitializing backup tables...")
-        init_backup_tables()
+        run_all_initializers(force_base=True)
         
         from utils.errors import success_response
 

--- a/e2e/scripts/prepare_visual_db.py
+++ b/e2e/scripts/prepare_visual_db.py
@@ -75,29 +75,13 @@ def apply_migrations(database_path: Path) -> None:
     import utils.config
     utils.config.DB_FILE = str(database_path)
 
-    from utils.db_initializer import initialize_database
-    from utils.database import (
-        add_body_composition_snapshots_table,
-        add_progression_goals_table,
-        add_strength_calibration_tables,
-        add_user_profile_tables,
-        add_volume_tracking_tables,
-    )
-    from routes.program_backup import init_backup_tables
-    from routes.workout_plan import initialize_exercise_order
+    from utils.schema_registry import run_all_initializers
 
     # Mirror app.py's startup table-creation sequence exactly so a visual seed is
-    # schema-identical to a freshly booted app — including the learned-calibration
-    # tables the Profile page reads on every render (a missing table 500s the page
-    # and would freeze a broken render into a baseline).
-    initialize_database()
-    add_progression_goals_table()
-    add_volume_tracking_tables()
-    add_user_profile_tables()
-    add_body_composition_snapshots_table()
-    add_strength_calibration_tables()
-    initialize_exercise_order()
-    init_backup_tables()
+    # schema-identical to a freshly booted app — including learned-calibration and
+    # fatigue-context settings tables the Profile page reads on every render (a
+    # missing table 500s the page and would freeze a broken render into a baseline).
+    run_all_initializers(force_base=False)
 
 
 def main() -> None:

--- a/e2e/scripts/seed_summary_regression_db.py
+++ b/e2e/scripts/seed_summary_regression_db.py
@@ -25,10 +25,10 @@ def main() -> None:
     # Ensure runtime config points to the requested DB before importing DB users.
     config.DB_FILE = db_file
 
-    from utils.db_initializer import initialize_database
     from utils.database import DatabaseHandler
+    from utils.schema_registry import run_all_initializers
 
-    initialize_database(force=True)
+    run_all_initializers(force_base=True)
 
     with DatabaseHandler() as db:
         # Start from clean state for deterministic assertions.

--- a/routes/workout_plan.py
+++ b/routes/workout_plan.py
@@ -13,6 +13,7 @@ from utils import supersets as superset_service
 from utils.logger import get_logger
 from utils.filter_values import fetch_filter_values
 from utils.plan_generator import GENERATOR_ROUTINE_PROGRAMS, generate_starter_plan
+from utils import schema_registry
 from utils.volume_progress import get_volume_progress
 from utils.workout_validation import UNSET, validate_workout_bounds
 
@@ -30,6 +31,12 @@ _apply_superset_link = superset_service._apply_superset_link
 _group_exercises_by_routine = superset_service._group_exercises_by_routine
 _find_antagonist_pairings = superset_service._find_antagonist_pairings
 unlink_partner_for_removal = superset_service.unlink_partner_for_removal
+
+# Temporary compatibility re-exports for callers that still import the schema
+# helpers from this route module.
+column_exists = schema_registry.column_exists
+table_exists = schema_registry.table_exists
+initialize_exercise_order = schema_registry.initialize_exercise_order
 
 def fetch_unique_values(column):
     """Backward-compatible route-level alias for the extracted contract."""
@@ -447,76 +454,6 @@ def update_exercise():
             extra={'exercise_id': exercise_id if exercise_id else 'unknown'}
         )
         return error_response("INTERNAL_ERROR", "Failed to update exercise", 500)
-
-def column_exists(db, table_name, column_name):
-    """Check if a column exists in a table using PRAGMA."""
-    query = f"PRAGMA table_info({table_name})"
-    columns = db.fetch_all(query)
-    return any(col['name'] == column_name for col in columns)
-
-def table_exists(db, table_name):
-    """Check if a table exists in the database."""
-    result = db.fetch_one(
-        "SELECT name FROM sqlite_master WHERE type='table' AND name=?",
-        (table_name,)
-    )
-    return result is not None
-
-def initialize_exercise_order():
-    """Initialize or update the order column in user_selection table."""
-    try:
-        with DatabaseHandler() as db:
-            # First check if the table exists
-            if not table_exists(db, 'user_selection'):
-                logger.debug("user_selection table does not exist yet, skipping exercise order initialization")
-                return True
-            
-            # Check if column exists using PRAGMA
-            if column_exists(db, 'user_selection', 'exercise_order'):
-                logger.debug("Exercise order column already exists")
-                # Check for any NULL exercise_order values and initialize them
-                null_count = db.fetch_one(
-                    "SELECT COUNT(*) as count FROM user_selection WHERE exercise_order IS NULL"
-                )
-                if null_count and null_count.get('count', 0) > 0:
-                    logger.info(f"Found {null_count['count']} rows with NULL exercise_order, initializing...")
-                    # Get max existing order
-                    max_order = db.fetch_one(
-                        "SELECT COALESCE(MAX(exercise_order), 0) as max_order FROM user_selection"
-                    )
-                    current_order = (max_order.get('max_order', 0) or 0) if max_order else 0
-                    
-                    # Get rows with NULL order, sorted by id (oldest first)
-                    null_rows = db.fetch_all(
-                        "SELECT id FROM user_selection WHERE exercise_order IS NULL ORDER BY id"
-                    )
-                    for row in null_rows:
-                        current_order += 1
-                        db.execute_query(
-                            "UPDATE user_selection SET exercise_order = ? WHERE id = ?",
-                            (current_order, row['id'])
-                        )
-                    logger.info(f"Initialized exercise_order for {len(null_rows)} rows")
-            else:
-                logger.info("Adding exercise_order column")
-                # Add the column
-                db.execute_query("ALTER TABLE user_selection ADD COLUMN exercise_order INTEGER")
-                
-                # Initialize with sequential order
-                db.execute_query("""
-                    UPDATE user_selection 
-                    SET exercise_order = (
-                        SELECT ROW_NUMBER() OVER (ORDER BY routine, exercise) 
-                        FROM user_selection AS t2 
-                        WHERE t2.id = user_selection.id
-                    )
-                """)
-                logger.info("Exercise order column initialized")
-                
-        return True
-    except Exception as e:
-        logger.exception("Error initializing exercise order")
-        return False
 
 @workout_plan_bp.route("/update_exercise_order", methods=["POST"])
 def update_exercise_order():

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -6,17 +6,8 @@ import os
 import shutil
 from pathlib import Path
 from flask import Flask, jsonify
-from utils.database import (
-    DatabaseHandler,
-    add_body_composition_snapshots_table,
-    add_fatigue_context_settings_table,
-    add_progression_goals_table,
-    add_strength_calibration_tables,
-    add_user_profile_tables,
-    add_volume_tracking_tables,
-)
-from utils.db_initializer import initialize_database
-from routes.workout_plan import workout_plan_bp, initialize_exercise_order
+from utils.database import DatabaseHandler
+from routes.workout_plan import workout_plan_bp
 from routes.filters import filters_bp
 from routes.workout_log import workout_log_bp
 from routes.weekly_summary import weekly_summary_bp
@@ -29,7 +20,7 @@ from routes.body_composition import body_composition_bp
 from routes.volume_splitter import volume_splitter_bp
 from routes.program_backup import program_backup_bp
 from routes.fatigue import fatigue_bp
-from utils.program_backup import initialize_backup_tables
+from utils.schema_registry import drop_all_owned_tables, run_all_initializers
 from utils.errors import success_response, error_response
 import utils.config
 
@@ -41,15 +32,7 @@ TEST_DB_FILENAME = "test_hypertrophy_toolbox.db"
 
 def _initialize_test_database() -> None:
     """Create the full test schema for the active database path."""
-    initialize_database(force=True)
-    add_progression_goals_table()
-    add_volume_tracking_tables()
-    add_user_profile_tables()
-    add_body_composition_snapshots_table()
-    add_strength_calibration_tables()
-    add_fatigue_context_settings_table()
-    initialize_exercise_order()
-    initialize_backup_tables()
+    run_all_initializers(force_base=True)
 
 
 def _cleanup_database_files(database_path: str) -> None:
@@ -124,26 +107,7 @@ def app(test_db_path):
         try:
             # Drop ALL tables including backup tables (full reset)
             with DatabaseHandler() as db:
-                tables = [
-                    'program_backup_items',  # Drop child table first (FK constraint)
-                    'program_backups',        # Then parent backup table
-                    'ignored_calibration_transfers',
-                    'exercise_transfer_ratios',
-                    'learned_strength_calibrations',
-                    'user_calibration_settings',
-                    'fatigue_context_settings',
-                    'user_profile_preferences',
-                    'user_profile_lifts',
-                    'user_profile',
-                    'body_composition_snapshots',
-                    'user_selection',
-                    'progression_goals',
-                    'muscle_volumes',
-                    'volume_plans',
-                    'workout_log'
-                ]
-                for table in tables:
-                    db.execute_query(f"DROP TABLE IF EXISTS {table}")
+                drop_all_owned_tables(db)
 
             _initialize_test_database()
 

--- a/tests/test_maintenance.py
+++ b/tests/test_maintenance.py
@@ -201,7 +201,11 @@ class TestNormalizeAndRebuildEim:
         
         # Check that CREATE TABLE was called
         create_call = mock_db.execute_query.call_args
-        assert "CREATE TABLE IF NOT EXISTS exercise_isolated_muscles" in create_call[0][0]
+        create_sql = create_call[0][0]
+        assert "CREATE TABLE IF NOT EXISTS exercise_isolated_muscles" in create_sql
+        assert "PRIMARY KEY (exercise_name, muscle)" in create_sql
+        assert "REFERENCES exercises(exercise_name) ON DELETE CASCADE" in create_sql
+        assert "id INTEGER PRIMARY KEY AUTOINCREMENT" not in create_sql
 
     @patch('utils.maintenance._normalize_existing_rows')
     @patch('utils.maintenance._exec_many')

--- a/tests/test_schema_registry.py
+++ b/tests/test_schema_registry.py
@@ -1,0 +1,138 @@
+"""Contracts for the canonical schema initializer and owned-table registry."""
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+import pytest
+
+from routes import workout_plan
+from utils import schema_registry
+
+
+def test_run_all_initializers_preserves_startup_order(monkeypatch):
+    calls = []
+
+    def record_base(*, force):
+        calls.append(("initialize_database", force))
+
+    monkeypatch.setattr(schema_registry, "initialize_database", record_base)
+    for name in (
+        "add_progression_goals_table",
+        "add_volume_tracking_tables",
+        "add_user_profile_tables",
+        "add_body_composition_snapshots_table",
+        "add_strength_calibration_tables",
+        "add_fatigue_context_settings_table",
+        "initialize_exercise_order",
+        "initialize_backup_tables",
+    ):
+        monkeypatch.setattr(
+            schema_registry,
+            name,
+            lambda name=name: calls.append((name, None)),
+        )
+
+    schema_registry.run_all_initializers(force_base=True)
+
+    assert calls == [
+        ("initialize_database", True),
+        ("add_progression_goals_table", None),
+        ("add_volume_tracking_tables", None),
+        ("add_user_profile_tables", None),
+        ("add_body_composition_snapshots_table", None),
+        ("add_strength_calibration_tables", None),
+        ("add_fatigue_context_settings_table", None),
+        ("initialize_exercise_order", None),
+        ("initialize_backup_tables", None),
+    ]
+
+
+def test_run_all_initializers_defaults_to_non_forced_base(monkeypatch):
+    force_values = []
+    monkeypatch.setattr(
+        schema_registry,
+        "initialize_database",
+        lambda *, force: force_values.append(force),
+    )
+    for name in (
+        "add_progression_goals_table",
+        "add_volume_tracking_tables",
+        "add_user_profile_tables",
+        "add_body_composition_snapshots_table",
+        "add_strength_calibration_tables",
+        "add_fatigue_context_settings_table",
+        "initialize_exercise_order",
+        "initialize_backup_tables",
+    ):
+        monkeypatch.setattr(schema_registry, name, lambda: None)
+
+    schema_registry.run_all_initializers()
+
+    assert force_values == [False]
+
+
+def test_run_all_initializers_propagates_backup_table_failure(monkeypatch):
+    for name in (
+        "initialize_database",
+        "add_progression_goals_table",
+        "add_volume_tracking_tables",
+        "add_user_profile_tables",
+        "add_body_composition_snapshots_table",
+        "add_strength_calibration_tables",
+        "add_fatigue_context_settings_table",
+        "initialize_exercise_order",
+    ):
+        if name == "initialize_database":
+            monkeypatch.setattr(schema_registry, name, lambda *, force: None)
+        else:
+            monkeypatch.setattr(schema_registry, name, lambda: None)
+
+    def fail_backup_initialization():
+        raise RuntimeError("backup DDL failed")
+
+    monkeypatch.setattr(
+        schema_registry,
+        "initialize_backup_tables",
+        fail_backup_initialization,
+    )
+
+    with pytest.raises(RuntimeError, match="backup DDL failed"):
+        schema_registry.run_all_initializers()
+
+
+def test_drop_all_owned_tables_uses_fk_safe_registry_order():
+    db = MagicMock()
+    expected_order = (
+        "program_backup_items",
+        "program_backups",
+        "ignored_calibration_transfers",
+        "exercise_transfer_ratios",
+        "learned_strength_calibrations",
+        "user_calibration_settings",
+        "fatigue_context_settings",
+        "user_profile_preferences",
+        "user_profile_lifts",
+        "user_profile",
+        "body_composition_snapshots",
+        "user_selection",
+        "progression_goals",
+        "muscle_volumes",
+        "volume_plans",
+        "workout_log",
+    )
+
+    schema_registry.drop_all_owned_tables(db)
+
+    assert schema_registry.OWNED_TABLES_DROP_ORDER == expected_order
+    assert [call.args[0] for call in db.execute_query.call_args_list] == [
+        f"DROP TABLE IF EXISTS {table}"
+        for table in expected_order
+    ]
+    assert "exercises" not in expected_order
+    assert "exercise_isolated_muscles" not in expected_order
+
+
+def test_workout_plan_keeps_schema_helper_reexports():
+    assert workout_plan.column_exists is schema_registry.column_exists
+    assert workout_plan.table_exists is schema_registry.table_exists
+    assert workout_plan.initialize_exercise_order is schema_registry.initialize_exercise_order

--- a/utils/database.py
+++ b/utils/database.py
@@ -530,29 +530,23 @@ class DatabaseHandler:
             return tuple(params)
         return (params,)
 
-    # -- Convenience DDL helpers --------------------------------------------
-    def add_progression_goals_table(self) -> None:
-        """Ensure the progression_goals table exists."""
-        ddl = """
-            CREATE TABLE IF NOT EXISTS progression_goals (
-                id INTEGER PRIMARY KEY AUTOINCREMENT,
-                exercise TEXT NOT NULL,
-                goal_type TEXT NOT NULL,
-                current_value REAL,
-                target_value REAL,
-                goal_date DATE NOT NULL,
-                created_at DATETIME NOT NULL,
-                completed BOOLEAN DEFAULT 0,
-                completed_at DATETIME
-            )
-        """
-        self.execute_query(ddl)
-
-
 def add_progression_goals_table() -> None:
     """Module-level helper to create the progression goals table."""
+    ddl = """
+        CREATE TABLE IF NOT EXISTS progression_goals (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            exercise TEXT NOT NULL,
+            goal_type TEXT NOT NULL,
+            current_value REAL,
+            target_value REAL,
+            goal_date DATE NOT NULL,
+            created_at DATETIME NOT NULL,
+            completed BOOLEAN DEFAULT 0,
+            completed_at DATETIME
+        )
+    """
     with DatabaseHandler() as db:
-        db.add_progression_goals_table()
+        db.execute_query(ddl)
 
 
 def add_volume_tracking_tables() -> None:

--- a/utils/db_initializer.py
+++ b/utils/db_initializer.py
@@ -10,6 +10,15 @@ from utils.normalization import normalize_equipment, normalize_muscle
 
 logger = get_logger()
 
+EXERCISE_ISOLATED_MUSCLES_DDL = """
+        CREATE TABLE IF NOT EXISTS exercise_isolated_muscles (
+            exercise_name TEXT NOT NULL,
+            muscle TEXT NOT NULL,
+            PRIMARY KEY (exercise_name, muscle),
+            FOREIGN KEY (exercise_name) REFERENCES exercises(exercise_name) ON DELETE CASCADE
+        )
+        """
+
 # Guard against double initialization during Flask auto-reload
 _INITIALIZATION_LOCK = threading.Lock()
 _INITIALIZATION_COMPLETE = False
@@ -138,16 +147,7 @@ def _initialize_isolated_muscles_table(db: DatabaseHandler) -> None:
         if columns != expected_columns or not fk_valid:
             db.execute_query("DROP TABLE IF EXISTS exercise_isolated_muscles")
 
-    db.execute_query(
-        """
-        CREATE TABLE IF NOT EXISTS exercise_isolated_muscles (
-            exercise_name TEXT NOT NULL,
-            muscle TEXT NOT NULL,
-            PRIMARY KEY (exercise_name, muscle),
-            FOREIGN KEY (exercise_name) REFERENCES exercises(exercise_name) ON DELETE CASCADE
-        )
-        """
-    )
+    db.execute_query(EXERCISE_ISOLATED_MUSCLES_DDL)
     db.execute_query(
         """
         CREATE INDEX IF NOT EXISTS idx_eim_muscle

--- a/utils/maintenance.py
+++ b/utils/maintenance.py
@@ -7,10 +7,12 @@ from typing import Iterable, List, Optional, Tuple
 
 try:  # Prefer package-relative imports when available
     from utils.database import DatabaseHandler
+    from utils.db_initializer import EXERCISE_ISOLATED_MUSCLES_DDL
     from utils.logger import get_logger
     from utils.normalization import normalize_advanced_muscles
 except ImportError:  # pragma: no cover - fallback for direct invocation
     from database import DatabaseHandler  # type: ignore
+    from db_initializer import EXERCISE_ISOLATED_MUSCLES_DDL  # type: ignore
     from logger import get_logger  # type: ignore
     from normalization import normalize_advanced_muscles  # type: ignore
 
@@ -107,15 +109,7 @@ def normalize_and_rebuild_eim() -> None:
     with DatabaseHandler() as db:
         _exec_many(db, NORMALIZE_SQL)
         _normalize_existing_rows(db)
-        db.execute_query(
-            """
-            CREATE TABLE IF NOT EXISTS exercise_isolated_muscles (
-              id INTEGER PRIMARY KEY AUTOINCREMENT,
-              exercise_name TEXT NOT NULL,
-              muscle TEXT NOT NULL
-            );
-            """
-        )
+        db.execute_query(EXERCISE_ISOLATED_MUSCLES_DDL)
         _exec_many(db, REBUILD_EIM_SQL)
 
 

--- a/utils/schema_registry.py
+++ b/utils/schema_registry.py
@@ -1,0 +1,140 @@
+"""Canonical database schema initialization and owned-table registry."""
+from __future__ import annotations
+
+from utils.database import (
+    DatabaseHandler,
+    add_body_composition_snapshots_table,
+    add_fatigue_context_settings_table,
+    add_progression_goals_table,
+    add_strength_calibration_tables,
+    add_user_profile_tables,
+    add_volume_tracking_tables,
+)
+from utils.db_initializer import initialize_database
+from utils.logger import get_logger
+from utils.program_backup import initialize_backup_tables
+
+
+logger = get_logger()
+
+
+OWNED_TABLES_DROP_ORDER = (
+    'program_backup_items',  # Drop child table first (FK constraint)
+    'program_backups',        # Then parent backup table
+    'ignored_calibration_transfers',
+    'exercise_transfer_ratios',
+    'learned_strength_calibrations',
+    'user_calibration_settings',
+    'fatigue_context_settings',
+    'user_profile_preferences',
+    'user_profile_lifts',
+    'user_profile',
+    'body_composition_snapshots',
+    'user_selection',
+    'progression_goals',
+    'muscle_volumes',
+    'volume_plans',
+    'workout_log',
+)
+
+
+def column_exists(db, table_name, column_name):
+    """Check if a column exists in a table using PRAGMA."""
+    query = f"PRAGMA table_info({table_name})"
+    columns = db.fetch_all(query)
+    return any(col['name'] == column_name for col in columns)
+
+
+def table_exists(db, table_name):
+    """Check if a table exists in the database."""
+    result = db.fetch_one(
+        "SELECT name FROM sqlite_master WHERE type='table' AND name=?",
+        (table_name,)
+    )
+    return result is not None
+
+
+def initialize_exercise_order():
+    """Initialize or update the order column in user_selection table."""
+    try:
+        with DatabaseHandler() as db:
+            # First check if the table exists
+            if not table_exists(db, 'user_selection'):
+                logger.debug("user_selection table does not exist yet, skipping exercise order initialization")
+                return True
+
+            # Check if column exists using PRAGMA
+            if column_exists(db, 'user_selection', 'exercise_order'):
+                logger.debug("Exercise order column already exists")
+                # Check for any NULL exercise_order values and initialize them
+                null_count = db.fetch_one(
+                    "SELECT COUNT(*) as count FROM user_selection WHERE exercise_order IS NULL"
+                )
+                if null_count and null_count.get('count', 0) > 0:
+                    logger.info(f"Found {null_count['count']} rows with NULL exercise_order, initializing...")
+                    # Get max existing order
+                    max_order = db.fetch_one(
+                        "SELECT COALESCE(MAX(exercise_order), 0) as max_order FROM user_selection"
+                    )
+                    current_order = (max_order.get('max_order', 0) or 0) if max_order else 0
+
+                    # Get rows with NULL order, sorted by id (oldest first)
+                    null_rows = db.fetch_all(
+                        "SELECT id FROM user_selection WHERE exercise_order IS NULL ORDER BY id"
+                    )
+                    for row in null_rows:
+                        current_order += 1
+                        db.execute_query(
+                            "UPDATE user_selection SET exercise_order = ? WHERE id = ?",
+                            (current_order, row['id'])
+                        )
+                    logger.info(f"Initialized exercise_order for {len(null_rows)} rows")
+            else:
+                logger.info("Adding exercise_order column")
+                # Add the column
+                db.execute_query("ALTER TABLE user_selection ADD COLUMN exercise_order INTEGER")
+
+                # Initialize with sequential order
+                db.execute_query("""
+                    UPDATE user_selection
+                    SET exercise_order = (
+                        SELECT ROW_NUMBER() OVER (ORDER BY routine, exercise)
+                        FROM user_selection AS t2
+                        WHERE t2.id = user_selection.id
+                    )
+                """)
+                logger.info("Exercise order column initialized")
+
+        return True
+    except Exception as e:
+        logger.exception("Error initializing exercise order")
+        return False
+
+
+def run_all_initializers(*, force_base: bool = False) -> None:
+    """Run every schema initializer in the canonical startup order."""
+    logger.info("Initializing database...")
+    initialize_database(force=force_base)
+    logger.info("Adding progression goals table...")
+    add_progression_goals_table()
+    logger.info("Adding volume tracking tables...")
+    add_volume_tracking_tables()
+    logger.info("Adding user profile tables...")
+    add_user_profile_tables()
+    logger.info("Adding body composition snapshots table...")
+    add_body_composition_snapshots_table()
+    logger.info("Adding strength calibration tables...")
+    add_strength_calibration_tables()
+    logger.info("Adding fatigue context settings table...")
+    add_fatigue_context_settings_table()
+    logger.info("Initializing exercise order...")
+    initialize_exercise_order()
+    logger.info("Initializing backup tables...")
+    initialize_backup_tables()
+    logger.info("Database initialization complete")
+
+
+def drop_all_owned_tables(db: DatabaseHandler) -> None:
+    """Drop application-owned user-state tables in FK-safe order."""
+    for table in OWNED_TABLES_DROP_ORDER:
+        db.execute_query(f"DROP TABLE IF EXISTS {table}")


### PR DESCRIPTION
## Scope

- add `utils/schema_registry.py` as the route-free owner of canonical startup initialization and application-owned table drop order
- rewire production startup, erase/reinitialize, pytest setup, visual/functional E2E prep, and the summary regression seed to the registry
- retain temporary `routes.workout_plan` re-exports for `column_exists`, `table_exists`, and `initialize_exercise_order`
- inline the duplicate progression-goals DDL into the module helper and remove its uncalled `DatabaseHandler` method
- reuse the canonical composite-PK/FK/CASCADE isolated-muscle DDL from maintenance

## Migration / contract notes

This is a pure initialization-wiring consolidation. Production/test initializer order is preserved exactly: base schema, all six `add_*` helpers, exercise-order migration, then backup tables. `create_startup_backup()` remains outside the registry and before erase drops. Catalog tables (`exercises`, `exercise_isolated_muscles`) remain excluded from erase.

No calculation logic, persisted schema shape, API URL, or response envelope changes. The intentional parity fix adds the already-canonical `fatigue_context_settings` table to the shared E2E seed migration path. The registry calls `utils.program_backup.initialize_backup_tables()` directly, so backup DDL failure now propagates instead of being swallowed by the route wrapper; this is deliberate fail-loud startup behavior and is regression-tested.

## Verification

- `pytest tests/ -q`: 1717 passed (1712 baseline + 5 registry contracts)
- required Chromium functional inventory: 407 passed
- full non-visual Chromium inventory, including isolated backup/erase/fatigue-context specs: green
- blocking flake8 set: 0
- pyright baseline gate: 0 net-new diagnostics; new registry has 0 diagnostics
- fresh scratch boot + erase/reinitialize: pass
- legacy partial-schema boot/upgrade: pass
- visual and functional E2E seed schema parity (including fatigue context): pass
- isolated backup restore: pass
- tracked `data/database.db` blob unchanged; skip-worktree retained

🤖 Generated with [Claude Code](https://claude.com/claude-code)