### PR TITLE
refactor(welcome/base): extract inline scripts to classic external files (WP3.2d)

### DIFF
--- a/static/js/global-error-handler.js
+++ b/static/js/global-error-handler.js
@@ -1,0 +1,35 @@
+/**
+ * Global Error Handler
+ * Hides the error placeholder on load and logs (only) uncaught errors and
+ * unhandled promise rejections. Loaded as a classic parse-time script on every
+ * page so the window listeners register before the app modules run.
+ */
+(function () {
+    'use strict';
+
+    // Ensure error container is hidden on page load
+    document.addEventListener('DOMContentLoaded', function() {
+        const errorContainer = document.getElementById('error-message-container');
+        if (errorContainer) {
+            errorContainer.classList.add('d-none');
+            errorContainer.classList.remove('show-error');
+            errorContainer.style.display = 'none';
+        }
+    });
+
+    // Global error handler - only log, don't show UI
+    window.addEventListener('error', function(e) {
+        console.error('Global error caught:', {
+            message: e.error?.message || e.message,
+            filename: e.filename,
+            line: e.lineno,
+            column: e.colno,
+            error: e.error
+        });
+    });
+
+    // Handle unhandled promise rejections - only log
+    window.addEventListener('unhandledrejection', function(e) {
+        console.error('Unhandled promise rejection:', e.reason);
+    });
+})();

--- a/static/js/welcome.js
+++ b/static/js/welcome.js
@@ -1,0 +1,54 @@
+/**
+ * Welcome page - Erase All Data flow
+ * Wires the erase-data modal + confirmation to POST /erase-data, shows a
+ * success/error toast, surfaces the auto-backup banner (WPB.8) when present,
+ * then reloads. Classic script at the same template position as the former
+ * inline block; the bootstrap globals and window.showAutoBackupBanner are
+ * available by DOMContentLoaded.
+ */
+(function () {
+    'use strict';
+
+    document.addEventListener('DOMContentLoaded', function() {
+        const eraseDataBtn = document.getElementById('eraseDataBtn');
+        const eraseDataModal = new bootstrap.Modal(document.getElementById('eraseDataModal'));
+        const confirmEraseBtn = document.getElementById('confirmEraseBtn');
+
+        eraseDataBtn.addEventListener('click', function() {
+            eraseDataModal.show();
+        });
+
+        confirmEraseBtn.addEventListener('click', async function() {
+            try {
+                const response = await fetch('/erase-data', {
+                    method: 'POST',
+                    headers: { 'Content-Type': 'application/json' },
+                    body: JSON.stringify({ confirm: 'ERASE_ALL_DATA' })
+                });
+
+                const data = await response.json();
+
+                if (data.ok) {
+                    eraseDataModal.hide();
+                    const toast = new bootstrap.Toast(document.getElementById('successToast'));
+                    document.querySelector('#successToast .toast-body span').textContent = data.message;
+                    toast.show();
+
+                    const autoBackup = data.data && data.data.auto_backup;
+                    if (autoBackup && typeof window.showAutoBackupBanner === 'function') {
+                        window.showAutoBackupBanner(autoBackup);
+                    }
+
+                    setTimeout(() => window.location.reload(), 2000);
+                } else {
+                    throw new Error(data.message);
+                }
+            } catch (error) {
+                eraseDataModal.hide();
+                const toast = new bootstrap.Toast(document.getElementById('errorToast'));
+                document.querySelector('#errorToast .toast-body span').textContent = `Failed to erase data: ${error.message}`;
+                toast.show();
+            }
+        });
+    });
+})();

--- a/templates/base.html
+++ b/templates/base.html
@@ -268,33 +268,7 @@
     <!-- Scripts -->
     <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.1.3/dist/js/bootstrap.bundle.min.js"></script>
     <!-- Global Error Handler -->
-    <script>
-        // Ensure error container is hidden on page load
-        document.addEventListener('DOMContentLoaded', function() {
-            const errorContainer = document.getElementById('error-message-container');
-            if (errorContainer) {
-                errorContainer.classList.add('d-none');
-                errorContainer.classList.remove('show-error');
-                errorContainer.style.display = 'none';
-            }
-        });
-        
-        // Global error handler - only log, don't show UI
-        window.addEventListener('error', function(e) {
-            console.error('Global error caught:', {
-                message: e.error?.message || e.message,
-                filename: e.filename,
-                line: e.lineno,
-                column: e.colno,
-                error: e.error
-            });
-        });
-        
-        // Handle unhandled promise rejections - only log
-        window.addEventListener('unhandledrejection', function(e) {
-            console.error('Unhandled promise rejection:', e.reason);
-        });
-    </script>
+    <script src="{{ url_for('static', filename='js/global-error-handler.js') }}"></script>
     <script type="module" src="{{ url_for('static', filename='js/app.js') }}?v={{ range(1, 1000000) | random }}"></script>
     <script src="{{ url_for('static', filename='js/darkMode.js') }}"></script>
     <script src="{{ url_for('static', filename='js/accessibility.js') }}"></script>

