### PR TITLE
refactor(workout-plan): extract swap/replace cluster to workout-plan-replacement.js (WP3.4e)

### DIFF
--- a/static/js/modules/workout-plan-replacement.js
+++ b/static/js/modules/workout-plan-replacement.js
@@ -1,0 +1,95 @@
+import { showToast } from './toast.js';
+import { api } from './fetch-wrapper.js';
+import { notifyVolumeAffectingPlanChange } from './workout-plan-events.js';
+import { updateCachedExercise, updateRowMetadata } from './workout-plan-table.js';
+import { buildReplacePayload, resolveSwapErrorToast } from './workout-plan-helpers.js';
+
+function getSwapButtonLoadingMarkup() {
+    return `
+        <span class="btn-swap-icon btn-swap-icon--spinner" aria-hidden="true">
+            <svg viewBox="0 0 16 16" focusable="false">
+                <circle cx="8" cy="8" r="5.25" fill="none" stroke="currentColor" stroke-linecap="round" stroke-width="1.75" stroke-dasharray="24 12"/>
+            </svg>
+        </span>
+        <span class="btn-swap-label">Swap</span>
+    `;
+}
+
+/**
+ * Handles the swap/replace exercise action
+ * @param {number} exerciseId - The user_selection.id of the exercise to swap
+ * @param {string} currentExerciseName - The current exercise name (for display)
+ */
+export async function handleSwapExercise(exerciseId, currentExerciseName) {
+    const row = document.querySelector(`tr[data-exercise-id="${exerciseId}"]`);
+    const swapBtn = row?.querySelector('.btn-swap');
+    
+    if (!row || !swapBtn) {
+        console.error('Could not find row or swap button for exercise:', exerciseId);
+        return;
+    }
+    
+    // Disable button and show loading state
+    swapBtn.disabled = true;
+    const originalIcon = swapBtn.innerHTML;
+    swapBtn.innerHTML = getSwapButtonLoadingMarkup();
+    swapBtn.classList.add('loading');
+    
+    try {
+        const data = await api.post('/replace_exercise', buildReplacePayload(exerciseId), { showLoading: false, showErrorToast: false }); // We handle our own loading state
+        
+        // api wrapper returns raw response, check if we got updated_row
+        const responseData = data.data || data;
+        
+        if (responseData?.updated_row) {
+            // Success - update the row in place
+            const updatedRow = responseData.updated_row;
+            const oldExercise = responseData.old_exercise;
+            const newExercise = responseData.new_exercise;
+            
+            // Update the exercise name in the cell
+            const exerciseNameSpan = row.querySelector('.exercise-name');
+            if (exerciseNameSpan) {
+                exerciseNameSpan.textContent = newExercise;
+            }
+            
+            // Update other metadata cells
+            updateRowMetadata(row, updatedRow);
+            
+            // Update the cached data
+            updateCachedExercise(exerciseId, updatedRow);
+            
+            // Show success toast with remaining options count
+            const remaining = responseData.remaining_options ?? 0;
+            const optionsText = remaining === 1 ? '1 option left' : `${remaining} options left`;
+            showToast('success', `Replaced "${oldExercise}" → "${newExercise}" (${optionsText})`);
+            notifyVolumeAffectingPlanChange('replace-exercise');
+            
+            // Brief highlight effect on the row
+            row.classList.add('row-swapped');
+            setTimeout(() => row.classList.remove('row-swapped'), 2000);
+            
+        } else {
+            // Handle specific error reasons
+            const reason = responseData?.error?.reason || 'unknown';
+            const message = responseData?.error?.message || responseData?.message || 'Failed to replace exercise';
+            
+            const t = resolveSwapErrorToast(reason, message);
+            showToast(t.severity, t.message);
+        }
+        
+    } catch (error) {
+        console.error('Error swapping exercise:', error);
+        // Handle specific error reasons from the error object
+        const reason = error?.reason || 'unknown';
+        const message = error?.message || 'Failed to replace exercise. Please try again.';
+        
+        const t = resolveSwapErrorToast(reason, message);
+        showToast(t.severity, t.message);
+    } finally {
+        // Restore button state
+        swapBtn.disabled = false;
+        swapBtn.innerHTML = originalIcon;
+        swapBtn.classList.remove('loading');
+    }
+}

