### PR TITLE
refactor(workout-plan): extract media integration (WP3.4h)

### DIFF
--- a/static/js/modules/workout-plan-media.js
+++ b/static/js/modules/workout-plan-media.js
@@ -1,0 +1,32 @@
+// Workout plan media integration (Refactor Plan v3 WP3.4h).
+//
+// Keeps the plan-specific thumbnail, image-preview, and reference-video glue
+// together while the shared media implementations remain reusable by other
+// pages (notably Workout Log and User Profile).
+import { escapeHtml, resolveExerciseMediaSrc } from './exercise-helpers.js';
+import { initializeExerciseImagePreview } from './exercise-image-preview.js';
+import { buildPlayButton } from './exercise-video-modal.js';
+
+export function initializeWorkoutPlanMedia() {
+    initializeExerciseImagePreview();
+}
+
+export function buildExerciseThumbnailHtml(exercise) {
+    const exerciseName = exercise.exercise || 'N/A';
+    const mediaSrc = resolveExerciseMediaSrc(exercise.media_path);
+
+    return mediaSrc
+        ? `<img class="exercise-thumbnail" src="${escapeHtml(mediaSrc)}" alt="${escapeHtml(exerciseName)} reference" data-preview-label="${escapeHtml(exerciseName)}" loading="lazy" width="32" height="32" tabindex="0">`
+        : '';
+}
+
+export function appendExerciseVideoButton(row, exercise) {
+    const cellContent = row.querySelector('.exercise-cell-content');
+    if (cellContent) {
+        const playBtn = buildPlayButton({
+            videoId: exercise.youtube_video_id,
+            exerciseName: exercise.exercise || '',
+        });
+        cellContent.appendChild(playBtn);
+    }
+}

--- a/static/js/modules/workout-plan-table.js
+++ b/static/js/modules/workout-plan-table.js
@@ -23,8 +23,11 @@ import {
     renderExecutionStyleBadge,
     supersetRowClasses,
 } from './workout-plan-helpers.js';
-import { escapeHtml, resolveExerciseMediaSrc } from './exercise-helpers.js';
-import { buildPlayButton } from './exercise-video-modal.js';
+import { escapeHtml } from './exercise-helpers.js';
+import {
+    appendExerciseVideoButton,
+    buildExerciseThumbnailHtml,
+} from './workout-plan-media.js';
 import { showToast } from './toast.js';
 import { api } from './fetch-wrapper.js';
 import { notifyVolumeAffectingPlanChange } from './workout-plan-events.js';
@@ -363,10 +366,7 @@ export function updateWorkoutPlanTable(exercises) {
         }
 
         const exerciseName = exercise.exercise || 'N/A';
-        const mediaSrc = resolveExerciseMediaSrc(exercise.media_path);
-        const thumbnailHtml = mediaSrc
-            ? `<img class="exercise-thumbnail" src="${escapeHtml(mediaSrc)}" alt="${escapeHtml(exerciseName)} reference" data-preview-label="${escapeHtml(exerciseName)}" loading="lazy" width="32" height="32" tabindex="0">`
-            : '';
+        const thumbnailHtml = buildExerciseThumbnailHtml(exercise);
 
         // Add checkbox column, drag handle and other cells with priority classes and data-labels
         row.innerHTML = `
@@ -425,14 +425,7 @@ export function updateWorkoutPlanTable(exercises) {
         // §5 — append the reference-video play button into the Exercise cell
         // action cluster (next to Swap). DOM-node creation avoids interpolating
         // exercise-name into an inline aria-label or onclick.
-        const cellContent = row.querySelector('.exercise-cell-content');
-        if (cellContent) {
-            const playBtn = buildPlayButton({
-                videoId: exercise.youtube_video_id,
-                exerciseName: exercise.exercise || '',
-            });
-            cellContent.appendChild(playBtn);
-        }
+        appendExerciseVideoButton(row, exercise);
 
         // Add click handlers for editable cells
         row.querySelectorAll('.editable').forEach(cell => {

--- a/static/js/modules/workout-plan.js
+++ b/static/js/modules/workout-plan.js
@@ -1,6 +1,5 @@
 import { showToast } from './toast.js';
 import { api } from './fetch-wrapper.js';
-import { initializeExerciseImagePreview } from './exercise-image-preview.js';
 import { workoutPlanState } from './workout-plan-state.js';
 import {
     configureWorkoutPlanTable,
@@ -34,8 +33,9 @@ import {
     initializeSupersetActions,
     updateSupersetActionButtons,
 } from './workout-plan-supersets.js';
+import { initializeWorkoutPlanMedia } from './workout-plan-media.js';
 
-initializeExerciseImagePreview();
+initializeWorkoutPlanMedia();
 
 // Re-export the table renderer so existing importers (and the workout-plan E2E
 // harness that imports this module directly) keep resolving it from here.


### PR DESCRIPTION
## WP3.4h — media boundary and final workout-plan split

Mechanical extraction of the remaining workout-plan media glue into `static/js/modules/workout-plan-media.js`.

### Moved
- import-time workout-plan image-preview initialization
- safe exercise-thumbnail markup construction
- reference-video play-button creation/attachment

The shared implementations (`exercise-helpers.js`, `exercise-image-preview.js`, and `exercise-video-modal.js`) stay reusable by Workout Log and User Profile. `workout-plan-table.js` consumes the dedicated media boundary, and `workout-plan.js` remains the stable entry/import path and wiring layer.

### Compatibility and invariants
- Existing `workout-plan.js` exports are unchanged.
- `app.js` imports and `window` bridges are unchanged.
- The template still loads one application entry script in the same order.
- The direct E2E `workout-plan.js` import continues to resolve `updateWorkoutPlanTable`.
- Image-preview initialization remains at module-load time in the same entry position.
- No circular imports were introduced.
- No behavior, UI, endpoint, payload, response envelope, database, calculation, styling, screenshot, or event-timing change.
- WP3.5 is not included.

### Verification
- `git diff --check` — pass
- `npx tsc --noEmit` — pass
- `npm run test:js` — **88 passed**
- Required Chromium set — **85 tests across 6 specs**:
  - `workout-plan.spec.ts` — 35
  - `exercise-interactions.spec.ts` — 21
  - `superset-edge-cases.spec.ts` — 12
  - `fatigue-context.spec.ts` — 6
  - `learned-calibration.spec.ts` — 8
  - `replace-exercise-errors.spec.ts` — 3

The combined focused run finished **84 passed / 1 failed** because the learned-calibration golden-path assertion observed `calibration.status !== updated` after earlier state-mutating specs. A fresh isolated rerun of the full learned-calibration spec passed **8/8**; all other focused tests passed in the combined run. All runs used the worktree-owned Playwright database under `artifacts/e2e/`; the main checkout database was untouched.