### PR TITLE
refactor(css): clean up Welcome dark tokens (WP4.3e)

### DIFF
--- a/docs/CSS_PHASE4_WP4_3E_EVIDENCE.md
+++ b/docs/CSS_PHASE4_WP4_3E_EVIDENCE.md
@@ -1,0 +1,182 @@
+# CSS Phase 4 WP4.3e Evidence — Welcome Dark/Token Cleanup
+
+Date: 2026-07-19
+
+Branch: `wt/wp4-3-welcome-dark-token-cleanup`
+
+Base: local `main` at `859ccea8b15a400188d9c5fe066d2fb1bc969d24`
+
+## Scope and isolation
+
+WP4.3e changed only the Welcome route bundle in production:
+`static/css/pages-welcome.css`. The companion change in
+`tests/test_css_cascade_contracts.py` pins the preserved cascade contract; this
+evidence file and the canonical handover documents are the only documentation
+changes. No template, JavaScript, API, schema, calculation, shared CSS,
+`theme-dark.css`, another page, or WP4.4 work is included. The production/test
+working diff is two files (+100 / -44).
+
+The isolated worktree started from base `859ccea` on branch
+`wt/wp4-3-welcome-dark-token-cleanup`. The worktree's seeded database and the
+tracked visual fixture both have SHA-256
+`6477B2AC0F91248F7022D1B7AAE60B98586CB13EC4D94CC37294D4115F0AE6E3`.
+
+## Changes
+
+Two behavior-preserving transformations, both exact-value:
+
+1. **Exact-repeat white-ink and translucent-white overlays extracted to four
+   page-local semantic tokens.** `--wl-on-accent: #ffffff` replaces every
+   `#ffffff !important` / `#ffffff` white-ink site on the featured bento card,
+   hero button ink, and developer-credit banner; `--wl-overlay-soft`
+   (`rgba(255, 255, 255, 0.15)`), `--wl-overlay-strong`
+   (`rgba(255, 255, 255, 0.25)`), and `--wl-overlay-border`
+   (`rgba(255, 255, 255, 0.4)`) replace the exact repeated translucent-white
+   surface/border expressions. Only exact repeated expressions were replaced; no
+   near-match (the brand accent/gradient literals `#1e40af`, `#3b82f6`,
+   `#2563eb`, `#1d4ed8`, the `#0d9488`/`#14b8a6` featured gradients, the
+   shimmer/credit multi-stop gradients, `#fff` shorthand color declarations, and
+   the other `rgba(255, 255, 255, *)` alphas at 0.2/0.7/0.9) was normalized.
+
+2. **Seven dead (unreferenced) custom properties removed outright.** Each was
+   proven to have zero `var()` consumers repo-wide, in both HEAD and the final
+   file:
+   - `--wl-featured-start`, `--wl-featured-end`, `--wl-featured-gradient` — a
+     dead chain: `--wl-featured-gradient` (0 consumers) was the only consumer of
+     `--wl-featured-start`/`--wl-featured-end`; the featured cards paint
+     hardcoded `linear-gradient(135deg, #0d9488 0%, #14b8a6 100%)` (light) and
+     `#0f766e 0%, #14b8a6 100%` (dark) `!important` gradients directly, so the
+     token trio and its dark-mode remap were never rendered. The live hardcoded
+     gradients and the `[data-theme='dark'] #welcome .bento-featured` override
+     remain.
+   - `--wl-accent-glow`, `--wl-shadow-glow` — a second dead chain:
+     `--wl-shadow-glow` (0 consumers) was the only consumer of
+     `--wl-accent-glow`.
+   - `--wl-info` — 0 consumers.
+   - `--wl-duration-slow` — 0 consumers (including its reduced-motion `0ms`
+     remap).
+
+Because every removed declaration is an unused CSS variable and every
+substitution is exact-value, no competing declaration on any rendered element was
+changed and no cascade winner moved. `#ffffff` now appears only in the
+`--wl-surface` and `--wl-on-accent` definitions. No document-wide `:has()`
+selector was introduced.
+
+## Rendered equivalence
+
+The focused Welcome visual suite renders all six Windows variants (desktop /
+tablet / mobile × light / dark) **byte-identical** to their committed baselines,
+update-free. Because the visual comparison checks every pixel, it is a strict
+superset of a sampled computed-value audit: it proves the token extraction and
+dead-variable removal produce zero rendered change in either theme. All twelve
+committed Welcome images (six Linux + six Windows) are byte-identical to base.
+
+## Contract lock
+
+`test_welcome_tokens_extract_exact_values_without_dead_custom_properties` pins:
+
+- stylesheet load order (a11y before the page bundle, page bundle before
+  `motion.css` before `theme-dark.css`) and the absence of document-wide
+  `html:has()`;
+- each of the four new page-local tokens defined once and consumed by at least
+  its exact-repeat replacement count (`--wl-on-accent` ≥21, `--wl-overlay-strong`
+  ≥5, `--wl-overlay-soft` ≥3, `--wl-overlay-border` ≥2);
+- the seven removed dead custom properties are absent;
+- no raw white `!important`/plain literal survives outside the two token
+  definitions (`#ffffff` count == 2; each removed `rgba(255, 255, 255, *)`
+  overlay literal appears exactly once, in its token definition);
+- the live featured hardcoded `!important` gradient, the dark featured override,
+  all three responsive breakpoints (1024/768/480px), and the
+  `id="welcome" data-page="welcome"` template hook.
+
+The combined selector/cascade + visual-selector contract gate is now **17/17**.
+
+## Stylelint measurement
+
+Pinned Stylelint `16.11.0` with `postcss-scss` parsed all measured sources with
+zero parse errors, invalid-option warnings, or errored files.
+
+| Measurement | pre-edit (HEAD) | WP4.3e final | Delta |
+| --- | ---: | ---: | ---: |
+| Focused Welcome warnings | 144 | 111 | -33 |
+| Focused hardcoded-value (`declaration-property-value-disallowed-list`) | 96 | 63 | -33 |
+| Focused `declaration-no-important` | 33 | 33 | 0 |
+| Focused `no-descending-specificity` | 15 | 15 | 0 |
+| Total warnings (all CSS/SCSS) | 6,364 | 6,331 | -33 |
+
+No monitored important, specificity, or duplicate category increased. Cumulative
+delta vs the WP4.1 pinned baseline (7,202) is -871.
+
+## Verification
+
+| Gate | Result |
+| --- | --- |
+| `git diff --check` | passed |
+| worktree isolation (commits ahead/behind main pre-commit) | 0 / 0 (working-tree change only) |
+| selector/cascade + visual contracts | 17/17 passed |
+| blocking Flake8 selection (changed test) | 0 findings |
+| TypeScript `tsc --noEmit` | passed |
+| Vitest | 105/105 passed |
+| focused Welcome Chromium visual | 6/6 passed update-free |
+| Welcome functional (erase-flow + smoke-navigation) | 12/12 passed |
+| required CI Chromium functional list (2-shard) | 215/215 + 211/211 = 426/426 passed |
+| tracked-file pytest | 1,738 passed + 2 permitted catalog reds |
+
+The required functional list has grown from 407 (WP4.3d) to 426 as later work
+added specs; it was run with the canonical two-shard topology and a freshly
+seeded throwaway database per shard, 0 failures and 0 flakes. The only pytest
+failures were the unchanged visual-seed catalog invariants: 633 null/blank
+`primary_muscle_group` rows and 454 null/blank `movement_pattern` rows. The
+additional Python pass relative to WP4.3d is the new Welcome cascade contract.
+
+Every visual command used `PW_VISUAL_SEED=1`; no command used
+`--update-snapshots`.
+
+| Visual suite | Result |
+| --- | --- |
+| all six Windows Welcome variants | 6/6 passed update-free |
+| complete `visual.spec.ts` | 59 passed + only workout-plan desktop-dark at exactly 1,039 pixels (initial 1,046, settling to 1,039 on retry) |
+| complete thumbnail suite | 1 passed + only plan-desktop-light-advanced at exactly 6,262 pixels (initial 6,276, settling to 6,262 on retry) + 16 not run |
+
+Both persistent reds are the exact WP4.0 known reds on the workout-plan page,
+which this Welcome-only change does not touch.
+
+## Integrity locks
+
+- Screenshot manifest: **156 files, 0 mismatches** against main; worktree
+  aggregate SHA-256
+  `93803A55BB5620F80557A9DCF85AB4CEC007A79B914B8F855EE644D00DB4C117`.
+- Generated Bootstrap SHA-256: main checkout
+  `24CC9F443D2D0933F1C89DC7203B0618063C4706ADE17627F0A03934C73D75D4`;
+  isolated worktree
+  `0F9E198319318E2DB274D7AA15CECD0CF536727D25A925B7C8C71BE6F9DEA68B`
+  (the established worktree-vs-main generated-bundle divergence recorded since
+  WP4.3a; the CSS change does not touch it).
+- Target worktree and visual-fixture DB SHA-256:
+  `6477B2AC0F91248F7022D1B7AAE60B98586CB13EC4D94CC37294D4115F0AE6E3`.
+- Main live DB SHA-256:
+  `36ECD8B4EBF747DFA8CFCECF1D1C1C54A6ABFEDF89B66C3AD33B73ABC852071F`.
+
+The twelve committed Welcome images remained byte-identical:
+
+| Platform / variant | SHA-256 |
+| --- | --- |
+| Linux desktop dark | `BBE70FC109AAD83F2ABEA1A45B622DB18E36EC06402EEF09D8368C13775B988D` |
+| Linux desktop light | `C9D69654FD5B7E60ACBCACD99E9A6B2E28B302E7D53A2326C8A31EE003B23008` |
+| Linux mobile dark | `65C904EA47222C637BFDA8F5111DC02CD6B8437114C9C087D8B40C7C3E66A985` |
+| Linux mobile light | `01A617CCCCF95E1C16DCB341447BC08624D27114975E0D2E29739D4429053961` |
+| Linux tablet dark | `DFA0ADC97ABFC2E1B878132765D83DE411AA2B661DB90726F1CA88230EBE4E06` |
+| Linux tablet light | `E24CFCE52191061D8CA7CE31A1F234A4DE139CB08C725E651B57D138FCC70EE6` |
+| Windows desktop dark | `CF9D0B9589A28608FB007CE470EAE07185DE1D78CFABB256C23AA926ED37F2E0` |
+| Windows desktop light | `5F9223CC5F9213279A9217845272D175EB9A4FD8A2DD99E0FAE5D8C2CC206152` |
+| Windows mobile dark | `60B6D8465F36A32863417EC9E633BAD2EEFCC9892BDF54F16891DD586C9D7D61` |
+| Windows mobile light | `12A1ADD26B76BF9321306143F51419206C882703EC31516EAB5CD9A783F7C674` |
+| Windows tablet dark | `144440DB3658099BEFBDA362C38E195A8BE710124558F308BB0854B384ABC8C1` |
+| Windows tablet light | `DDB7E2ABAFFF8D09CC2CD20FCA028D62BDD841DECD636601AB5E92A7FD442F3E` |
+
+## Next action
+
+WP4.3e is complete in isolated `wt/wp4-3-welcome-dark-token-cleanup`. Awaiting
+owner direction to integrate into local `main` by history-preserving merge and
+whether to push. Do not begin Session Summary, another WP4.3 page, or WP4.4
+without explicit direction.

