### PR TITLE
WP3.3: characterize workout plan seams and shared state

### DIFF
--- a/static/js/modules/__tests__/workout-plan-seams.test.js
+++ b/static/js/modules/__tests__/workout-plan-seams.test.js
@@ -1,0 +1,226 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+    applyRoutineTabFilter,
+    buildAddExercisePayload,
+    buildExecutionStylePayload,
+    buildExerciseOrderPayload,
+    buildFieldUpdatePayload,
+    buildReplacePayload,
+    buildSupersetLinkPayload,
+    buildSupersetUnlinkPayload,
+    clampToAttrRange,
+    collectMissingAddFields,
+    collectMissingRequiredSelections,
+    compareRoutines,
+    computeNudgedValue,
+    estimateProvenanceLabel,
+    fatigueChipTitle,
+    formatRoutineForDisplay,
+    formatRoutineForTab,
+    learnedBadgeText,
+    nextSupersetColorIndex,
+    parseRoutine,
+    renderExecutionStyleBadge,
+    resolveMin,
+    resolveProfileEstimate,
+    resolveStep,
+    resolveSwapErrorToast,
+    supersetRowClasses,
+    traceHeadline,
+    traceStepValueText,
+} from '../workout-plan-helpers.js';
+
+describe('routine formatting seams', () => {
+    it('parses empty, complete, and missing routine parts', () => {
+        expect(parseRoutine('')).toEqual({ env: '', program: '', workout: '' });
+        expect(parseRoutine(' GYM - PPL - Push ')).toEqual({ env: 'GYM', program: 'PPL', workout: 'Push' });
+        expect(parseRoutine('HOME - Upper')).toEqual({ env: 'HOME', program: 'Upper', workout: '' });
+    });
+
+    it('formats display routines and escapes each part', () => {
+        expect(formatRoutineForDisplay('')).toBe('N/A');
+        expect(formatRoutineForDisplay(' -  - ')).toBe('N/A');
+        expect(formatRoutineForDisplay('<Gym> - A&B - Push')).toBe(
+            '<span class="routine-env">&lt;Gym&gt;</span><span class="routine-program">A&amp;B</span><span class="routine-workout">Push</span>'
+        );
+    });
+
+    it('formats tab routines, including blank parsed parts and escaping', () => {
+        expect(formatRoutineForTab(null)).toBe('N/A');
+        expect(formatRoutineForTab(' -  - ')).toBe(' -  - ');
+        expect(formatRoutineForTab('GYM - <PPL> - Push & Pull')).toContain('&lt;PPL&gt;');
+        expect(formatRoutineForTab('GYM - <PPL> - Push & Pull')).toContain('Push &amp; Pull');
+    });
+
+    it('compares environment, then program, then workout', () => {
+        expect(compareRoutines('HOME - A - A', 'GYM - Z - Z')).toBeGreaterThan(0);
+        expect(compareRoutines('GYM - A - Z', 'GYM - B - A')).toBeLessThan(0);
+        expect(compareRoutines('GYM - A - A', 'GYM - A - B')).toBeLessThan(0);
+        expect(compareRoutines('', null)).toBe(0);
+    });
+
+    it('returns the original list for all and filters an exact routine', () => {
+        const exercises = [{ routine: 'A' }, { routine: 'B' }];
+        expect(applyRoutineTabFilter(exercises, 'all')).toBe(exercises);
+        expect(applyRoutineTabFilter(exercises, 'A')).toEqual([{ routine: 'A' }]);
+    });
+});
+
+describe('execution style seams', () => {
+    it('renders standard, AMRAP, and EMOM badge branches', () => {
+        expect(renderExecutionStyleBadge({})).toContain('execution-badge--standard');
+        expect(renderExecutionStyleBadge({ execution_style: 'amrap', time_cap_seconds: 90 })).toContain('90s');
+        expect(renderExecutionStyleBadge({ execution_style: 'amrap', time_cap_seconds: 0 })).not.toContain('execution-details');
+        expect(renderExecutionStyleBadge({ execution_style: 'emom', emom_interval_seconds: 45, emom_rounds: 8 })).toContain('8×45s');
+        expect(renderExecutionStyleBadge({ execution_style: 'emom', emom_interval_seconds: 45 })).not.toContain('execution-details');
+    });
+
+    it('builds standard, AMRAP, and EMOM payloads with falsy fallbacks', () => {
+        expect(buildExecutionStylePayload(4, 'standard', {})).toEqual({ exercise_id: 4, execution_style: 'standard' });
+        expect(buildExecutionStylePayload(4, 'amrap', { timeCap: 120 })).toEqual({ exercise_id: 4, execution_style: 'amrap', time_cap_seconds: 120 });
+        expect(buildExecutionStylePayload(4, 'amrap', { timeCap: NaN })).toEqual({ exercise_id: 4, execution_style: 'amrap', time_cap_seconds: 60 });
+        expect(buildExecutionStylePayload(4, 'emom', { emomInterval: 30, emomRounds: 10 })).toEqual({ exercise_id: 4, execution_style: 'emom', emom_interval_seconds: 30, emom_rounds: 10 });
+        expect(buildExecutionStylePayload(4, 'emom', { emomInterval: 0, emomRounds: undefined })).toEqual({ exercise_id: 4, execution_style: 'emom', emom_interval_seconds: 60, emom_rounds: 5 });
+    });
+});
+
+describe('payload builders', () => {
+    it('coerces add-exercise fields and applies RIR/RPE empty semantics', () => {
+        const base = { exercise: 'Squat', routine: 'GYM - A - 1', sets: '3', minRepRange: '6', maxRepRange: '10', weight: '82.5' };
+        expect(buildAddExercisePayload({ ...base, rir: '', rpe: '' })).toEqual({
+            exercise: 'Squat', routine: 'GYM - A - 1', sets: 3, min_rep_range: 6,
+            max_rep_range: 10, rir: 0, weight: 82.5, rpe: null,
+        });
+        expect(buildAddExercisePayload({ ...base, rir: '2', rpe: '8.5' })).toMatchObject({ rir: 2, rpe: 8.5 });
+    });
+
+    it('builds field, replacement, superset, and ordering payloads', () => {
+        expect(buildFieldUpdatePayload(7, 'sets', '4')).toEqual({ id: 7, updates: { sets: '4' } });
+        expect(buildReplacePayload(7)).toEqual({ id: 7, strategy: 'ai' });
+        const ids = [7, 9];
+        expect(buildSupersetLinkPayload(ids)).toEqual({ exercise_ids: ids });
+        expect(buildSupersetUnlinkPayload(7)).toEqual({ exercise_id: 7 });
+        expect(buildExerciseOrderPayload([9, 7])).toEqual([{ id: 9, order: 1 }, { id: 7, order: 2 }]);
+        expect(buildExerciseOrderPayload([])).toEqual([]);
+    });
+});
+
+describe('add-exercise validation seams', () => {
+    it('collects required selections in UI order', () => {
+        expect(collectMissingRequiredSelections('', '')).toEqual(['Routine', 'Exercise']);
+        expect(collectMissingRequiredSelections('A', '')).toEqual(['Exercise']);
+        expect(collectMissingRequiredSelections('', 'Squat')).toEqual(['Routine']);
+        expect(collectMissingRequiredSelections('A', 'Squat')).toEqual([]);
+    });
+
+    it('collects detailed missing fields in UI order and preserves truthiness rules', () => {
+        expect(collectMissingAddFields({})).toEqual(['Exercise', 'Routine', 'Sets', 'Min Rep Range', 'Max Rep Range', 'Weight']);
+        expect(collectMissingAddFields({ exercise: 'Squat', routine: 'A', sets: '3', minRepRange: '6', maxRepRange: '10', weight: '0' })).toEqual([]);
+        expect(collectMissingAddFields({ exercise: 'Squat', routine: 'A', sets: '', minRepRange: '6', maxRepRange: '', weight: '20' })).toEqual(['Sets', 'Max Rep Range']);
+    });
+
+    it('clamps against present bounds and treats null/empty attributes as infinite', () => {
+        expect(clampToAttrRange(5, null, '')).toBe(5);
+        expect(clampToAttrRange(-1, '0', '10')).toBe(0);
+        expect(clampToAttrRange(11, '0', '10')).toBe(10);
+        expect(clampToAttrRange(4.5, '0', '10')).toBe(4.5);
+    });
+});
+
+describe('replacement and superset seams', () => {
+    it.each([
+        ['no_candidates', 'warning', 'No alternative found for this muscle/equipment.'],
+        ['duplicate', 'warning', 'All alternatives are already in this routine.'],
+        ['not_found', 'error', 'Exercise not found in workout plan.'],
+        ['missing_metadata', 'warning', 'This exercise is missing muscle/equipment data and cannot be replaced.'],
+        ['unknown', 'error', 'fallback'],
+    ])('maps %s to its toast decision', (reason, severity, message) => {
+        expect(resolveSwapErrorToast(reason, 'fallback')).toEqual({ severity, message });
+    });
+
+    it('cycles superset colors from 0 through 4 and back to 1', () => {
+        expect([0, 1, 2, 3, 4].map(nextSupersetColorIndex)).toEqual([1, 2, 3, 4, 1]);
+    });
+
+    it('adds connector classes only to adjacent first/last rows', () => {
+        expect(supersetRowClasses(2, 0, [3, 4])).toBe('superset-group superset-group-2 superset-first');
+        expect(supersetRowClasses(2, 1, [3, 4])).toBe('superset-group superset-group-2 superset-last');
+        expect(supersetRowClasses(2, 1, [3, 4, 5])).toBe('superset-group superset-group-2');
+        expect(supersetRowClasses(2, 0, [3, 5])).toBe('superset-group superset-group-2');
+        expect(supersetRowClasses(2, 0, [3])).toBe('superset-group superset-group-2');
+    });
+});
+
+describe('estimate rendering data seams', () => {
+    it('resolves profile defaults and lets estimates override them', () => {
+        expect(resolveProfileEstimate(null)).toEqual({ weight: 25, sets: 3, min_rep: 6, max_rep: 8, rir: 3, rpe: 7, source: 'default', is_dumbbell: false });
+        expect(resolveProfileEstimate({ weight: 40, source: 'profile' })).toMatchObject({ weight: 40, sets: 3, source: 'profile' });
+    });
+
+    it('maps estimate provenance and falls back to default', () => {
+        expect(estimateProvenanceLabel('learned')).toBe('learned from your recent logs');
+        expect(estimateProvenanceLabel('related_learned')).toBe('learned from a related exercise');
+        expect(estimateProvenanceLabel('log')).toBe('from your last set');
+        expect(estimateProvenanceLabel('profile')).toBe('from your profile');
+        expect(estimateProvenanceLabel('cold_start')).toBe('from population estimate');
+        expect(estimateProvenanceLabel('unknown')).toBe('default values');
+    });
+
+    it('hides the learned badge for non-learned sources', () => {
+        expect(learnedBadgeText({ source: 'profile' })).toEqual({ isLearned: false });
+    });
+
+    it('describes learned samples for zero, one, and many logs', () => {
+        expect(learnedBadgeText({ source: 'learned', trace: {} })).toEqual({ isLearned: true, confidence: '', label: 'Learned', title: 'Suggested from your scored logs' });
+        expect(learnedBadgeText({ source: 'learned', trace: { confidence: 'high', sample_count: 1 } })).toMatchObject({ label: 'Learned · high confidence', title: 'Suggested from 1 scored log for this exercise' });
+        expect(learnedBadgeText({ source: 'learned', trace: { confidence: 'custom', sample_count: 3 } })).toMatchObject({ label: 'Learned · custom', title: 'Suggested from 3 scored logs for this exercise' });
+    });
+
+    it('describes related learned samples and source fallbacks', () => {
+        expect(learnedBadgeText({ source: 'related_learned', trace: {} })).toMatchObject({ label: 'Related', title: 'Suggested from a related exercise' });
+        expect(learnedBadgeText({ source: 'related_learned', trace: { source_exercise: 'Front Squat', sample_count: 1 } })).toMatchObject({ title: 'Suggested from 1 scored log for Front Squat' });
+        expect(learnedBadgeText({ source: 'related_learned', trace: { source_exercise: 'Front Squat', sample_count: 4 } })).toMatchObject({ title: 'Suggested from 4 scored logs for Front Squat' });
+    });
+
+    it('builds fatigue titles with headline/advisory fallbacks', () => {
+        expect(fatigueChipTitle({ headline: 'High fatigue', advisory: 'Take care.' })).toBe('High fatigue Take care.');
+        expect(fatigueChipTitle({ headline: 'High fatigue' })).toBe('High fatigue');
+        expect(fatigueChipTitle({ advisory: 'Take care.' })).toBe('Fatigue context');
+    });
+
+    it('maps every trace headline and falls back to default', () => {
+        expect(traceHeadline('learned')).toBe('Learned from your recent logs');
+        expect(traceHeadline('related_learned')).toBe('Learned from a related exercise');
+        expect(traceHeadline('log')).toBe('From your last logged set');
+        expect(traceHeadline('profile')).toBe('From your saved reference lift');
+        expect(traceHeadline('cold_start')).toBe('From a population estimate');
+        expect(traceHeadline('unknown')).toBe('Default values');
+    });
+
+    it('formats trace values, units, factors, and empty steps', () => {
+        expect(traceStepValueText({ value: 80, unit: 'kg', factor: 0.9 })).toBe('80 kg × 0.9');
+        expect(traceStepValueText({ value: 0 })).toBe('0');
+        expect(traceStepValueText({ factor: 0 })).toBe('× 0');
+        expect(traceStepValueText({ value: '', factor: null })).toBe('');
+    });
+
+    it('resolves valid steps/minimums and their fallbacks', () => {
+        expect(resolveStep('0.5')).toBe(0.5);
+        expect(resolveStep('any')).toBe(1);
+        expect(resolveStep('0')).toBe(1);
+        expect(resolveStep(null)).toBe(1);
+        expect(resolveMin('0')).toBe(0);
+        expect(resolveMin('-5')).toBe(-5);
+        expect(resolveMin(null)).toBeNull();
+    });
+
+    it('nudges up/down, chooses a base for NaN, clamps, and rounds to two decimals', () => {
+        expect(computeNudgedValue(10, 2, 0, 'up')).toBe(12);
+        expect(computeNudgedValue(10, 2, 0, 'down')).toBe(8);
+        expect(computeNudgedValue(NaN, 2, 5, 'up')).toBe(7);
+        expect(computeNudgedValue(NaN, 2, null, 'down')).toBe(-2);
+        expect(computeNudgedValue(1, 2, 0, 'down')).toBe(0);
+        expect(computeNudgedValue(1.005, 0.111, null, 'up')).toBe(1.12);
+    });
+});

