### PR TITLE
ci(security-audit): upgrade setuptools>=83.0.0 to clear PYSEC-2026-3447

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,7 +25,9 @@ jobs:
       run: |
         python -m pip install --upgrade pip
         pip install -r requirements.txt
-        
+        # PYSEC-2026-3447 affects setuptools 79.0.1; upgrade to the fixed release.
+        python -m pip install --upgrade "setuptools>=83.0.0"
+
     - name: Run pip-audit
       run: |
         pip install pip-audit


### PR DESCRIPTION
## What
Upgrade setuptools to >=83.0.0 in the Security Audit CI job so pip-audit no
longer reports PYSEC-2026-3447.

## Why
pip-audit (required `Security Audit` check) fails on PYSEC-2026-3447 in
setuptools 79.0.1. A fixed release exists (83.0.0), so we upgrade to the fixed
release without suppressing the advisory.

## Change (one line, security-audit job only)
Appended after `pip install -r requirements.txt`, before pip-audit runs:

    python -m pip install --upgrade "setuptools>=83.0.0"

## Verification (CI steps reproduced in an isolated venv)
- Baseline setuptools 79.0.1: pip-audit flags PYSEC-2026-3447 (fix 83.0.0), non-zero exit.
- After upgrade: setuptools 83.0.0; `pip-audit --desc --ignore-vuln CVE-2026-3219`
  exits 0, "No known vulnerabilities found"; PYSEC-2026-3447 gone.

## Notes
- Fixed release, not an ignore: no advisory suppression added for PYSEC-2026-3447.
- CVE-2026-3219 (pip, no upstream fix yet) handling is unchanged.
- Only `.github/workflows/ci.yml` changes — no app/test/dependency-manifest/DB changes.
- Does NOT touch PR #156's branch, files, or diff.