--- a/docs/REFACTOR_PLAN.md
+++ b/docs/REFACTOR_PLAN.md
@@ -5,7 +5,9 @@ WP4.0, WP4.1, WP4.2, WP4.3a, WP4.3b, WP4.3c, and WP4.3d are complete. WP2.2 is c
 committed as `0cbedac`. WP4.0 measurement provenance remains unchanged head
 `e46b67e`, with its ledger committed as `ca725c2`. Local integration verification
 is complete through WP4.3d: its history-preserving local merge is `40bc09f` and
-the narrow post-merge gates passed. Nothing was pushed. Welcome and later packets have not started.
+the narrow post-merge gates passed. Nothing was pushed. WP4.3e (Welcome) is
+complete in isolated `wt/wp4-3-welcome-dark-token-cleanup` and awaits owner
+integration direction; Session Summary and later packets have not started.
 Track B is mostly shipped; WPB.4 remains unimplemented
 and product-risk gated.**
 
@@ -1001,6 +1003,32 @@ integrated into local `main` as merge `40bc09f`; narrow post-merge gates passed,
 all protected identities remained unchanged, and nothing was pushed. Leave its
 isolated worktree and branch for review and wait for explicit direction before
 another packet.
+
+**WP4.3e Welcome completed 2026-07-19 in isolated
+`wt/wp4-3-welcome-dark-token-cleanup`.** The exact repeated white-ink and
+translucent-white overlay expressions now use four page-local semantic tokens
+(`--wl-on-accent`, `--wl-overlay-soft`, `--wl-overlay-strong`,
+`--wl-overlay-border`); no near-match brand accent/gradient literal was
+normalized. Seven dead (zero-`var()`-consumer) custom properties were removed
+outright — the `--wl-featured-start`/`-end`/`-gradient` trio (the cards paint
+their hardcoded `!important` gradients directly), the
+`--wl-accent-glow`/`--wl-shadow-glow` chain, `--wl-info`, and
+`--wl-duration-slow`. Every substitution is exact-value and every removal is an
+unused variable, so no rendered element's cascade winner moved; the live
+featured gradients, dark override, and all three breakpoints remain. Pinned
+Stylelint falls **6,364 → 6,331** (focused Welcome **144 → 111**, all -33 in
+hardcoded values), with important, specificity, and duplicate counts unchanged.
+Contracts **17/17**, focused Welcome Chromium visual **6/6** update-free,
+required Chromium **426/426** (the list grew from 407 as later specs landed), and
+pytest **1,738 + 2 catalog known-reds** match the expected gates. All six Windows
+Welcome variants pass; all twelve committed Welcome images and every integrity
+lock are unchanged. Full visuals reproduce only the exact WP4.0 known reds
+(workout-plan desktop-dark 1,039 px; plan-desktop-light-advanced 6,262 px).
+Evidence: [`CSS_PHASE4_WP4_3E_EVIDENCE.md`](CSS_PHASE4_WP4_3E_EVIDENCE.md). The
+packet is committed on its isolated branch and **not yet integrated**; awaiting
+owner direction on the history-preserving merge and whether to push. Leave the
+worktree and branch for review and wait for explicit direction before Session
+Summary or another packet.
 
 ### WP4.4 Shared bundles, navbar, and `theme-dark.css`
 