--- a/static/js/modules/__tests__/workout-plan-state.test.js
+++ b/static/js/modules/__tests__/workout-plan-state.test.js
@@ -1,0 +1,23 @@
+import { describe, expect, it } from 'vitest';
+
+import { workoutPlanState } from '../workout-plan-state.js';
+
+describe('workoutPlanState', () => {
+    it('has the characterized initial shape', () => {
+        expect(Object.keys(workoutPlanState)).toEqual([
+            'currentRoutineTabFilter',
+            'allExercisesCache',
+            'selectedExerciseIds',
+            'supersetColorMap',
+        ]);
+        expect(workoutPlanState.currentRoutineTabFilter).toBe('all');
+        expect(workoutPlanState.allExercisesCache).toEqual([]);
+        expect(workoutPlanState.selectedExerciseIds).toBeInstanceOf(Set);
+        expect(workoutPlanState.supersetColorMap).toBeInstanceOf(Map);
+    });
+
+    it('is the same singleton across imports', async () => {
+        const secondImport = await import('../workout-plan-state.js');
+        expect(secondImport.workoutPlanState).toBe(workoutPlanState);
+    });
+});

--- a/static/js/modules/workout-plan-helpers.js
+++ b/static/js/modules/workout-plan-helpers.js
@@ -1,3 +1,5 @@
+import { escapeHtml } from './exercise-helpers.js';
+
 // Pure helpers for the workout plan page.
 //
 // Extracted verbatim from the page-local inline script in
