### PR TITLE
docs: reconcile status trackers with pushed state (#156/#158)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -172,7 +172,10 @@ npx playwright test --project=chromium --reporter=line
 
 ## 5. Current State & Risks
 
-### Verified test counts (2026-07-19 — Phase 3 through WP4.3d integrated locally)
+> **2026-07-19 UPDATE — everything below is now PUSHED. `main` == `origin/main` at `bdec996`.**
+> The per-WP "Nothing was pushed" notes below are **historical point-in-time records**, no longer the current state. The full WP4.0–WP4.3d line + the origin-only security fix #157 landed on `origin/main` via **PR #158** (`ae081cd`); the Agent Workflow v2 line (agent charters + KI-005 controls-persistence feature) landed via **PR #156** (`bdec996`). Local `main` was fast-forwarded to match; no worktree divergence remains. **Phase 5 of Agent Workflow v2 (end-to-end dry-run on KI-005) ran and shipped** — evidence in `docs/ki005_controls_persistence/PLANNING.md` (Gate 0 2026-07-12, Gate 1 rulings 2026-07-12/07-13, blind automation-qa tests, council review).
+
+### Verified test counts (2026-07-19 — Phase 3 through WP4.3d; now pushed to origin/main via #158)
 - WP4.2 was integrated into local `main` by history-preserving merge `d695188`;
   its documentation closeout is `e9062bc`. Nothing was pushed.
 - WP4.3a is complete in isolated `wt/wp4-3-backup-dark-token-cleanup`: contracts

--- a/docs/MASTER_HANDOVER.md
+++ b/docs/MASTER_HANDOVER.md
@@ -4,6 +4,19 @@
 
 ## Current State
 
+> **2026-07-19 (LATEST) — everything below is now PUSHED; `main` == `origin/main`
+> at `bdec996`.** The dated entries below that end with "Nothing was pushed" are
+> **historical point-in-time records**, superseded by this note. The whole
+> WP4.0–WP4.3d line plus the origin-only security fix #157 reached `origin/main`
+> via **PR #158** (`ae081cd`); the Agent Workflow v2 line — agent charters and the
+> KI-005 Workout-Controls persistence feature — reached it via **PR #156**
+> (`bdec996`). Local `main` was fast-forwarded to match; no worktree divergence
+> remains. **Agent Workflow v2 Phase 5 (end-to-end dry-run on KI-005) ran and
+> shipped** — full gate evidence in `docs/ki005_controls_persistence/PLANNING.md`
+> (Gate 0 2026-07-12; Gate 1 owner rulings 2026-07-12 and 2026-07-13; blind
+> `automation-qa` acceptance tests; council review). The `wt/agent-workflow`
+> worktree branch is fully merged and can be retired.
+>
 > **2026-07-19 — WP4.3d Volume Splitter dark/token cleanup integrated locally as
 > merge `40bc09f`.** Exact repeated status,
 > accent, heading, and dark-surface values now use page-local semantic tokens.


### PR DESCRIPTION
## Summary
Documentation-only. Reconciles the status trackers with the now-pushed state of the repo.

- **CLAUDE.md §5** and **docs/MASTER_HANDOVER.md** gained a `2026-07-19` current-state banner: `main == origin/main` at `bdec996`. The WP4.0–WP4.3d line + security fix #157 landed via **#158**; Agent Workflow v2 (agent charters + KI-005 Workout-Controls persistence feature) landed via **#156**. The older per-WP "Nothing was pushed" notes are preserved but marked historical.
- Records that **Agent Workflow v2 Phase 5** (end-to-end dry-run on KI-005) ran and shipped — evidence in `docs/ki005_controls_persistence/PLANNING.md` (Gate 0, two Gate 1 owner rulings, blind automation-qa tests, council review). The `wt/agent-workflow` worktree branch is fully merged and can be retired.

## Verification
Docs only — no code, schema, or API change. Falls under the "Product docs only" quality-gate row.

🤖 Generated with [Claude Code](https://claude.com/claude-code)