--- a/static/css/pages-welcome.css
+++ b/static/css/pages-welcome.css
@@ -33,21 +33,20 @@
     --wl-accent: #2563eb;
     --wl-accent-hover: #1d4ed8;
     --wl-accent-light: rgba(37, 99, 235, 0.08);
-    --wl-accent-glow: rgba(37, 99, 235, 0.25);
     --wl-gradient-start: #1e40af;
     --wl-gradient-end: #3b82f6;
     --wl-gradient: linear-gradient(135deg, var(--wl-gradient-start) 0%, var(--wl-gradient-end) 100%);
 
-    /* Featured card - distinct teal/cyan */
-    --wl-featured-start: #0d9488;
-    --wl-featured-end: #14b8a6;
-    --wl-featured-gradient: linear-gradient(135deg, var(--wl-featured-start) 0%, var(--wl-featured-end) 100%);
+    /* On-accent ink and translucent white overlays (featured/credit surfaces) */
+    --wl-on-accent: #ffffff;
+    --wl-overlay-soft: rgba(255, 255, 255, 0.15);
+    --wl-overlay-strong: rgba(255, 255, 255, 0.25);
+    --wl-overlay-border: rgba(255, 255, 255, 0.4);
 
     /* Semantic Colors */
     --wl-success: var(--success);
     --wl-warning: var(--warning);
     --wl-danger: var(--danger);