--- a/templates/welcome.html
+++ b/templates/welcome.html
@@ -374,49 +374,6 @@
     </div>
 </div>
 
-<script>
-document.addEventListener('DOMContentLoaded', function() {
-    const eraseDataBtn = document.getElementById('eraseDataBtn');
-    const eraseDataModal = new bootstrap.Modal(document.getElementById('eraseDataModal'));
-    const confirmEraseBtn = document.getElementById('confirmEraseBtn');
-
-    eraseDataBtn.addEventListener('click', function() {
-        eraseDataModal.show();
-    });
-
-    confirmEraseBtn.addEventListener('click', async function() {
-        try {
-            const response = await fetch('/erase-data', {
-                method: 'POST',
-                headers: { 'Content-Type': 'application/json' },
-                body: JSON.stringify({ confirm: 'ERASE_ALL_DATA' })
-            });
-            
-            const data = await response.json();
-            
-            if (data.ok) {
-                eraseDataModal.hide();
-                const toast = new bootstrap.Toast(document.getElementById('successToast'));
-                document.querySelector('#successToast .toast-body span').textContent = data.message;
-                toast.show();
-
-                const autoBackup = data.data && data.data.auto_backup;
-                if (autoBackup && typeof window.showAutoBackupBanner === 'function') {
-                    window.showAutoBackupBanner(autoBackup);
-                }
-
-                setTimeout(() => window.location.reload(), 2000);
-            } else {
-                throw new Error(data.message);
-            }
-        } catch (error) {
-            eraseDataModal.hide();
-            const toast = new bootstrap.Toast(document.getElementById('errorToast'));
-            document.querySelector('#errorToast .toast-body span').textContent = `Failed to erase data: ${error.message}`;
-            toast.show();
-        }
-    });
-});
-</script>
+<script src="{{ url_for('static', filename='js/welcome.js') }}"></script>
 
 {% endblock %}


### PR DESCRIPTION
## WP3.2d — extract the welcome/base inline scripts

Final page of the WP3.2 inline-extraction arc (after #143 weekly-summary, #144 session-summary, #145 workout-plan). Moves the two remaining page-inline `<script>` blocks into external files, wired at the same template positions with the **same script type** (classic → classic), no behavior change (CLAUDE.md §1 refactor invariant).

### Audit — both blocks survive as non-trivial → both extracted

Per `REFACTOR_PLAN §WP3.2a–d` item 4 ("welcome/base only if their blocks remain non-trivial after audit"). Both are non-trivial (26 and 43 lines of real logic), so both are extracted.

| Block | Decision | Script type | Why |
|---|---|---|---|
| `base.html` global error handler (~26 lines, every page) | **Extract** → `static/js/global-error-handler.js` | **Classic external** (NOT module) | The `window` `error`/`unhandledrejection` listeners register at **parse time**; converting to a module would defer registration and change *when* they attach. A classic external script wrapped in an IIFE keeps synchronous parse-time registration, at the same position (after the bootstrap bundle, before `app.js`). |
| `welcome.html` erase-data flow (~43 lines) | **Extract** → `static/js/welcome.js` | **Classic external** | All logic is `DOMContentLoaded`-wrapped, so the `bootstrap.Modal`/`Toast` globals and `window.showAutoBackupBanner` are available at execution regardless. Classic external at the same position (inside the content block, which renders before the bootstrap bundle) is timing-identical to the former inline classic block. |

### Design calls
- **Script type preserved** per the plan's explicit rule — classic stays classic; no `type=module` conversion (unlike 3.2a/b/c) because parse-time global-listener registration and the pre-bootstrap content-block position depend on it.
- **File location**: `static/js/` top-level classic files, mirroring the classic siblings `app.js`/`darkMode.js`/`accessibility.js`. Wrapped in `(function(){ 'use strict'; … })()` IIFEs like `accessibility.js`.
- **No cache-buster** on the new `<script src>` — matches the classic siblings `darkMode.js`/`accessibility.js` (the original inline blocks had none).
- **Raw `fetch('/erase-data')` + `data.ok` envelope kept as-is** — `apiFetch` migration is WP3.5, out of scope. WPB.8 `showAutoBackupBanner` guard preserved exactly.
- **No pure helper fell out** (all DOM/async I/O), so no Vitest DOM tests were forced.

### Scope
Welcome/base inline only. `app.js` / `darkMode.js` / `muscle-selector.js` / `summary.js` untouched. No `ci.yml`/CSS changes — the Vitest job stays `JS Unit (Vitest, non-required)` and **no required CI context is renamed**.

Changed files:
- `static/js/global-error-handler.js` (new, classic)
- `static/js/welcome.js` (new, classic)
- `templates/base.html` (inline block → `<script src>`)
- `templates/welcome.html` (inline block → `<script src>`)

### Gates
- Vitest **57** passed (unchanged)
- pytest **1717** passed
- Chromium E2E **25** passed: `erase-flow` (primary) + `smoke-navigation` + `nav-dropdown` + `dark-mode` — no console errors (the global error handler runs on every page)

🤖 Generated with [Claude Code](https://claude.com/claude-code)