@@ -7,6 +9,8 @@
 // equipment list. DOM-free and side-effect-free so they can be unit-tested under
 // the node-environment Vitest runner. The DOM wrappers in workout-plan-page.js
 // call these and keep their branching byte-identical to the original inline code.
+// WP3.3 extends this module with characterized seams from workout-plan.js ahead
+// of the later feature split; all helpers remain DOM-free and side-effect-free.
 
 // Temperature colour class for the volume-scale value display.
 export function volumeColorClass(value) {
@@ -56,4 +60,245 @@ export function equipmentForEnvironment(environment) {
     const homeEquipment = ['Dumbbells', 'Bodyweight', 'Band', 'Kettlebells', 'Trx', 'Medicine_Ball'];
 
     return environment === 'gym' ? gymEquipment : homeEquipment;
+}
+
+export function parseRoutine(routine) {
+    if (!routine) return { env: '', program: '', workout: '' };
+    const parts = routine.split(' - ').map(p => p.trim());
+    return {
+        env: parts[0] || '',
+        program: parts[1] || '',
+        workout: parts[2] || ''
+    };
+}
+
+export function formatRoutineForDisplay(routine) {
+    if (!routine) return 'N/A';
+    const parsed = parseRoutine(routine);
+    if (!parsed.env && !parsed.program && !parsed.workout) return 'N/A';
+    return `<span class="routine-env">${escapeHtml(parsed.env || '')}</span><span class="routine-program">${escapeHtml(parsed.program || '')}</span><span class="routine-workout">${escapeHtml(parsed.workout || '')}</span>`;
+}
+
+export function formatRoutineForTab(routine) {
+    if (!routine) return 'N/A';
+    const parsed = parseRoutine(routine);
+    if (!parsed.env && !parsed.program && !parsed.workout) return escapeHtml(routine);
+    return `<span class="tab-env">${escapeHtml(parsed.env || '')}</span><span class="tab-program">${escapeHtml(parsed.program || '')}</span><span class="tab-workout">${escapeHtml(parsed.workout || '')}</span>`;
+}
+
+export function compareRoutines(a, b) {
+    const parsedA = parseRoutine(a);
+    const parsedB = parseRoutine(b);
+
+    if (parsedA.env !== parsedB.env) {
+        return parsedA.env.localeCompare(parsedB.env);
+    }
+    if (parsedA.program !== parsedB.program) {
+        return parsedA.program.localeCompare(parsedB.program);
+    }
+    return parsedA.workout.localeCompare(parsedB.workout);
+}
+
+export function applyRoutineTabFilter(exercises, routineFilter) {
+    if (routineFilter === 'all') {
+        return exercises;
+    }
+    return exercises.filter(ex => ex.routine === routineFilter);
+}
+
+export function renderExecutionStyleBadge(exercise) {
+    const style = exercise.execution_style || 'standard';
+    const timeCap = exercise.time_cap_seconds;
+    const emomInterval = exercise.emom_interval_seconds;
+    const emomRounds = exercise.emom_rounds;
+
+    let badgeClass = 'execution-badge';
+    let icon = '';
+    let label = '';
+    let details = '';
+
+    switch (style) {
+        case 'amrap':
+            badgeClass += ' execution-badge--amrap';
+            icon = '<i class="fas fa-stopwatch"></i>';
+            label = 'AMRAP';
+            if (timeCap) {
+                details = `<span class="execution-details">${timeCap}s</span>`;
+            }
+            break;
+        case 'emom':
+            badgeClass += ' execution-badge--emom';
+            icon = '<i class="fas fa-clock"></i>';
+            label = 'EMOM';
+            if (emomInterval && emomRounds) {
+                details = `<span class="execution-details">${emomRounds}×${emomInterval}s</span>`;
+            }
+            break;
+        default:
+            badgeClass += ' execution-badge--standard';
+            icon = '<i class="fas fa-dumbbell"></i>';
+            label = 'STD';
+    }
+
+    return `<button class="btn ${badgeClass}" aria-label="Click to change execution style">
+        ${icon} <span class="execution-label">${label}</span>${details}
+    </button>`;
+}
+
+export function buildExecutionStylePayload(exerciseId, selectedStyle, { timeCap, emomInterval, emomRounds }) {
+    const payload = { exercise_id: exerciseId, execution_style: selectedStyle };
+    if (selectedStyle === 'amrap') {
+        payload.time_cap_seconds = timeCap || 60;
+    } else if (selectedStyle === 'emom') {
+        payload.emom_interval_seconds = emomInterval || 60;
+        payload.emom_rounds = emomRounds || 5;
+    }
+    return payload;
+}
+
+export function buildAddExercisePayload({ exercise, routine, sets, minRepRange, maxRepRange, rir, weight, rpe }) {
+    return {
+        exercise, routine,
+        sets: parseInt(sets),
+        min_rep_range: parseInt(minRepRange),
+        max_rep_range: parseInt(maxRepRange),
+        rir: parseInt(rir || 0),
+        weight: parseFloat(weight),
+        rpe: rpe ? parseFloat(rpe) : null,
+    };
+}
+
+export function buildFieldUpdatePayload(exerciseId, fieldName, value) {
+    return { id: exerciseId, updates: { [fieldName]: value } };
+}
+
+export function buildReplacePayload(exerciseId) { return { id: exerciseId, strategy: 'ai' }; }
+export function buildSupersetLinkPayload(exerciseIds) { return { exercise_ids: exerciseIds }; }
+export function buildSupersetUnlinkPayload(exerciseId) { return { exercise_id: exerciseId }; }
+export function buildExerciseOrderPayload(ids) { return ids.map((id, index) => ({ id, order: index + 1 })); }
+
+export function collectMissingRequiredSelections(routine, exercise) {
+    const missing = [];
+    if (!routine) missing.push('Routine');
+    if (!exercise) missing.push('Exercise');
+    return missing;
+}
+
+export function collectMissingAddFields({ exercise, routine, sets, minRepRange, maxRepRange, weight }) {
+    const missing = [];
+    if (!exercise) missing.push('Exercise');
+    if (!routine) missing.push('Routine');
+    if (!sets) missing.push('Sets');
+    if (!minRepRange) missing.push('Min Rep Range');
+    if (!maxRepRange) missing.push('Max Rep Range');
+    if (!weight) missing.push('Weight');
+    return missing;
+}
+
+export function clampToAttrRange(parsed, minAttr, maxAttr) {
+    const min = minAttr !== null && minAttr !== '' ? parseFloat(minAttr) : -Infinity;
+    const max = maxAttr !== null && maxAttr !== '' ? parseFloat(maxAttr) : Infinity;
+    return Math.max(min, Math.min(max, parsed));
+}
+
+export function resolveSwapErrorToast(reason, message) {
+    switch (reason) {
+        case 'no_candidates': return { severity: 'warning', message: 'No alternative found for this muscle/equipment.' };
+        case 'duplicate': return { severity: 'warning', message: 'All alternatives are already in this routine.' };
+        case 'not_found': return { severity: 'error', message: 'Exercise not found in workout plan.' };
+        case 'missing_metadata': return { severity: 'warning', message: 'This exercise is missing muscle/equipment data and cannot be replaced.' };
+        default: return { severity: 'error', message };
+    }
+}
+
+export function nextSupersetColorIndex(prev) { return (prev % 4) + 1; }
+
+export function supersetRowClasses(colorNum, posInGroup, groupIndices) {
+    let classes = `superset-group superset-group-${colorNum}`;
+    const isAdjacentSuperset = groupIndices.length >= 2 && (groupIndices[1] - groupIndices[0] === 1);
+    if (isAdjacentSuperset) {
+        if (posInGroup === 0) {
+            classes += ' superset-first';
+        } else if (posInGroup === groupIndices.length - 1) {
+            classes += ' superset-last';
+        }
+    }
+    return classes;
+}
+
+const DEFAULT_PROFILE_ESTIMATE = {
+    weight: 25,
+    sets: 3,
+    min_rep: 6,
+    max_rep: 8,
+    rir: 3,
+    rpe: 7,
+    source: 'default',
+    is_dumbbell: false,
+};
+
+const ESTIMATE_SOURCE_LABELS = {
+    learned: 'learned from your recent logs',
+    related_learned: 'learned from a related exercise',
+    log: 'from your last set',
+    profile: 'from your profile',
+    cold_start: 'from population estimate',
+    default: 'default values',
+};
+
+const CONFIDENCE_LABELS = {
+    high: 'high confidence',
+    medium: 'medium confidence',
+    low: 'low confidence',
+};
+
+export function resolveProfileEstimate(estimate) { return { ...DEFAULT_PROFILE_ESTIMATE, ...(estimate || {}) }; }
+export function estimateProvenanceLabel(source) { return ESTIMATE_SOURCE_LABELS[source] || ESTIMATE_SOURCE_LABELS.default; }
+
+export function learnedBadgeText(estimate) {
+    const isLearned = ['learned', 'related_learned'].includes(estimate?.source);
+    if (!isLearned) return { isLearned: false };
+    const confidence = estimate?.trace?.confidence || '';
+    const sampleCount = estimate?.trace?.sample_count || 0;
+    const prefix = estimate?.source === 'related_learned' ? 'Related' : 'Learned';
+    const label = confidence ? `${prefix} · ${CONFIDENCE_LABELS[confidence] || confidence}` : prefix;
+    let title;
+    if (estimate?.source === 'related_learned') {
+        const source = estimate?.trace?.source_exercise || 'a related exercise';
+        title = sampleCount ? `Suggested from ${sampleCount} scored ${sampleCount === 1 ? 'log' : 'logs'} for ${source}` : `Suggested from ${source}`;
+    } else {
+        title = sampleCount ? `Suggested from ${sampleCount} scored ${sampleCount === 1 ? 'log' : 'logs'} for this exercise` : 'Suggested from your scored logs';
+    }
+    return { isLearned: true, confidence, label, title };
+}
+
+export function fatigueChipTitle(fatigue) {
+    return fatigue.headline ? `${fatigue.headline} ${fatigue.advisory || ''}`.trim() : 'Fatigue context';
+}
+
+export function traceHeadline(source) {
+    const headlineMap = { learned: 'Learned from your recent logs', related_learned: 'Learned from a related exercise', log: 'From your last logged set', profile: 'From your saved reference lift', cold_start: 'From a population estimate', default: 'Default values' };
+    return headlineMap[source] || headlineMap.default;
+}
+
+export function traceStepValueText(step) {
+    const parts = [];
+    if (step.value !== undefined && step.value !== null && step.value !== '') {
+        parts.push(`${step.value}${step.unit ? ' ' + step.unit : ''}`);
+    }
+    if (step.factor !== undefined && step.factor !== null) {
+        parts.push(`× ${step.factor}`);
+    }
+    return parts.join(' ');
+}
+
+export function resolveStep(rawStepAttr) { const raw = parseFloat(rawStepAttr); return Number.isFinite(raw) && raw > 0 ? raw : 1; }
+export function resolveMin(rawMinAttr) { const raw = parseFloat(rawMinAttr); return Number.isFinite(raw) ? raw : null; }
+
+export function computeNudgedValue(current, step, min, direction) {
+    const base = Number.isFinite(current) ? current : (min ?? 0);
+    let next = base + (direction === 'down' ? -step : step);
+    if (min !== null && next < min) next = min;
+    next = Number(next.toFixed(2));
+    return next;
 }

--- a/static/js/modules/workout-plan-state.js
+++ b/static/js/modules/workout-plan-state.js
@@ -1,0 +1,29 @@
+// Shared mutable state for the workout plan page (Refactor Plan v3 WP3.3).
+//
+// These four values were previously module-level `let`/`const` bindings inside
+// workout-plan.js, mutated across many functions (routine-tab filtering, the
+// exercise cache, superset selection, and the per-render superset colour map).
+// They are consolidated here as a single named state object so the later
+// feature split (WP3.4a `state.js`) has one explicit seam to inject, instead of
+// module-private variables that every extracted feature module would have to
+// reach back into.
+//
+// Design note — state module vs. dependency object: the workout plan page is a
+// single instance (one page, one table), so there is never more than one state
+// bag; a shared singleton object is enough and keeps every existing function
+// signature intact (app.js calls `fetchWorkoutPlan()`, `handleAddExercise(e)`,
+// etc. with fixed arities, so threading a deps parameter through would force
+// wrapper churn at those boundaries). Property access on this object preserves
+// the original semantics exactly: reassignment (`state.currentRoutineTabFilter =
+// 'all'`) matches the old `let` reassignment, and in-place mutation
+// (`state.selectedExerciseIds.add(id)`) matches the old `Set`/`Map` mutation.
+export const workoutPlanState = {
+    // Which routine tab is active ('all' or a routine name).
+    currentRoutineTabFilter: 'all',
+    // Every exercise returned by the last /get_workout_plan fetch (unfiltered).
+    allExercisesCache: [],
+    // Exercise ids currently checked for superset link/unlink.
+    selectedExerciseIds: new Set(),
+    // Maps a superset_group to its colour index (1-4), rebuilt per table render.
+    supersetColorMap: new Map(),
+};

--- a/static/js/modules/workout-plan.js
+++ b/static/js/modules/workout-plan.js
@@ -4,6 +4,36 @@ import { notifyVolumeAffectingPlanChange } from './workout-plan-events.js';
 import { buildPlayButton } from './exercise-video-modal.js';
 import { escapeHtml, resolveExerciseMediaSrc } from './exercise-helpers.js';
 import { initializeExerciseImagePreview } from './exercise-image-preview.js';
+import { workoutPlanState } from './workout-plan-state.js';
+import {
+    applyRoutineTabFilter,
+    buildAddExercisePayload,
+    buildExecutionStylePayload,
+    buildExerciseOrderPayload,
+    buildFieldUpdatePayload,
+    buildReplacePayload,
+    buildSupersetLinkPayload,
+    buildSupersetUnlinkPayload,
+    clampToAttrRange,
+    collectMissingAddFields,
+    collectMissingRequiredSelections,
+    compareRoutines,
+    computeNudgedValue,
+    estimateProvenanceLabel,
+    fatigueChipTitle,
+    formatRoutineForDisplay,
+    formatRoutineForTab,
+    learnedBadgeText,
+    nextSupersetColorIndex,
+    renderExecutionStyleBadge,
+    resolveMin,
+    resolveProfileEstimate,
+    resolveStep,
+    resolveSwapErrorToast,
+    supersetRowClasses,
+    traceHeadline,
+    traceStepValueText,
+} from './workout-plan-helpers.js';
 
 initializeExerciseImagePreview();
 
@@ -127,43 +157,10 @@ async function handleApiResponse(response) {
     return data.ok === true ? (data.data !== undefined ? data.data : data) : data;
 }
 
-// Module-level state for routine tabs
-let currentRoutineTabFilter = 'all';
-let allExercisesCache = [];
 let isExerciseSubmissionPending = false;
-
-// Superset selection state
-let selectedExerciseIds = new Set();
-let supersetColorMap = new Map(); // Maps superset_group to color index (1-4)
 
 // Execution style state
 let executionStyleOptions = null;
-
-const DEFAULT_PROFILE_ESTIMATE = {
-    weight: 25,
-    sets: 3,
-    min_rep: 6,
-    max_rep: 8,
-    rir: 3,
-    rpe: 7,
-    source: 'default',
-    is_dumbbell: false,
-};
-
-const ESTIMATE_SOURCE_LABELS = {
-    learned: 'learned from your recent logs',
-    related_learned: 'learned from a related exercise',
-    log: 'from your last set',
-    profile: 'from your profile',
-    cold_start: 'from population estimate',
-    default: 'default values',
-};
-
-const CONFIDENCE_LABELS = {
-    high: 'high confidence',
-    medium: 'medium confidence',
-    low: 'low confidence',
-};
 
 /**
  * Fetches execution style options from the API (cached)
@@ -178,50 +175,6 @@ async function getExecutionStyleOptions() {
         console.error('Failed to load execution style options:', error);
         return null;
     }
-}
-
-/**
- * Renders an execution style badge for an exercise
- * @param {Object} exercise - The exercise object
- * @returns {string} HTML string for the badge
- */
-function renderExecutionStyleBadge(exercise) {
-    const style = exercise.execution_style || 'standard';
-    const timeCap = exercise.time_cap_seconds;
-    const emomInterval = exercise.emom_interval_seconds;
-    const emomRounds = exercise.emom_rounds;
-    
-    let badgeClass = 'execution-badge';
-    let icon = '';
-    let label = '';
-    let details = '';
-    
-    switch (style) {
-        case 'amrap':
-            badgeClass += ' execution-badge--amrap';
-            icon = '<i class="fas fa-stopwatch"></i>';
-            label = 'AMRAP';
-            if (timeCap) {
-                details = `<span class="execution-details">${timeCap}s</span>`;
-            }
-            break;
-        case 'emom':
-            badgeClass += ' execution-badge--emom';
-            icon = '<i class="fas fa-clock"></i>';
-            label = 'EMOM';
-            if (emomInterval && emomRounds) {
-                details = `<span class="execution-details">${emomRounds}×${emomInterval}s</span>`;
-            }
-            break;
-        default:
-            badgeClass += ' execution-badge--standard';
-            icon = '<i class="fas fa-dumbbell"></i>';
-            label = 'STD';
-    }
-    
-    return `<button class="btn ${badgeClass}" aria-label="Click to change execution style">
-        ${icon} <span class="execution-label">${label}</span>${details}
-    </button>`;
 }
 
 /**
@@ -380,17 +333,10 @@ async function showExecutionStylePicker(exerciseId, currentExercise) {
     
     picker.querySelector('.btn-save-exec').addEventListener('click', async () => {
         const selectedStyle = picker.querySelector(`input[name="exec-style-${exerciseId}"]:checked`).value;
-        const payload = {
-            exercise_id: exerciseId,
-            execution_style: selectedStyle
-        };
-        
-        if (selectedStyle === 'amrap') {
-            payload.time_cap_seconds = parseInt(picker.querySelector(`#time-cap-${exerciseId}`).value) || 60;
-        } else if (selectedStyle === 'emom') {
-            payload.emom_interval_seconds = parseInt(picker.querySelector(`#emom-interval-${exerciseId}`).value) || 60;
-            payload.emom_rounds = parseInt(picker.querySelector(`#emom-rounds-${exerciseId}`).value) || 5;
-        }
+        const timeCap = parseInt(picker.querySelector(`#time-cap-${exerciseId}`).value);
+        const emomInterval = parseInt(picker.querySelector(`#emom-interval-${exerciseId}`).value);
+        const emomRounds = parseInt(picker.querySelector(`#emom-rounds-${exerciseId}`).value);
+        const payload = buildExecutionStylePayload(exerciseId, selectedStyle, { timeCap, emomInterval, emomRounds });
         
         try {
             const result = await api.post('/api/execution_style', payload);
@@ -411,68 +357,6 @@ async function showExecutionStylePicker(exerciseId, currentExercise) {
     }, 100);
 }
 
-/**
- * Parses a routine string in "Environment - Program - Workout" format
- * @param {string} routine - The routine string to parse
- * @returns {Object} Object with env, program, workout properties
- */
-function parseRoutine(routine) {
-    if (!routine) return { env: '', program: '', workout: '' };
-    const parts = routine.split(' - ').map(p => p.trim());
-    return {
-        env: parts[0] || '',
-        program: parts[1] || '',
-        workout: parts[2] || ''
-    };
-}
-
-/**
- * Formats a routine string for display in 3 lines (Environment, Program, Workout)
- * @param {string} routine - The routine string to format
- * @returns {string} HTML string with routine formatted on 3 lines
- */
-function formatRoutineForDisplay(routine) {
-    if (!routine) return 'N/A';
-    const parsed = parseRoutine(routine);
-    if (!parsed.env && !parsed.program && !parsed.workout) return 'N/A';
-    return `<span class="routine-env">${escapeHtml(parsed.env || '')}</span><span class="routine-program">${escapeHtml(parsed.program || '')}</span><span class="routine-workout">${escapeHtml(parsed.workout || '')}</span>`;
-}
-
-/**
- * Formats a routine string for display in tab labels (3 lines)
- * @param {string} routine - The routine string to format
- * @returns {string} HTML string with routine formatted on 3 lines for tabs
- */
-function formatRoutineForTab(routine) {
-    if (!routine) return 'N/A';
-    const parsed = parseRoutine(routine);
-    if (!parsed.env && !parsed.program && !parsed.workout) return escapeHtml(routine);
-    return `<span class="tab-env">${escapeHtml(parsed.env || '')}</span><span class="tab-program">${escapeHtml(parsed.program || '')}</span><span class="tab-workout">${escapeHtml(parsed.workout || '')}</span>`;
-}
-
-/**
- * Compares two routine strings for sorting
- * Sorts by Environment, then Program, then Workout
- * @param {string} a - First routine
- * @param {string} b - Second routine
- * @returns {number} Comparison result (-1, 0, or 1)
- */
-function compareRoutines(a, b) {
-    const parsedA = parseRoutine(a);
-    const parsedB = parseRoutine(b);
-    
-    // Compare environment first
-    if (parsedA.env !== parsedB.env) {
-        return parsedA.env.localeCompare(parsedB.env);
-    }
-    // Then compare program
-    if (parsedA.program !== parsedB.program) {
-        return parsedA.program.localeCompare(parsedB.program);
-    }
-    // Finally compare workout
-    return parsedA.workout.localeCompare(parsedB.workout);
-}
-
 // Workout plan functionality
 export async function fetchWorkoutPlan() {
     try {
@@ -482,13 +366,13 @@ export async function fetchWorkoutPlan() {
         const exercises = data.data !== undefined ? data.data : data;
         
         // Cache all exercises for tab filtering
-        allExercisesCache = exercises;
+        workoutPlanState.allExercisesCache = exercises;
         
         // Update routine tabs based on available routines
         updateRoutineTabs(exercises);
         
         // Apply current tab filter and render
-        const filteredExercises = applyRoutineTabFilter(exercises, currentRoutineTabFilter);
+        const filteredExercises = applyRoutineTabFilter(exercises, workoutPlanState.currentRoutineTabFilter);
         updateWorkoutPlanTable(filteredExercises);
         updateWorkoutPlanUI(exercises); // Always show totals for all exercises
         
@@ -549,7 +433,7 @@ function updateRoutineTabs(exercises) {
         tabBtn.setAttribute('id', tabId);
         
         // Mark as active if this is the currently selected tab
-        if (routine === currentRoutineTabFilter) {
+        if (routine === workoutPlanState.currentRoutineTabFilter) {
             tabBtn.classList.add('active');
             tabBtn.setAttribute('aria-selected', 'true');
             // Also remove active from "All" tab
@@ -572,7 +456,7 @@ function updateRoutineTabs(exercises) {
     });
     
     // If current filter is "all", ensure the "All" tab is active
-    if (currentRoutineTabFilter === 'all') {
+    if (workoutPlanState.currentRoutineTabFilter === 'all') {
         const allTabBtn = tabsContainer.querySelector('[data-routine="all"]');
         if (allTabBtn) {
             allTabBtn.classList.add('active');
@@ -581,8 +465,8 @@ function updateRoutineTabs(exercises) {
     }
     
     // If the current filter's routine no longer exists, reset to "all"
-    if (currentRoutineTabFilter !== 'all' && !sortedRoutines.includes(currentRoutineTabFilter)) {
-        currentRoutineTabFilter = 'all';
+    if (workoutPlanState.currentRoutineTabFilter !== 'all' && !sortedRoutines.includes(workoutPlanState.currentRoutineTabFilter)) {
+        workoutPlanState.currentRoutineTabFilter = 'all';
         const allTabBtn = tabsContainer.querySelector('[data-routine="all"]');
         if (allTabBtn) {
             allTabBtn.classList.add('active');
@@ -607,24 +491,11 @@ function handleRoutineTabClick(routine) {
     });
     
     // Update current filter
-    currentRoutineTabFilter = routine;
+    workoutPlanState.currentRoutineTabFilter = routine;
     
     // Apply filter and re-render table
-    const filteredExercises = applyRoutineTabFilter(allExercisesCache, routine);
+    const filteredExercises = applyRoutineTabFilter(workoutPlanState.allExercisesCache, routine);
     updateWorkoutPlanTable(filteredExercises);
-}
-
-/**
- * Filters exercises by routine
- * @param {Array} exercises - Array of exercise objects
- * @param {string} routineFilter - The routine to filter by, or 'all'
- * @returns {Array} Filtered exercises
- */
-function applyRoutineTabFilter(exercises, routineFilter) {
-    if (routineFilter === 'all') {
-        return exercises;
-    }
-    return exercises.filter(ex => ex.routine === routineFilter);
 }
 
     const WORKOUT_PLAN_DEBUG = false;
@@ -754,7 +625,7 @@ function initializeWeightDirtyTracking() {
 }
 
 function applyEstimateToWorkoutControls(estimate) {
-    const resolved = { ...DEFAULT_PROFILE_ESTIMATE, ...(estimate || {}) };
+    const resolved = resolveProfileEstimate(estimate);
     if (!weightUserDirty) {
         setWorkoutControlValue('weight', resolved.weight);
     }
@@ -766,7 +637,7 @@ function applyEstimateToWorkoutControls(estimate) {
 
     const provenance = document.getElementById('workout-estimate-provenance');
     if (provenance) {
-        provenance.textContent = ESTIMATE_SOURCE_LABELS[resolved.source] || ESTIMATE_SOURCE_LABELS.default;
+        provenance.textContent = estimateProvenanceLabel(resolved.source);
     }
 
     updateLearnedBadge(resolved);
@@ -786,34 +657,20 @@ function applyEstimateToWorkoutControls(estimate) {
 function updateLearnedBadge(estimate) {
     const badge = document.getElementById('workout-estimate-learned-badge');
     if (!badge) return;
-    const isLearned = ['learned', 'related_learned'].includes(estimate?.source);
-    if (!isLearned) {
+    const info = learnedBadgeText(estimate);
+    if (!info.isLearned) {
         badge.hidden = true;
         badge.dataset.confidence = '';
         badge.removeAttribute('title');
         return;
     }
-    const confidence = estimate?.trace?.confidence || '';
-    const sampleCount = estimate?.trace?.sample_count || 0;
     badge.hidden = false;
-    badge.dataset.confidence = confidence;
+    badge.dataset.confidence = info.confidence;
     const label = badge.querySelector('.workout-estimate-learned-badge-label');
     if (label) {
-        const prefix = estimate?.source === 'related_learned' ? 'Related' : 'Learned';
-        label.textContent = confidence
-            ? `${prefix} · ${CONFIDENCE_LABELS[confidence] || confidence}`
-            : prefix;
+        label.textContent = info.label;
     }
-    if (estimate?.source === 'related_learned') {
-        const source = estimate?.trace?.source_exercise || 'a related exercise';
-        badge.title = sampleCount
-            ? `Suggested from ${sampleCount} scored ${sampleCount === 1 ? 'log' : 'logs'} for ${source}`
-            : `Suggested from ${source}`;
-    } else {
-        badge.title = sampleCount
-            ? `Suggested from ${sampleCount} scored ${sampleCount === 1 ? 'log' : 'logs'} for this exercise`
-            : 'Suggested from your scored logs';
-    }
+    badge.title = info.title;
 }
 
 // Fatigue context (Phase 2D-A) — neutral, non-source chip next to the
@@ -830,9 +687,7 @@ function updateFatigueContextChip(estimate) {
         return;
     }
     chip.hidden = false;
-    chip.title = fatigue.headline
-        ? `${fatigue.headline} ${fatigue.advisory || ''}`.trim()
-        : 'Fatigue context';
+    chip.title = fatigueChipTitle(fatigue);
 }
 
 // Force the current learned suggestion into the Workout Controls inputs.
@@ -924,17 +779,9 @@ function renderEstimateTrace(estimate) {
     const trace = estimate?.trace;
     if (!trace) return;
 
-    const headlineMap = {
-        learned: 'Learned from your recent logs',
-        related_learned: 'Learned from a related exercise',
-        log: 'From your last logged set',
-        profile: 'From your saved reference lift',
-        cold_start: 'From a population estimate',
-        default: 'Default values',
-    };
     const headline = document.createElement('p');
     headline.className = 'workout-estimate-trace-headline';
-    headline.textContent = headlineMap[trace.source] || headlineMap.default;
+    headline.textContent = traceHeadline(trace.source);
     container.appendChild(headline);
 
     const list = document.createElement('ul');
@@ -946,17 +793,11 @@ function renderEstimateTrace(estimate) {
         labelEl.textContent = step.label;
         li.appendChild(labelEl);
 
-        const parts = [];
-        if (step.value !== undefined && step.value !== null && step.value !== '') {
-            parts.push(`${step.value}${step.unit ? ' ' + step.unit : ''}`);
-        }
-        if (step.factor !== undefined && step.factor !== null) {
-            parts.push(`× ${step.factor}`);
-        }
-        if (parts.length > 0) {
+        const valueText = traceStepValueText(step);
+        if (valueText) {
             const valueEl = document.createElement('span');
             valueEl.className = 'workout-estimate-trace-step-value';
-            valueEl.textContent = parts.join(' ');
+            valueEl.textContent = valueText;
             li.appendChild(valueEl);
         }
 
@@ -1037,13 +878,11 @@ function buildFatigueContextSection(fatigue) {
 // own attributes. `step="any"` (weight) and an absent step (sets) both fall back
 // to 1 — i.e. the input's native arrow-key step. No fatigue math here.
 function resolveControlStep(input) {
-    const raw = parseFloat(input.getAttribute('step'));
-    return Number.isFinite(raw) && raw > 0 ? raw : 1;
+    return resolveStep(input.getAttribute('step'));
 }
 
 function resolveControlMin(input) {
-    const raw = parseFloat(input.getAttribute('min'));
-    return Number.isFinite(raw) ? raw : null;
+    return resolveMin(input.getAttribute('min'));
 }
 
 // Step a Workout Controls input up/down by its own manual step, clamped to the
@@ -1055,10 +894,7 @@ function nudgeWorkoutControl(id, direction) {
     const step = resolveControlStep(field);
     const min = resolveControlMin(field);
     const current = parseFloat(field.value);
-    const base = Number.isFinite(current) ? current : (min ?? 0);
-    let next = base + (direction === 'down' ? -step : step);
-    if (min !== null && next < min) next = min;
-    next = Number(next.toFixed(2));
+    const next = computeNudgedValue(current, step, min, direction);
     setWorkoutControlValue(id, next);
 }
 
@@ -1211,7 +1047,7 @@ export async function applyUserProfileEstimateForSelectedExercise() {
         applyEstimateToWorkoutControls(response.data || response);
     } catch (error) {
         console.warn('Unable to apply user profile estimate:', error);
-        applyEstimateToWorkoutControls(DEFAULT_PROFILE_ESTIMATE);
+        applyEstimateToWorkoutControls(null);
     }
 }
 
@@ -1514,9 +1350,7 @@ export function handleAddExercise(e) {
         const routine = document.getElementById('routine')?.value;
         const exercise = document.getElementById('exercise')?.value;
         
-        const missingSelections = [];
-        if (!routine) missingSelections.push('Routine');
-        if (!exercise) missingSelections.push('Exercise');
+        const missingSelections = collectMissingRequiredSelections(routine, exercise);
         
         if (missingSelections.length > 0) {
             showToast(`Please select: ${missingSelections.join(' and ')}`, true);
@@ -1535,13 +1369,7 @@ export function handleAddExercise(e) {
     const rpe = document.getElementById('rpe')?.value;
 
     // Detailed validation
-    const missingFields = [];
-    if (!exercise) missingFields.push('Exercise');
-    if (!routine) missingFields.push('Routine');
-    if (!sets) missingFields.push('Sets');
-    if (!minRepRange) missingFields.push('Min Rep Range');
-    if (!maxRepRange) missingFields.push('Max Rep Range');
-    if (!weight) missingFields.push('Weight');
+    const missingFields = collectMissingAddFields({ exercise, routine, sets, minRepRange, maxRepRange, weight });
 
     if (missingFields.length > 0) {
         const message = `Please fill in the following required fields: ${missingFields.join(', ')}`;
@@ -1552,16 +1380,7 @@ export function handleAddExercise(e) {
     }
 
     // Prepare exercise data
-    const exerciseData = {
-        exercise: exercise,
-        routine: routine,
-        sets: parseInt(sets),
-        min_rep_range: parseInt(minRepRange),
-        max_rep_range: parseInt(maxRepRange),
-        rir: parseInt(rir || 0),
-        weight: parseFloat(weight),
-        rpe: rpe ? parseFloat(rpe) : null
-    };
+    const exerciseData = buildAddExercisePayload({ exercise, routine, sets, minRepRange, maxRepRange, rir, weight, rpe });
 
     workoutPlanDebugLog('Sending exercise data:', exerciseData);
     void sendExerciseData(exerciseData);
@@ -1644,11 +1463,9 @@ function initializeDefaultValues() {
                 if (this.value === '') return;
                 const minAttr = this.getAttribute('min');
                 const maxAttr = this.getAttribute('max');
-                const min = minAttr !== null && minAttr !== '' ? parseFloat(minAttr) : -Infinity;
-                const max = maxAttr !== null && maxAttr !== '' ? parseFloat(maxAttr) : Infinity;
                 const parsed = parseFloat(this.value);
                 if (Number.isNaN(parsed)) return;
-                const clamped = Math.max(min, Math.min(max, parsed));
+                const clamped = clampToAttrRange(parsed, minAttr, maxAttr);
                 if (clamped !== parsed) {
                     this.value = clamped;
                 }
@@ -1742,7 +1559,7 @@ export function updateWorkoutPlanTable(exercises) {
     tbody.innerHTML = '';
     
     // Reset selection state when table is rebuilt
-    selectedExerciseIds.clear();
+    workoutPlanState.selectedExerciseIds.clear();
     updateSupersetActionButtons();
 
     // Sort exercises: first by routine (Environment > Program > Workout), 
@@ -1760,7 +1577,7 @@ export function updateWorkoutPlanTable(exercises) {
     });
     
     // Build superset color map and identify superset pairs
-    supersetColorMap.clear();
+    workoutPlanState.supersetColorMap.clear();
     let colorIndex = 0;
     const supersetGroups = new Map(); // Maps superset_group to array of exercise indices
     
@@ -1768,8 +1585,8 @@ export function updateWorkoutPlanTable(exercises) {
         if (ex.superset_group) {
             if (!supersetGroups.has(ex.superset_group)) {
                 supersetGroups.set(ex.superset_group, []);
-                colorIndex = (colorIndex % 4) + 1;
-                supersetColorMap.set(ex.superset_group, colorIndex);
+                colorIndex = nextSupersetColorIndex(colorIndex);
+                workoutPlanState.supersetColorMap.set(ex.superset_group, colorIndex);
             }
             supersetGroups.get(ex.superset_group).push(idx);
         }
@@ -1788,23 +1605,10 @@ export function updateWorkoutPlanTable(exercises) {
         if (supersetGroup) {
             const groupIndices = supersetGroups.get(supersetGroup) || [];
             const posInGroup = groupIndices.indexOf(idx);
-            const colorNum = supersetColorMap.get(supersetGroup) || 1;
+            const colorNum = workoutPlanState.supersetColorMap.get(supersetGroup) || 1;
             
             row.dataset.supersetGroup = supersetGroup;
-            supersetClasses = `superset-group superset-group-${colorNum}`;
-            
-            // Only add superset-first/superset-last classes if exercises are actually adjacent
-            // This prevents broken visual connectors when viewing "All" routines
-            const isAdjacentSuperset = groupIndices.length >= 2 && 
-                (groupIndices[1] - groupIndices[0] === 1);
-            
-            if (isAdjacentSuperset) {
-                if (posInGroup === 0) {
-                    supersetClasses += ' superset-first';
-                } else if (posInGroup === groupIndices.length - 1) {
-                    supersetClasses += ' superset-last';
-                }
-            }
+            supersetClasses = supersetRowClasses(colorNum, posInGroup, groupIndices);
             
             supersetBadgeHtml = `<span class="superset-badge" style="--superset-row-color: var(--superset-color-${colorNum})"><i class="fas fa-link"></i> SS</span>`;
         }
@@ -1939,10 +1743,10 @@ function handleSupersetCheckboxChange(checkbox) {
     const row = checkbox.closest('tr');
     
     if (checkbox.checked) {
-        selectedExerciseIds.add(exerciseId);
+        workoutPlanState.selectedExerciseIds.add(exerciseId);
         row.classList.add('superset-selected');
     } else {
-        selectedExerciseIds.delete(exerciseId);
+        workoutPlanState.selectedExerciseIds.delete(exerciseId);
         row.classList.remove('superset-selected');
     }
     
@@ -1960,7 +1764,7 @@ function updateSupersetActionButtons() {
     
     if (!actionsContainer || !linkBtn || !unlinkBtn || !infoSpan) return;
     
-    const selectedCount = selectedExerciseIds.size;
+    const selectedCount = workoutPlanState.selectedExerciseIds.size;
     
     if (selectedCount === 0) {
         actionsContainer.style.display = 'none';
@@ -2046,19 +1850,19 @@ function initializeSupersetActions() {
  * Handle linking selected exercises as a superset
  */
 async function handleLinkSuperset() {
-    if (selectedExerciseIds.size !== 2) {
+    if (workoutPlanState.selectedExerciseIds.size !== 2) {
         showToast('Please select exactly 2 exercises to create a superset', true);
         return;
     }
     
-    const exerciseIds = Array.from(selectedExerciseIds);
+    const exerciseIds = Array.from(workoutPlanState.selectedExerciseIds);
     
     try {
-        const data = await api.post('/api/superset/link', { exercise_ids: exerciseIds }, { showErrorToast: false });
+        const data = await api.post('/api/superset/link', buildSupersetLinkPayload(exerciseIds), { showErrorToast: false });
         
         showToast(data.message || 'Superset created successfully');
         // Clear selection and refresh table
-        selectedExerciseIds.clear();
+        workoutPlanState.selectedExerciseIds.clear();
         document.querySelectorAll('.superset-checkbox:checked').forEach(cb => {
             cb.checked = false;
         });
@@ -2085,11 +1889,11 @@ async function handleUnlinkSuperset() {
     const exerciseId = parseInt(selectedCheckbox.dataset.exerciseId);
     
     try {
-        const data = await api.post('/api/superset/unlink', { exercise_id: exerciseId }, { showErrorToast: false });
+        const data = await api.post('/api/superset/unlink', buildSupersetUnlinkPayload(exerciseId), { showErrorToast: false });
         
         showToast(data.message || 'Superset unlinked successfully');
         // Clear selection and refresh table
-        selectedExerciseIds.clear();
+        workoutPlanState.selectedExerciseIds.clear();
         document.querySelectorAll('.superset-checkbox:checked').forEach(cb => {
             cb.checked = false;
         });
@@ -2122,10 +1926,7 @@ async function handleSwapExercise(exerciseId, currentExerciseName) {
     swapBtn.classList.add('loading');
     
     try {
-        const data = await api.post('/replace_exercise', {
-            id: exerciseId,
-            strategy: 'ai'  // Try AI-based suggestion first
-        }, { showLoading: false, showErrorToast: false }); // We handle our own loading state
+        const data = await api.post('/replace_exercise', buildReplacePayload(exerciseId), { showLoading: false, showErrorToast: false }); // We handle our own loading state
         
         // api wrapper returns raw response, check if we got updated_row
         const responseData = data.data || data;
@@ -2163,17 +1964,8 @@ async function handleSwapExercise(exerciseId, currentExerciseName) {
             const reason = responseData?.error?.reason || 'unknown';
             const message = responseData?.error?.message || responseData?.message || 'Failed to replace exercise';
             
-            if (reason === 'no_candidates') {
-                showToast('warning', 'No alternative found for this muscle/equipment.');
-            } else if (reason === 'duplicate') {
-                showToast('warning', 'All alternatives are already in this routine.');
-            } else if (reason === 'not_found') {
-                showToast('error', 'Exercise not found in workout plan.');
-            } else if (reason === 'missing_metadata') {
-                showToast('warning', 'This exercise is missing muscle/equipment data and cannot be replaced.');
-            } else {
-                showToast('error', message);
-            }
+            const t = resolveSwapErrorToast(reason, message);
+            showToast(t.severity, t.message);
         }
         
     } catch (error) {
@@ -2182,17 +1974,8 @@ async function handleSwapExercise(exerciseId, currentExerciseName) {
         const reason = error?.reason || 'unknown';
         const message = error?.message || 'Failed to replace exercise. Please try again.';
         
-        if (reason === 'no_candidates') {
-            showToast('warning', 'No alternative found for this muscle/equipment.');
-        } else if (reason === 'duplicate') {
-            showToast('warning', 'All alternatives are already in this routine.');
-        } else if (reason === 'not_found') {
-            showToast('error', 'Exercise not found in workout plan.');
-        } else if (reason === 'missing_metadata') {
-            showToast('warning', 'This exercise is missing muscle/equipment data and cannot be replaced.');
-        } else {
-            showToast('error', message);
-        }
+        const t = resolveSwapErrorToast(reason, message);
+        showToast(t.severity, t.message);
     } finally {
         // Restore button state
         swapBtn.disabled = false;
@@ -2235,11 +2018,11 @@ function updateRowMetadata(row, updatedData) {
  */
 function updateCachedExercise(exerciseId, updatedData) {
     // Update allExercisesCache if it exists
-    const cacheIndex = allExercisesCache.findIndex(ex => ex.id === exerciseId);
+    const cacheIndex = workoutPlanState.allExercisesCache.findIndex(ex => ex.id === exerciseId);
     if (cacheIndex !== -1) {
         // Merge the updated data while preserving exercise_order
-        allExercisesCache[cacheIndex] = {
-            ...allExercisesCache[cacheIndex],
+        workoutPlanState.allExercisesCache[cacheIndex] = {
+            ...workoutPlanState.allExercisesCache[cacheIndex],
             ...updatedData
         };
     }
@@ -2348,12 +2131,8 @@ function makeTableCellEditable(cell, exerciseId, fieldName) {
 }
 
 async function updateExerciseField(exerciseId, fieldName, value) {
-    const updates = { [fieldName]: value };
     // Use api wrapper with showLoading: false for quick inline edits
-    const data = await api.post('/update_exercise', {
-        id: exerciseId,
-        updates: updates
-    }, { showLoading: false, showErrorToast: false });
+    const data = await api.post('/update_exercise', buildFieldUpdatePayload(exerciseId, fieldName, value), { showLoading: false, showErrorToast: false });
     
     return data.data || data;
 }
@@ -2407,10 +2186,7 @@ function initializeDragAndDrop() {
             
             // Now get the final order and save it
             const rows = Array.from(tbody.querySelectorAll('tr'));
-            const orderData = rows.map((row, index) => ({
-                id: parseInt(row.dataset.exerciseId),
-                order: index + 1
-            }));
+            const orderData = buildExerciseOrderPayload(rows.map(row => parseInt(row.dataset.exerciseId)));
 
             try {
                 const data = await api.post('/update_exercise_order', orderData, { showLoading: false, showErrorToast: false });


### PR DESCRIPTION
## Summary

- introduce `workout-plan-state.js` with the four characterized shared values: `currentRoutineTabFilter`, `allExercisesCache`, `selectedExerciseIds`, and `supersetColorMap`
- extract DOM-free workout-plan seams for routine formatting/filtering, execution-style and API payloads, Add Exercise validation, replacement decisions, superset styling, and estimate-rendering data
- add branch-boundary characterization plus singleton/initial-shape coverage (31 new Vitest cases; 88 total)

## State-module decision

This uses a shared state module instead of threading a dependency object. The workout-plan page has one runtime instance, and the existing callers in `app.js` and `exercises.js` rely on fixed export signatures such as `fetchWorkoutPlan()` and `handleAddExercise(e)`. A singleton preserves those signatures while object-property reassignment and Set/Map mutation retain the prior semantics.

## WP3.3 boundary

No DOM feature was moved; DOM ownership and event timing remain in `workout-plan.js` for WP3.4a-h. There are no calculation, database, API URL, payload-shape, response-contract, CSS, or Python changes. No required CI check was renamed; Vitest remains non-required.

## Verification

- `npm run test:js` — 88 passed
- `.venv/Scripts/python.exe -m pytest tests/ -q` — 1717 passed
- Chromium workout-plan / exercise-interactions / superset-edge-cases / replace-exercise-errors / fatigue-context — passed with no collected console errors
- Chromium learned-calibration — 8 passed on a fresh test DB (including the real-data golden path)

A combined mutable-DB invocation of all six specs reports 84/85 because earlier specs leave unrelated workout-log rows and the learned golden test edits `.first()`; the exact failed test passes 1/1 and the full learned spec passes 8/8 from a fresh DB. No test or product behavior was changed for that pre-existing cross-spec isolation issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)