-    --wl-info: #3b82f6;
 
     /* Borders & Shadows */
     --wl-border: rgba(0, 0, 0, 0.06);
@@ -55,7 +54,6 @@
     --wl-shadow-sm: 0 1px 3px rgba(0, 0, 0, 0.04), 0 1px 2px rgba(0, 0, 0, 0.06);
     --wl-shadow-md: 0 4px 12px rgba(0, 0, 0, 0.05), 0 2px 4px rgba(0, 0, 0, 0.04);
     --wl-shadow-lg: 0 12px 32px rgba(0, 0, 0, 0.08), 0 4px 8px rgba(0, 0, 0, 0.04);
-    --wl-shadow-glow: 0 0 40px var(--wl-accent-glow);
 
     /* Spacing */
     --wl-space-xs: 0.25rem;
@@ -79,7 +77,6 @@
     --wl-ease-spring: cubic-bezier(0.34, 1.56, 0.64, 1);
     --wl-duration-fast: var(--dur-fast);
     --wl-duration-base: 250ms;
-    --wl-duration-slow: 400ms;
   }
 
   /* Dark Mode */
@@ -97,10 +94,6 @@
     --wl-shadow-md: 0 4px 12px rgba(0, 0, 0, 0.3);
     --wl-shadow-lg: 0 12px 32px rgba(0, 0, 0, 0.4);
     --wl-accent-light: rgba(59, 130, 246, 0.15);
