### PR TITLE
WP3.5: consolidate JSON API transport

### DIFF
--- a/docs/WP3_5_FETCH_INVENTORY.md
+++ b/docs/WP3_5_FETCH_INVENTORY.md
@@ -1,0 +1,81 @@
+# WP3.5 raw-fetch inventory
+
+This is the repository-wide before/after inventory for WP3.5. It covers tracked
+files under `static/`, `templates/`, `tests/`, and `e2e/` after the WP3.2 inline
+script extraction and WP3.4 workout-plan split. The inventory command was:
+
+```powershell
+git grep -n -E "\bfetch[[:space:]]*\(" -- static templates tests e2e
+```
+
+Two textual mentions (`static/js/CLAUDE.md` and a comment in
+`workout-plan-state.js`) were excluded from invocation counts. The ignored
+`static/bodymaps/GPT/_preview.html` scratch preview is not a tracked repository
+caller; its raw fetch also reads a local SVG as text and was not modified.
+
+## Before WP3.5
+
+There were 23 tracked raw-fetch invocations: 20 in production JavaScript and
+three in direct browser/Puppeteer harnesses.
+
+| Classification | Count | Callers | WP3.5 disposition |
+|---|---:|---|---|
+| JSON application endpoint | 14 | `app.js` (1), `welcome.js` (1), `exercises.js` (2), `filters.js` (1), `session-summary.js` (1), `weekly-summary.js` (2), `volume-splitter.js` (6) | Migrated to `api.get` / `api.post` / `api.delete` |
+| Intentional static-asset text | 2 | `bodymap-svg.js` (1), `muscle-selector.js` (1) | Retained raw; both require SVG text rather than the JSON contract |
+| Intentional blob/download | 3 | `exports.js` (2), `volume-splitter.js` (1) | Retained raw; callers require blobs and response headers/filenames |
+| Shared transport implementation | 1 | `fetch-wrapper.js` | Retained raw; this is the single underlying network boundary |
+| Direct test/harness transport probe | 3 | `error-handling.spec.ts` (2), `puppeteer_mcp_summary_regression.py` (1) | Retained raw; these execute in the browser to test endpoints independently of application transport |
+| Dead or unreachable tracked code | 0 | None | No deletion proposed |
+
+No raw-fetch invocation existed in a Jinja template or pytest file. The
+classic `welcome.js` script remains classic and uses a click-time dynamic import
+of the shared transport; this preserves template script type, order, and
+DOMContentLoaded listener timing without adding a `window` bridge.
+
+## Shared transport caller audit
+
+Before WP3.5, 15 production modules made 46 `api.*` calls. Callers consume the
+full parsed response envelope: feature modules read `response.data` for payloads
+and top-level `message` where required. HTTP/network failures are thrown as the
+wrapper's normalized `{code, message, requestId}` object. Existing callers vary
+deliberately between wrapper-owned and feature-owned UI behavior:
+
+- `showLoading` defaults to `true`; feature-owned spinners pass `false`.
+- `showErrorToast` defaults to `true`; callers with an existing toast/error UI
+  pass `false`.
+- GET retries default to two; migrated raw GETs pass `retries: 0` to retain
+  their original single-attempt behavior.
+- Methods and object bodies flow through `api.get/post/patch/delete`; the
+  wrapper JSON-stringifies object bodies. Fetch-native options, including
+  credentials and abort signals, continue through `...fetchOptions`.
+- Default JSON/request-ID headers remain unchanged for existing callers. WP3.5
+  adds the opt-out `useDefaultHeaders: false` so migrated calls retain their
+  exact pre-WP3.5 header sets.
+- Public exports remain `apiFetch`, `api`, helper named exports, and the default
+  `apiFetch` export. There was no `window.api` or `window.apiFetch` bridge, and
+  WP3.5 adds none.
+
+The migrated calls explicitly disable wrapper loading/error toasts where the
+feature already owns those states. `volume-splitter.js` now consumes the shared
+envelope directly (`response.data`); its local wrapped-response detector,
+unwrapper, error-message extractor, and `parseJsonResponse` wrapper were
+removed.
+
+## After WP3.5
+
+Nine tracked raw-fetch invocations remain and every one is intentional:
+
+| File | Calls | Justification |
+|---|---:|---|
+| `static/js/modules/fetch-wrapper.js` | 1 | The shared transport must ultimately call the browser Fetch API. |
+| `static/js/modules/bodymap-svg.js` | 1 | Loads a static SVG and consumes `response.text()`; the JSON wrapper has no text-asset contract. |
+| `static/js/modules/muscle-selector.js` | 1 | Loads/caches a static SVG and consumes `response.text()`; bodymap behavior is unchanged. |
+| `static/js/modules/exports.js` | 2 | Downloads Excel workbooks via `response.blob()` and, for plan export, preserves the server `Content-Disposition` filename. `exportSummary` has no current template caller but remains reachable through the preserved public `window.exportSummary` bridge, so it is not deleted or rewritten opportunistically. |
+| `static/js/modules/volume-splitter.js` | 1 | Downloads an Excel workbook via `response.blob()` and preserves the existing `volume_plan_YYYY-MM-DD.xlsx` filename. |
+| `e2e/error-handling.spec.ts` | 2 | Browser-context direct-fetch probes assert malformed/error endpoint behavior without coupling the test to production transport. |
+| `e2e/puppeteer_mcp_summary_regression.py` | 1 | Browser-context regression harness directly requests the summary JSON contract; importing app transport would weaken the independent contract probe. |
+
+All 14 production JSON application calls were removed from the raw-fetch
+inventory. The shared transport now has 60 production calls across 21 caller
+files. There is no dead/unreachable fetch code awaiting deletion, and no
+binary/static-resource path was forced through the JSON-only transport.