--- a/static/js/modules/workout-plan.js
+++ b/static/js/modules/workout-plan.js
@@ -8,21 +8,17 @@ import {
     handleViewModeChange,
     initializeRoutineTabs,
     transformMuscleDisplay,
-    updateCachedExercise,
     updateRoutineTabs,
-    updateRowMetadata,
     updateWorkoutPlanTable,
 } from './workout-plan-table.js';
 import {
     applyRoutineTabFilter,
     buildAddExercisePayload,
-    buildReplacePayload,
     buildSupersetLinkPayload,
     buildSupersetUnlinkPayload,
     clampToAttrRange,
     collectMissingAddFields,
     collectMissingRequiredSelections,
-    resolveSwapErrorToast,
 } from './workout-plan-helpers.js';
 import {
     applyUserProfileEstimateForSelectedExercise,
@@ -34,6 +30,7 @@ import {
     configureExecutionStyle,
     showExecutionStylePicker,
 } from './workout-plan-execution-style.js';
+import { handleSwapExercise } from './workout-plan-replacement.js';
 
 initializeExerciseImagePreview();
 
@@ -60,17 +57,6 @@ configureWorkoutPlanTable({
 // Wire the execution-style picker's plan-refresh callback (orchestration that
 // stays here) so it never imports back into this monolith.
 configureExecutionStyle({ refreshPlan: fetchWorkoutPlan });
-
-function getSwapButtonLoadingMarkup() {
-    return `
-        <span class="btn-swap-icon btn-swap-icon--spinner" aria-hidden="true">
-            <svg viewBox="0 0 16 16" focusable="false">
-                <circle cx="8" cy="8" r="5.25" fill="none" stroke="currentColor" stroke-linecap="round" stroke-width="1.75" stroke-dasharray="24 12"/>
-            </svg>
-        </span>
-        <span class="btn-swap-label">Swap</span>
-    `;
-}
 
 /**
  * Helper function to handle standardized API responses
@@ -847,84 +833,5 @@ async function handleUnlinkSuperset() {
     } catch (error) {
         console.error('Error unlinking superset:', error);
         showToast(error.message || 'Failed to unlink superset', true);
-    }
-}
-
-/**
- * Handles the swap/replace exercise action
- * @param {number} exerciseId - The user_selection.id of the exercise to swap
- * @param {string} currentExerciseName - The current exercise name (for display)
- */
-async function handleSwapExercise(exerciseId, currentExerciseName) {
-    const row = document.querySelector(`tr[data-exercise-id="${exerciseId}"]`);
-    const swapBtn = row?.querySelector('.btn-swap');
-    
-    if (!row || !swapBtn) {
-        console.error('Could not find row or swap button for exercise:', exerciseId);
-        return;
-    }
-    
-    // Disable button and show loading state
-    swapBtn.disabled = true;
-    const originalIcon = swapBtn.innerHTML;
-    swapBtn.innerHTML = getSwapButtonLoadingMarkup();
-    swapBtn.classList.add('loading');
-    
-    try {
-        const data = await api.post('/replace_exercise', buildReplacePayload(exerciseId), { showLoading: false, showErrorToast: false }); // We handle our own loading state
-        
-        // api wrapper returns raw response, check if we got updated_row
-        const responseData = data.data || data;
-        
-        if (responseData?.updated_row) {
-            // Success - update the row in place
-            const updatedRow = responseData.updated_row;
-            const oldExercise = responseData.old_exercise;
-            const newExercise = responseData.new_exercise;
-            
-            // Update the exercise name in the cell
-            const exerciseNameSpan = row.querySelector('.exercise-name');
-            if (exerciseNameSpan) {
-                exerciseNameSpan.textContent = newExercise;
-            }
-            
-            // Update other metadata cells
-            updateRowMetadata(row, updatedRow);
-            
-            // Update the cached data
-            updateCachedExercise(exerciseId, updatedRow);
-            
-            // Show success toast with remaining options count
-            const remaining = responseData.remaining_options ?? 0;
-            const optionsText = remaining === 1 ? '1 option left' : `${remaining} options left`;
-            showToast('success', `Replaced "${oldExercise}" → "${newExercise}" (${optionsText})`);
-            notifyVolumeAffectingPlanChange('replace-exercise');
-            
-            // Brief highlight effect on the row
-            row.classList.add('row-swapped');
-            setTimeout(() => row.classList.remove('row-swapped'), 2000);
-            
-        } else {
-            // Handle specific error reasons
-            const reason = responseData?.error?.reason || 'unknown';
-            const message = responseData?.error?.message || responseData?.message || 'Failed to replace exercise';
-            
-            const t = resolveSwapErrorToast(reason, message);
-            showToast(t.severity, t.message);
-        }
-        
-    } catch (error) {
-        console.error('Error swapping exercise:', error);
-        // Handle specific error reasons from the error object
-        const reason = error?.reason || 'unknown';
-        const message = error?.message || 'Failed to replace exercise. Please try again.';
-        
-        const t = resolveSwapErrorToast(reason, message);
-        showToast(t.severity, t.message);
-    } finally {
-        // Restore button state
-        swapBtn.disabled = false;
-        swapBtn.innerHTML = originalIcon;
-        swapBtn.classList.remove('loading');
     }
 }


### PR DESCRIPTION
## WP3.4e — `replacement.js` split

Move-only extraction of the swap/replace-exercise cluster out of the
`static/js/modules/workout-plan.js` monolith into a new
`static/js/modules/workout-plan-replacement.js` module, continuing the WP3.4 feature-boundary split.

### Moved (verbatim)
- `getSwapButtonLoadingMarkup` (private; sole caller is `handleSwapExercise`)
- `handleSwapExercise` (now exported)

### Dependency direction — plain import (WP3.4c-style), not callback injection
`handleSwapExercise` updates the row **in place** and never calls `fetchWorkoutPlan()`, so the new module imports its deps directly and imports nothing back from the monolith → **no circular import**:
- `updateRowMetadata`, `updateCachedExercise` ← `workout-plan-table.js` (already exported by WP3.4b)
- `notifyVolumeAffectingPlanChange` ← `workout-plan-events.js`
- pure helpers `buildReplacePayload`, `resolveSwapErrorToast` ← `workout-plan-helpers.js`
- `showToast` ← `toast.js`, `api` ← `fetch-wrapper.js`

The monolith imports `handleSwapExercise` and keeps injecting it into the table via `configureWorkoutPlanTable({ onSwap: handleSwapExercise })`. Now-unused imports pruned from the monolith: `buildReplacePayload`, `resolveSwapErrorToast`, `updateRowMetadata`, `updateCachedExercise` (`notifyVolumeAffectingPlanChange` kept — still used by add-exercise).

### Refactor invariant
No behavior / API / DB / calculation / response-shape / event-timing change. The swap button disable→loading→finally-restore sequence and the `row-swapped` highlight timing are preserved exactly. Moved bodies proven byte-identical to HEAD (only `export` prepended to the `handleSwapExercise` def); monolith remainder proven `== HEAD` minus moved/pruned lines plus one new import. New module written LF (index LF); monolith kept CRLF worktree / LF index.

### Gates
- Vitest **88** (unchanged — no test imports the moved fns)
- E2E Chromium **77 passed**: replace-exercise-errors (primary) + workout-plan + exercise-interactions + superset-edge-cases + fatigue-context
- learned-calibration **8/8** isolated (known `:506` combined-run flake did not apply)

🤖 Generated with [Claude Code](https://claude.com/claude-code)