-
-    /* Dark mode featured - brighter for visibility */
-    --wl-featured-start: #0f766e;
-    --wl-featured-end: #14b8a6;
   }
 
   /* Reduced Motion */
@@ -108,7 +101,6 @@
     :root {
       --wl-duration-fast: 0ms;
       --wl-duration-base: 0ms;
-      --wl-duration-slow: 0ms;
     }
   }
 
@@ -216,27 +208,27 @@
 
   #welcome .btn-hero-primary {
     background: #1d4ed8 !important;
-    color: #ffffff !important;
+    color: var(--wl-on-accent) !important;
     box-shadow: 0 4px 14px rgba(29, 78, 216, 0.4);
     text-shadow: none;
   }
 
   #welcome .btn-hero-primary:hover {
     background: #1e40af !important;
-    color: #ffffff !important;
+    color: var(--wl-on-accent) !important;
     transform: translateY(-2px);
     box-shadow: 0 8px 20px rgba(29, 78, 216, 0.5);
   }
 
   [data-theme='dark'] #welcome .btn-hero-primary {
     background: #3b82f6 !important;
-    color: #ffffff !important;
+    color: var(--wl-on-accent) !important;
     box-shadow: 0 4px 14px rgba(59, 130, 246, 0.4);
   }
 
   [data-theme='dark'] #welcome .btn-hero-primary:hover {
     background: #2563eb !important;
-    color: #ffffff !important;
+    color: var(--wl-on-accent) !important;
     box-shadow: 0 8px 20px rgba(59, 130, 246, 0.5);
   }
 
@@ -245,7 +237,7 @@
   #welcome .btn-hero-primary .fas,
   [data-theme='dark'] #welcome .btn-hero-primary i,
   [data-theme='dark'] #welcome .btn-hero-primary .fas {
-    color: #ffffff !important;
+    color: var(--wl-on-accent) !important;
   }
 
   #welcome .btn-hero-secondary {
@@ -408,14 +400,14 @@
   #welcome .bento-featured {
     grid-column: span 2;
     background: linear-gradient(135deg, #0d9488 0%, #14b8a6 100%) !important;
-    color: #ffffff !important;
+    color: var(--wl-on-accent) !important;
     border: none;
     box-shadow: var(--wl-shadow-md), 0 4px 20px rgba(13, 148, 136, 0.3);
   }
 
   [data-theme='dark'] #welcome .bento-featured {
     background: linear-gradient(135deg, #0f766e 0%, #14b8a6 100%) !important;
-    color: #ffffff !important;
+    color: var(--wl-on-accent) !important;
   }
 
   #welcome .bento-featured:hover {
@@ -426,45 +418,45 @@
   #welcome .bento-featured h3,
   #welcome .bento-featured p,
   #welcome .bento-featured .bento-list li {
-    color: #ffffff !important;
+    color: var(--wl-on-accent) !important;
   }
 
   [data-theme='dark'] #welcome .bento-featured h3,
   [data-theme='dark'] #welcome .bento-featured p,
   [data-theme='dark'] #welcome .bento-featured .bento-list li {
-    color: #ffffff !important;
+    color: var(--wl-on-accent) !important;
   }
 
   #welcome .bento-featured .bento-icon-wrap {
-    background: rgba(255, 255, 255, 0.25) !important;
-    color: #ffffff !important;
+    background: var(--wl-overlay-strong) !important;
+    color: var(--wl-on-accent) !important;
   }
 
   [data-theme='dark'] #welcome .bento-featured .bento-icon-wrap {
-    background: rgba(255, 255, 255, 0.25) !important;
-    color: #ffffff !important;
+    background: var(--wl-overlay-strong) !important;
+    color: var(--wl-on-accent) !important;
   }
 
   #welcome .bento-featured .bento-link {
-    color: #ffffff !important;
-    border-color: rgba(255, 255, 255, 0.4) !important;
-    background: rgba(255, 255, 255, 0.15) !important;
+    color: var(--wl-on-accent) !important;
+    border-color: var(--wl-overlay-border) !important;
+    background: var(--wl-overlay-soft) !important;
   }
 
   [data-theme='dark'] #welcome .bento-featured .bento-link {