--- a/static/js/app.js
+++ b/static/js/app.js
@@ -30,6 +30,7 @@ import { showAutoBackupBanner } from './modules/program-backup.js';
 import { initializeBackupCenter } from './modules/backup-center.js';
 import { initializePlanVolumePanel } from './modules/plan_volume_panel.js';
 import { notifyVolumeAffectingPlanChange } from './modules/workout-plan-events.js';
+import { api } from './modules/fetch-wrapper.js';
 
 const APP_DEBUG = false;
 const appDebugLog = (...args) => {
@@ -112,28 +113,27 @@ window.generateStarterPlan = async function() {
         }
         
         // Make API request
-        const response = await fetch('/generate_starter_plan', {
-            method: 'POST',
+        const result = await api.post('/generate_starter_plan', {
+            training_days: trainingDays,
+            environment: environment,
+            experience_level: experienceLevel,
+            goal: goal,
+            volume_scale: volumeScale,
+            overwrite: overwrite,
+            movement_restrictions: Object.keys(movementRestrictions).length > 0 ? movementRestrictions : null,
+            equipment_whitelist: equipmentWhitelist,
+            priority_muscles: priorityMuscles.length > 0 ? priorityMuscles : null,
+            persist: true
+        }, {
             headers: {
                 'Content-Type': 'application/json',
             },
-            body: JSON.stringify({
-                training_days: trainingDays,
-                environment: environment,
-                experience_level: experienceLevel,
-                goal: goal,
-                volume_scale: volumeScale,
-                overwrite: overwrite,
-                movement_restrictions: Object.keys(movementRestrictions).length > 0 ? movementRestrictions : null,
-                equipment_whitelist: equipmentWhitelist,
-                priority_muscles: priorityMuscles.length > 0 ? priorityMuscles : null,
-                persist: true
-            })
+            showLoading: false,
+            showErrorToast: false,
+            useDefaultHeaders: false
         });
-        
-        const result = await response.json();
-        
-        if (response.ok && result.data) {
+
+        if (result.data) {
             // Close modal
             const modal = bootstrap.Modal.getInstance(document.getElementById('generatePlanModal'));
             modal.hide();
@@ -157,7 +157,10 @@ window.generateStarterPlan = async function() {
         }
     } catch (error) {
         console.error('Error generating plan:', error);
-        showToast('error', 'Error generating plan. Please try again.');
+        const errorMsg = error?.code === 'NETWORK_ERROR'
+            ? 'Error generating plan. Please try again.'
+            : (error?.message || 'Error generating plan. Please try again.');
+        showToast('error', errorMsg);
     } finally {
         // Restore button state
         submitBtn.disabled = false;

--- a/static/js/modules/__tests__/exports.test.js
+++ b/static/js/modules/__tests__/exports.test.js
@@ -1,0 +1,66 @@
+// @vitest-environment jsdom
+
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+vi.mock('../toast.js', () => ({ showToast: vi.fn() }));
+vi.mock('../fetch-wrapper.js', () => ({
+    api: { post: vi.fn() },
+    isHandledApiError: vi.fn(() => false),
+    logApiError: vi.fn(),
+}));
+
+import { exportSummary, exportToExcel } from '../exports.js';
+
+describe('raw blob export transport', () => {
+    let clickedFilename;
+
+    beforeEach(() => {
+        vi.restoreAllMocks();
+        clickedFilename = null;
+        document.body.innerHTML = `
+            <table><tbody id="workout_plan_table_body"><tr><td>Squat</td></tr></tbody></table>
+        `;
+        localStorage.clear();
+        vi.spyOn(console, 'log').mockImplementation(() => {});
+        vi.spyOn(URL, 'createObjectURL').mockReturnValue('blob:test');
+        vi.spyOn(URL, 'revokeObjectURL').mockImplementation(() => {});
+        vi.spyOn(HTMLAnchorElement.prototype, 'click').mockImplementation(function () {
+            clickedFilename = this.download;
+        });
+    });
+
+    it('keeps workout-plan export on raw blob transport and the server filename', async () => {
+        const headers = new Headers({
+            'Content-Disposition': 'attachment; filename="workout_plan_test.xlsx"',
+        });
+        const fetchMock = vi.spyOn(globalThis, 'fetch').mockResolvedValue({
+            ok: true,
+            status: 200,
+            statusText: 'OK',
+            headers,
+            blob: vi.fn().mockResolvedValue(new Blob(['workbook'])),
+        });
+
+        await exportToExcel();
+
+        expect(fetchMock).toHaveBeenCalledWith('/export_to_excel?view_mode=simple', {
+            method: 'GET',
+            headers: {
+                Accept: 'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet',
+            },
+        });
+        expect(clickedFilename).toBe('workout_plan_test.xlsx');
+    });
+
+    it('keeps the public summary export helper on raw blob transport and its filename', async () => {
+        const fetchMock = vi.spyOn(globalThis, 'fetch').mockResolvedValue({
+            ok: true,
+            blob: vi.fn().mockResolvedValue(new Blob(['workbook'])),
+        });
+
+        await exportSummary('session');
+
+        expect(fetchMock).toHaveBeenCalledWith('/export_session_summary', { method: 'GET' });
+        expect(clickedFilename).toBe('session_summary.xlsx');
+    });
+});

--- a/static/js/modules/__tests__/fetch-wrapper.test.js
+++ b/static/js/modules/__tests__/fetch-wrapper.test.js
@@ -1,0 +1,70 @@
+// @vitest-environment jsdom
+
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+vi.mock('../toast.js', () => ({ showToast: vi.fn() }));
+
+import { apiFetch } from '../fetch-wrapper.js';
+
+describe('apiFetch request compatibility options', () => {
+    beforeEach(() => {
+        vi.restoreAllMocks();
+    });
+
+    it('can preserve an existing caller header set exactly', async () => {
+        const response = {
+            ok: true,
+            headers: { get: () => 'application/json' },
+            json: vi.fn().mockResolvedValue({ ok: true, status: 'success', data: {} }),
+        };
+        const fetchMock = vi.spyOn(globalThis, 'fetch').mockResolvedValue(response);
+        const headers = {
+            Accept: 'application/json',
+            'X-Requested-With': 'XMLHttpRequest',
+        };
+
+        await apiFetch('/example', {
+            headers,
+            useDefaultHeaders: false,
+            showLoading: false,
+            showErrorToast: false,
+            retries: 0,
+        });
+
+        expect(fetchMock).toHaveBeenCalledWith('/example', {
+            method: 'GET',
+            headers,
+        });
+    });
+
+    it('preserves a top-level message from a non-standard JSON error response', async () => {
+        vi.spyOn(globalThis, 'fetch').mockResolvedValue({
+            ok: false,
+            status: 400,
+            headers: { get: () => 'application/json' },
+            json: vi.fn().mockResolvedValue({ message: 'Existing caller message' }),
+        });
+
+        await expect(apiFetch('/example', {
+            showLoading: false,
+            showErrorToast: false,
+            retries: 0,
+        })).rejects.toMatchObject({
+            code: 'UNKNOWN_ERROR',
+            message: 'Existing caller message',
+        });
+    });
+
+    it('retains the existing NETWORK_ERROR classification for rejected fetches', async () => {
+        vi.spyOn(globalThis, 'fetch').mockRejectedValue(new Error('Connection lost'));
+
+        await expect(apiFetch('/example', {
+            showLoading: false,
+            showErrorToast: false,
+            retries: 0,
+        })).rejects.toMatchObject({
+            code: 'NETWORK_ERROR',
+            message: 'Connection lost',
+        });
+    });
+});

--- a/static/js/modules/exercises.js
+++ b/static/js/modules/exercises.js
@@ -1,6 +1,7 @@
 import { showToast } from './toast.js';
 import { fetchWorkoutPlan } from './workout-plan.js';
 import { notifyVolumeAffectingPlanChange } from './workout-plan-events.js';
+import { api } from './fetch-wrapper.js';
 
 // Track exercises being deleted to prevent double-delete
 const deletingExercises = new Set();
@@ -21,21 +22,15 @@ export async function removeExercise(exerciseId) {
     deletingExercises.add(exerciseId);
 
     try {
-        const response = await fetch("/remove_exercise", {
-            method: "POST",
+        const result = await api.post("/remove_exercise", { id: exerciseId }, {
             headers: { "Content-Type": "application/json" },
-            body: JSON.stringify({ id: exerciseId }),
+            showLoading: false,
+            showErrorToast: false,
+            useDefaultHeaders: false
         });
-
-        const result = await response.json();
-
-        if (response.ok) {
-            showToast(result.message || "Exercise removed successfully!");
-            fetchWorkoutPlan();
-            notifyVolumeAffectingPlanChange('remove-exercise');
-        } else {
-            throw new Error(result.message || "Failed to remove exercise");
-        }
+        showToast(result.message || "Exercise removed successfully!");
+        fetchWorkoutPlan();
+        notifyVolumeAffectingPlanChange('remove-exercise');
     } catch (error) {
         console.error("Error removing exercise:", error);
         showToast(`Unable to remove exercise: ${error.message}`, true);
@@ -55,20 +50,15 @@ export async function clearWorkoutPlan() {
             }
         }
 
-        const response = await fetch('/clear_workout_plan', {
-            method: 'POST',
-            headers: { 'Content-Type': 'application/json' }
+        const result = await api.post('/clear_workout_plan', null, {
+            headers: { 'Content-Type': 'application/json' },
+            showLoading: false,
+            showErrorToast: false,
+            useDefaultHeaders: false
         });
-
-        const result = await response.json();
-
-        if (response.ok) {
-            showToast(result.message || 'Workout plan cleared successfully!');
-            fetchWorkoutPlan(); // Refresh the table to show empty state
-            notifyVolumeAffectingPlanChange('clear-workout-plan');
-        } else {
-            throw new Error(result.error?.message || result.message || 'Failed to clear workout plan');
-        }
+        showToast(result.message || 'Workout plan cleared successfully!');
+        fetchWorkoutPlan(); // Refresh the table to show empty state
+        notifyVolumeAffectingPlanChange('clear-workout-plan');
     } catch (error) {
         console.error('Error clearing workout plan:', error);
         showToast(`Unable to clear workout plan: ${error.message}`, true);

--- a/static/js/modules/fetch-wrapper.js
+++ b/static/js/modules/fetch-wrapper.js
@@ -58,7 +58,7 @@ function normalizeError(error, requestId) {
     if (error.ok === false && error.error) {
         return {
             code: error.error.code || 'UNKNOWN_ERROR',
-            message: error.error.message || 'An unexpected error occurred',
+            message: error.error.message || error.message || 'An unexpected error occurred',
             requestId: error.error.requestId || requestId
         };
     }
@@ -69,6 +69,16 @@ function normalizeError(error, requestId) {
             code: 'NETWORK_ERROR',
             message: error.message || 'Network error occurred',
             requestId: requestId
+        };
+    }
+
+    // Preserve legacy/non-standard JSON error payloads that expose only a
+    // top-level message. Raw callers surfaced this text before consolidation.
+    if (error && typeof error === 'object' && typeof error.message === 'string') {
+        return {
+            code: error.code || 'UNKNOWN_ERROR',
+            message: error.message,
+            requestId: error.requestId || requestId
         };
     }
 
@@ -114,6 +124,7 @@ function delay(ms) {
  * @param {any} options.body - Request body
  * @param {boolean} options.showLoading - Show loading indicator (default: true)
  * @param {boolean} options.showErrorToast - Show error toast on failure (default: true)
+ * @param {boolean} options.useDefaultHeaders - Merge shared JSON headers (default: true)
  * @param {number} options.retries - Number of retries for idempotent requests (default: 2 for GET, 0 for others)
  * @param {number} options.retryDelay - Delay between retries in ms (default: 1000)
  * @returns {Promise<Object>} Response data
@@ -125,6 +136,7 @@ export async function apiFetch(url, options = {}) {
         body = null,
         showLoading = true,
         showErrorToast = true,
+        useDefaultHeaders = true,
         retries = method === 'GET' ? 2 : 0,
         retryDelay = 1000,
         ...fetchOptions
@@ -141,7 +153,7 @@ export async function apiFetch(url, options = {}) {
         'X-Request-ID': requestId,
     };
     
-    const mergedHeaders = { ...defaultHeaders, ...headers };
+    const mergedHeaders = useDefaultHeaders ? { ...defaultHeaders, ...headers } : headers;
     
     // If body is an object, stringify it
     const processedBody = body && typeof body === 'object' ? JSON.stringify(body) : body;

--- a/static/js/modules/filters.js
+++ b/static/js/modules/filters.js
@@ -219,29 +219,32 @@ async function clearFilters() {
     
     // Reload all exercises in the exercise dropdown
     try {
-        const response = await fetch("/get_all_exercises");
-        if (response.ok) {
-            const exercises = await response.json();
-            if (exerciseDropdown && Array.isArray(exercises)) {
-                // Clear existing options
-                exerciseDropdown.innerHTML = '<option value="">Select Exercise</option>';
-                
-                // Add all exercises
-                exercises.forEach(exercise => {
-                    if (exercise) {
-                        const option = document.createElement("option");
-                        option.value = exercise;
-                        option.textContent = exercise;
-                        exerciseDropdown.appendChild(option);
-                    }
-                });
-                
-                // Remove filter-applied class if it exists
-                exerciseDropdown.classList.remove('filter-applied', 'filtered');
-                
-                // Trigger rebuild event for enhanced dropdown
-                exerciseDropdown.dispatchEvent(new CustomEvent('wpdd-rebuild', { bubbles: true }));
-            }
+        const response = await api.get("/get_all_exercises", {
+            showLoading: false,
+            showErrorToast: false,
+            useDefaultHeaders: false,
+            retries: 0
+        });
+        const exercises = response.data;
+        if (exerciseDropdown && Array.isArray(exercises)) {
+            // Clear existing options
+            exerciseDropdown.innerHTML = '<option value="">Select Exercise</option>';
+
+            // Add all exercises
+            exercises.forEach(exercise => {
+                if (exercise) {
+                    const option = document.createElement("option");
+                    option.value = exercise;
+                    option.textContent = exercise;
+                    exerciseDropdown.appendChild(option);
+                }
+            });
+
+            // Remove filter-applied class if it exists
+            exerciseDropdown.classList.remove('filter-applied', 'filtered');
+
+            // Trigger rebuild event for enhanced dropdown
+            exerciseDropdown.dispatchEvent(new CustomEvent('wpdd-rebuild', { bubbles: true }));
         }
     } catch (error) {
         console.error("Error reloading exercises:", error);

--- a/static/js/modules/session-summary.js
+++ b/static/js/modules/session-summary.js
@@ -25,6 +25,7 @@ import {
     getSubcategoryTooltip,
 } from './summary-helpers.js';
 import { getSessionWarningBadge } from './session-summary-helpers.js';
+import { api } from './fetch-wrapper.js';
 
 // Function to update the session summary table based on the selected modes
 async function updateSessionSummary() {
@@ -53,15 +54,18 @@ async function updateSessionSummary() {
             contribution_mode: contributionMode
         });
 
-        const response = await fetch(`/session_summary?${params.toString()}`, {
+        const result = await api.get(`/session_summary?${params.toString()}`, {
             headers: {
                 "Accept": "application/json",
                 "X-Requested-With": "XMLHttpRequest"
-            }
+            },
+            showLoading: false,
+            showErrorToast: false,
+            useDefaultHeaders: false,
+            retries: 0
         });
 
-        const result = await response.json();
-        if (!response.ok || isApiFailure(result)) {
+        if (isApiFailure(result)) {
             throw new Error(getApiErrorMessage(result, "Failed to fetch session summary."));
         }
 

--- a/static/js/modules/volume-splitter.js
+++ b/static/js/modules/volume-splitter.js
@@ -1,4 +1,5 @@
 import { showToast } from './toast.js';
+import { api } from './fetch-wrapper.js';
 
 let volumeConfig = null;
 let currentMode = 'basic';
@@ -19,52 +20,6 @@ const JSON_REQUEST_HEADERS = {
 };
 
 const deepClone = (value) => JSON.parse(JSON.stringify(value || {}));
-
-const isWrappedApiResponse = (payload) => Boolean(
-    payload &&
-    typeof payload === 'object' &&
-    !Array.isArray(payload) &&
-    'data' in payload &&
-    (payload.ok === true || payload.status === 'success' || payload.success === true)
-);
-
-const isApiFailure = (payload) => Boolean(
-    payload &&
-    typeof payload === 'object' &&
-    (payload.ok === false || payload.success === false)
-);
-
-const unwrapApiPayload = (payload) => (isWrappedApiResponse(payload) ? payload.data : payload);
-
-const getApiErrorMessage = (payload, fallbackMessage) => {
-    if (!payload || typeof payload !== 'object') {
-        return fallbackMessage;
-    }
-
-    if (payload.error && typeof payload.error === 'object' && typeof payload.error.message === 'string') {
-        return payload.error.message;
-    }
-
-    if (typeof payload.error === 'string') {
-        return payload.error;
-    }
-
-    if (typeof payload.message === 'string' && payload.message.trim()) {
-        return payload.message;
-    }
-
-    return fallbackMessage;
-};
-
-async function parseJsonResponse(response, fallbackMessage) {
-    const payload = await response.json();
-
-    if (!response.ok || isApiFailure(payload)) {
-        throw new Error(getApiErrorMessage(payload, fallbackMessage));
-    }
-
-    return unwrapApiPayload(payload);
-}
 
 const toNumericRange = (range) => {
     const fallback = { min: 12, max: 20 };
@@ -161,20 +116,21 @@ function calculateVolume() {
     modeVolumeState[currentMode] = volumes;
     modeRangeState[currentMode] = ranges;
 
-    fetch('/api/calculate_volume', {
-        method: 'POST',
+    api.post('/api/calculate_volume', {
+        mode: currentMode,
+        training_days: trainingDays,
+        volumes,
+        ranges
+    }, {
         headers: {
             'Content-Type': 'application/json',
             ...JSON_REQUEST_HEADERS
         },
-        body: JSON.stringify({
-            mode: currentMode,
-            training_days: trainingDays,
-            volumes,
-            ranges
-        })
+        showLoading: false,
+        showErrorToast: false,
+        useDefaultHeaders: false
     })
-        .then(response => parseJsonResponse(response, 'Failed to calculate volume.'))
+        .then(response => response.data)
         .then(handleCalculateResponse)
         .catch(error => {
             console.error('Error calculating volume:', error);
@@ -228,10 +184,14 @@ function resetValues() {
 }
 
 function loadPlan(planId) {
-    fetch(`/api/volume_plan/${planId}`, {
-        headers: JSON_REQUEST_HEADERS
+    api.get(`/api/volume_plan/${planId}`, {
+        headers: JSON_REQUEST_HEADERS,
+        showLoading: false,
+        showErrorToast: false,
+        useDefaultHeaders: false,
+        retries: 0
     })
-        .then(response => parseJsonResponse(response, 'Failed to load plan.'))
+        .then(response => response.data)
         .then(plan => {
             const trainingSelect = document.getElementById('training-days');
             if (trainingSelect) {
@@ -284,11 +244,13 @@ function deletePlan(planId) {
 }
 
 function executeDeletePlan(planId) {
-    fetch(`/api/volume_plan/${planId}`, {
-        method: 'DELETE',
-        headers: JSON_REQUEST_HEADERS
+    api.delete(`/api/volume_plan/${planId}`, {
+        headers: JSON_REQUEST_HEADERS,
+        showLoading: false,
+        showErrorToast: false,
+        useDefaultHeaders: false
     })
-    .then(response => parseJsonResponse(response, 'Failed to delete volume plan.'))
+    .then(response => response.data)
     .then(result => {
         if (deleteModal) deleteModal.hide();
         showToast('success', result?.message || 'Volume plan deleted successfully!');
@@ -316,15 +278,16 @@ function exportVolumePlan(activate = false) {
         activate
     };
     
-    fetch('/api/save_volume_plan', {
-        method: 'POST',
+    api.post('/api/save_volume_plan', data, {
         headers: {
             'Content-Type': 'application/json',
             ...JSON_REQUEST_HEADERS
         },
-        body: JSON.stringify(data)
+        showLoading: false,
+        showErrorToast: false,
+        useDefaultHeaders: false
     })
-    .then(response => parseJsonResponse(response, 'Failed to save volume plan.'))
+    .then(response => response.data)
     .then(result => {
         const planId = result?.plan_id;
         if (!planId) {
@@ -384,10 +347,14 @@ function displaySuggestions(suggestions) {
 }
 
 function loadVolumeHistory() {
-    return fetch('/api/volume_history', {
-        headers: JSON_REQUEST_HEADERS
+    return api.get('/api/volume_history', {
+        headers: JSON_REQUEST_HEADERS,
+        showLoading: false,
+        showErrorToast: false,
+        useDefaultHeaders: false,
+        retries: 0
     })
-        .then(response => parseJsonResponse(response, 'Failed to load volume history.'))
+        .then(response => response.data)
         .then(history => {
             const tbody = document.getElementById('history-body');
             tbody.innerHTML = '';
@@ -827,14 +794,13 @@ function handleHistoryClick(event) {
 
 function toggleActivePlan(planId, isActive) {
     const endpoint = `/api/volume_plan/${planId}/${isActive ? 'deactivate' : 'activate'}`;
-    fetch(endpoint, {
-        method: 'POST',
-        headers: JSON_REQUEST_HEADERS
+    api.post(endpoint, null, {
+        headers: JSON_REQUEST_HEADERS,
+        showLoading: false,
+        showErrorToast: false,
+        useDefaultHeaders: false
     })
-        .then(response => parseJsonResponse(
-            response,
-            isActive ? 'Failed to deactivate volume plan.' : 'Failed to activate volume plan.'
-        ))
+        .then(response => response.data)
         .then(() => {
             showToast('success', isActive ? `Plan #${planId} deactivated.` : `Plan #${planId} activated for Plan tab.`);
             loadVolumeHistory();

--- a/static/js/modules/weekly-summary.js
+++ b/static/js/modules/weekly-summary.js
@@ -24,20 +24,24 @@ import {
     getCategoryTooltip,
     getSubcategoryTooltip,
 } from './summary-helpers.js';
+import { api } from './fetch-wrapper.js';
 
 // Function to fetch and display pattern coverage
 async function updatePatternCoverage() {
     const container = document.getElementById('pattern-coverage-container');
 
     try {
-        const response = await fetch('/api/pattern_coverage', {
+        const result = await api.get('/api/pattern_coverage', {
             headers: {
                 "Accept": "application/json",
                 "X-Requested-With": "XMLHttpRequest"
-            }
+            },
+            showLoading: false,
+            showErrorToast: false,
+            useDefaultHeaders: false,
+            retries: 0
         });
-        const result = await response.json();
-        if (!response.ok || isApiFailure(result)) {
+        if (isApiFailure(result)) {
             throw new Error(getApiErrorMessage(result, 'Failed to fetch pattern coverage'));
         }
 
@@ -174,15 +178,18 @@ async function updateWeeklySummary() {
     }
 
     try {
-        const response = await fetch(`/weekly_summary?contribution_mode=${contributionMode}`, {
+        const result = await api.get(`/weekly_summary?contribution_mode=${contributionMode}`, {
             headers: {
                 "Accept": "application/json",
                 "X-Requested-With": "XMLHttpRequest"
-            }
+            },
+            showLoading: false,
+            showErrorToast: false,
+            useDefaultHeaders: false,
+            retries: 0
         });
 
-        const result = await response.json();
-        if (!response.ok || isApiFailure(result)) {
+        if (isApiFailure(result)) {
             throw new Error(getApiErrorMessage(result, "Failed to fetch weekly summary."));
         }
 

--- a/static/js/welcome.js
+++ b/static/js/welcome.js
@@ -20,13 +20,13 @@
 
         confirmEraseBtn.addEventListener('click', async function() {
             try {
-                const response = await fetch('/erase-data', {
-                    method: 'POST',
+                const { api } = await import('./modules/fetch-wrapper.js');
+                const data = await api.post('/erase-data', { confirm: 'ERASE_ALL_DATA' }, {
                     headers: { 'Content-Type': 'application/json' },
-                    body: JSON.stringify({ confirm: 'ERASE_ALL_DATA' })
+                    showLoading: false,
+                    showErrorToast: false,
+                    useDefaultHeaders: false
                 });
-
-                const data = await response.json();
 
                 if (data.ok) {
                     eraseDataModal.hide();


### PR DESCRIPTION
## Summary

- migrate all 14 remaining production JSON endpoint calls to the shared `apiFetch` / `api` transport
- remove volume-splitter's local response-envelope/error wrapper and consume the shared envelope directly
- preserve exact migrated headers, retries, loading ownership, error-toast ownership, methods, and bodies
- document the repository-wide before/after raw-fetch inventory and every retained exception
- add focused wrapper compatibility and raw blob/download tests

## Invariants

- mechanical WP3.5 transport consolidation only; no endpoint, payload, response-envelope, database, calculation, UI, styling, copy, loading-state, toast, retry, or event-timing changes
- existing public imports/exports/globals and template script order remain intact
- no binary or static-text resource is routed through the JSON wrapper
- no WP3.6, Phase 4, bodymap behavior, heatmap, or screenshot-baseline work
- `data/database.db` and all runtime artifacts are excluded

## Inventory

Before: 23 tracked raw-fetch calls:
- 14 JSON application endpoints
- 2 static SVG/text assets
- 3 blob/download calls
- 1 shared transport implementation
- 3 direct test/harness probes
- 0 dead/unreachable tracked calls

After: 9 tracked raw-fetch calls, all intentional:
- `bodymap-svg.js` and `muscle-selector.js`: static SVG text
- `exports.js` (2) and `volume-splitter.js` (1): blob/download responses and existing filenames
- `fetch-wrapper.js`: underlying browser transport boundary
- `error-handling.spec.ts` (2) and `puppeteer_mcp_summary_regression.py` (1): independent browser endpoint probes

Shared transport now has 60 calls across 21 production caller files. Full classification and justification: `docs/WP3_5_FETCH_INVENTORY.md`.

## Verification

- `git diff --check`: passed
- `npx tsc --noEmit`: passed
- `npm run test:js`: 93 passed (8 files)
- `.venv/Scripts/python.exe -m pytest tests/ -q`: 1717 passed
- Chromium targeted functional sweep: 263 passed, covering:
  - api-integration
  - volume-splitter
  - volume-progress
  - workout-plan
  - workout-log
  - user-profile
  - smoke-navigation
  - summary-pages
  - error-handling
  - erase-flow
  - empty-states
  - exercise-interactions
- retained static SVG loads explicitly returned 200 during Chromium coverage
- retained `/export_to_excel` and `/api/export_volume_excel` blob paths passed live Chromium coverage
- focused unit coverage verifies both `exports.js` raw blob paths and their preserved filenames
- direct Puppeteer summary harness attempted twice with a fresh temporary DB and isolated server; both attempts loaded the migrated modules/endpoints, then its MCP subprocess returned a response without `result` and the harness raised `KeyError: 'result'` before assertions. The equivalent summary paths passed in the 263-test Chromium sweep.