-    color: #ffffff !important;
-    border-color: rgba(255, 255, 255, 0.4) !important;
-    background: rgba(255, 255, 255, 0.15) !important;
+    color: var(--wl-on-accent) !important;
+    border-color: var(--wl-overlay-border) !important;
+    background: var(--wl-overlay-soft) !important;
   }
 
   #welcome .bento-featured .bento-link:hover {
-    background: rgba(255, 255, 255, 0.25) !important;
-    border-color: #ffffff !important;
+    background: var(--wl-overlay-strong) !important;
+    border-color: var(--wl-on-accent) !important;
   }
 
   [data-theme='dark'] #welcome .bento-featured .bento-link:hover {
-    background: rgba(255, 255, 255, 0.25) !important;
-    border-color: #ffffff !important;
+    background: var(--wl-overlay-strong) !important;
+    border-color: var(--wl-on-accent) !important;
   }
 
   #welcome .bento-icon-wrap {
@@ -514,11 +506,11 @@
   }
 
   #welcome .bento-featured .bento-list li i {
-    color: #ffffff !important;
+    color: var(--wl-on-accent) !important;
   }
 
   [data-theme='dark'] #welcome .bento-featured .bento-list li i {
-    color: #ffffff !important;
+    color: var(--wl-on-accent) !important;
   }
 
   #welcome .bento-tags {
@@ -822,7 +814,7 @@
     justify-content: center;
     gap: var(--wl-space-sm);
     font-size: var(--wl-fs-body);
-    color: #ffffff;
+    color: var(--wl-on-accent);
     position: relative;
     z-index: 1;
   }
@@ -846,30 +838,30 @@
 
   #welcome .developer-credit-banner .developer-link {
     text-decoration: none;
-    color: #ffffff;
+    color: var(--wl-on-accent);
     display: inline-flex;
     align-items: center;
     gap: var(--wl-space-xs);
     transition: all var(--wl-duration-fast) var(--wl-ease);
     padding: 4px 12px;
     border-radius: var(--wl-radius-sm);
-    background: rgba(255, 255, 255, 0.15);
+    background: var(--wl-overlay-soft);
   }
 
   #welcome .developer-credit-banner .developer-link:hover {
-    background: rgba(255, 255, 255, 0.25);
+    background: var(--wl-overlay-strong);
     transform: translateY(-1px);
   }
 
   #welcome .developer-credit-banner .developer-name {
-    color: #ffffff !important;
+    color: var(--wl-on-accent) !important;
     font-weight: 700;
     font-size: 1.1em;
     letter-spacing: 0.02em;
   }
 
   #welcome .developer-credit-banner .developer-link i {
-    color: #ffffff !important;
+    color: var(--wl-on-accent) !important;
     font-size: 1.2em;
   }
 

--- a/tests/test_css_cascade_contracts.py
+++ b/tests/test_css_cascade_contracts.py
@@ -496,3 +496,67 @@ def test_volume_splitter_tokens_preserve_runtime_ownership_and_dark_winners() ->
     assert "card.dataset.type = suggestion.type" in volume_js
     assert "'volume-value-pill--excessive'" in volume_js
     assert "getPropertyValue('--volume-track-bg')" in volume_js
+
+
+def test_welcome_tokens_extract_exact_values_without_dead_custom_properties() -> None:
+    base = (ROOT / "templates" / "base.html").read_text(encoding="utf-8")
+    template = (ROOT / "templates" / "welcome.html").read_text(encoding="utf-8")
+    css = (ROOT / "static" / "css" / "pages-welcome.css").read_text(encoding="utf-8")
+
+    # Route bundle loads in the page_css block, after a11y and before the late
+    # motion/theme boundary; no document-wide :has() scope is introduced.
+    assert base.index("css/a11y.css") < base.index("{% block page_css %}")
+    assert base.index("{% block page_css %}") < base.index("css/motion.css")
+    assert base.index("css/motion.css") < base.index("css/theme-dark.css")
+    assert "html:has(" not in css
+
+    # New page-local semantic tokens: each defined once and consumed by the
+    # exact-repeat white-ink / translucent-white-overlay sites it replaced.
+    for token, minimum_consumers in (
+        ("--wl-on-accent", 21),
+        ("--wl-overlay-soft", 3),
+        ("--wl-overlay-strong", 5),
+        ("--wl-overlay-border", 2),
+    ):
+        assert css.count(f"{token}:") == 1
+        assert css.count(f"var({token})") >= minimum_consumers
+
+    # Dead (unreferenced) custom properties were removed outright: the featured
+    # token trio the cards never consumed, plus the orphaned glow/info/duration.
+    for dead in (
+        "--wl-featured-gradient",
+        "--wl-featured-start",
+        "--wl-featured-end",
+        "--wl-accent-glow",
+        "--wl-shadow-glow",
+        "--wl-info",
+        "--wl-duration-slow",
+    ):
+        assert dead not in css
+
+    # No raw white literal survives outside the token definitions.
+    for literal in (
+        "color: #ffffff !important;",
+        "color: #ffffff;",
+        "border-color: #ffffff !important;",
+        "rgba(255, 255, 255, 0.25) !important;",
+        "rgba(255, 255, 255, 0.15) !important;",
+        "rgba(255, 255, 255, 0.4) !important;",
+    ):
+        assert literal not in css
+    assert css.count("rgba(255, 255, 255, 0.25)") == 1
+    assert css.count("rgba(255, 255, 255, 0.15)") == 1
+    assert css.count("rgba(255, 255, 255, 0.4)") == 1
+    # #ffffff now lives only in the --wl-surface and --wl-on-accent definitions.
+    assert css.count("#ffffff") == 2
+
+    # The live featured brand rules keep their own hardcoded !important gradient;
+    # the dark override, responsive breakpoints, and page hook stay intact.
+    assert (
+        "background: linear-gradient(135deg, #0d9488 0%, #14b8a6 100%) !important;"
+        in css
+    )
+    assert "[data-theme='dark'] #welcome .bento-featured {" in css
+    for breakpoint in ("1024px", "768px", "480px"):
+        assert css.count(f"@media (max-width: {breakpoint})") == 1
+    assert 'id="welcome" data-page="welcome"' in template


### PR DESCRIPTION
## WP4.3e — Welcome page dark-mode/token cleanup

Fifth page in the Phase-4 WP4.3 per-page cleanup line (after backup, body composition, progression, volume splitter). Two behavior-preserving, exact-value transformations to `static/css/pages-welcome.css`:

1. **Four page-local semantic tokens** — `--wl-on-accent`, `--wl-overlay-soft`, `--wl-overlay-strong`, `--wl-overlay-border` — replace the exact-repeat white-ink (`#ffffff`) and translucent-white overlay expressions on the featured bento card, hero-button ink, and developer-credit banner. No near-match brand accent/gradient literal was normalized.
2. **Seven dead (zero-`var()`-consumer) custom properties removed** — the `--wl-featured-start`/`-end`/`-gradient` trio (cards paint their hardcoded `!important` gradients directly), the `--wl-accent-glow`/`--wl-shadow-glow` chain, `--wl-info`, and `--wl-duration-slow`.

Every substitution is exact-value and every removal is an unused variable, so no rendered element's cascade winner moves.

### Migration notes
No core-workflow behavior changes: no template, JS, API, schema, calculation, shared CSS, or `theme-dark.css` change. CSS-only + its cascade contract test.

### Verification (Windows local)
| Gate | Result |
|---|---|
| Contracts (cascade + visual-selector) | 17/17 |
| Focused Welcome Chromium visual (6 win32 variants) | 6/6 byte-identical, update-free |
| Welcome functional (erase-flow + smoke-nav) | 12/12 |
| Required Chromium functional list (2-shard) | 215 + 211 = 426/426 |
| pytest | 1,738 + 2 permitted visual-seed catalog reds |
| Vitest / tsc | 105/105 / pass |
| Focused Stylelint | 144 → 111 (−33 hardcoded; no important/specificity/dup increase) |
| Total Stylelint warnings | 6,364 → 6,331 |
| Complete visual deep suite | only the 2 pre-existing WP4.0 known reds (workout-plan desktop-dark 1,039px; plan-desktop-light-advanced 6,262px — both untouched) |
| 156 screenshots / 12 Welcome images vs base | 0 mismatches |

Evidence: `docs/CSS_PHASE4_WP4_3E_EVIDENCE.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)