### PR TITLE
refactor(css): clean up Session Summary dark tokens (WP4.3f)

### DIFF
--- a/docs/CSS_PHASE4_WP4_3F_EVIDENCE.md
+++ b/docs/CSS_PHASE4_WP4_3F_EVIDENCE.md
@@ -1,0 +1,182 @@
+# CSS Phase 4 WP4.3f Evidence — Session Summary Dark/Token Cleanup
+
+Date: 2026-07-19
+
+Branch: `wt/wp4-3-session-summary-dark-token-cleanup`
+
+Base: local `main` at `5e7d290b3168b4c58e5533b45aed3f3b73a8cb52`
+
+## Scope and isolation
+
+WP4.3f changed only the Session Summary route bundle in production:
+`static/css/pages-session-summary.css`. The companion change in
+`tests/test_css_cascade_contracts.py` pins the preserved cascade contract; this
+evidence file and the canonical handover documents are the only documentation
+changes. No template, JavaScript, API, schema, calculation, shared CSS,
+`theme-dark.css`, another page, or WP4.4 work is included. The production/test
+working diff is two files.
+
+`pages-session-summary.css` is loaded only by `templates/session_summary.html`
+(via the `page_css` block). The worktree started from base `5e7d290` on branch
+`wt/wp4-3-session-summary-dark-token-cleanup`; its seeded database and the
+tracked visual fixture both have SHA-256
+`6477B2AC0F91248F7022D1B7AAE60B98586CB13EC4D94CC37294D4115F0AE6E3`.
+
+## Change — value-preserving token extraction
+
+The repeated solid-color dark-mode, ink, and border literals were extracted into
+eleven page-local semantic tokens (a `:root` block for the two light-context
+tokens, a `[data-theme='dark']` block for the nine dark-context tokens, mirroring
+the WP4.3d `pages-volume-splitter.css` pattern). Every substitution is
+exact-value, so no rendered element changes:
+
+| Token | Value | Role | Consumers |
+| --- | --- | --- | ---: |
+| `--ss-table-border` | `#d0d0d0` | light table border | 6 |
+| `--ss-label-ink` | `#495057` | light label/heading ink | 2 |
+| `--ss-dark-ink` | `#e0e0e0` | dark body/legend ink | 9 |
+| `--ss-dark-ink-bright` | `#fff` | dark bright ink | 12 |
+| `--ss-dark-border` | `#404040` | dark border | 5 |
+| `--ss-dark-border-strong` | `#495057` | dark strong border | 6 |
+| `--ss-dark-surface` | `#212529` | dark table surface | 3 |
+| `--ss-dark-surface-deep` | `#1a1a1a` | dark deep surface | 2 |
+| `--ss-dark-elevated` | `#343a40` | dark elevated surface | 3 |
+| `--ss-dark-cell` | `#2d2d2d` | dark cell/stripe | 2 |
+| `--ss-dark-hover` | `#3d3d3d` | dark row hover | 2 |
+
+Distinct semantic roles keep distinct tokens even when values coincide:
+`#495057` backs both `--ss-label-ink` (light label ink, `color:`) and
+`--ss-dark-border-strong` (dark border, `border-color:`); the two were split by
+CSS property, not merged. Only exact repeated expressions were replaced. Single
+or shared literals were deliberately left untouched: the shared volume-badge
+classification colors (`#dc3545`, `#fd7e14`, `#198754`, `#6f42c1`), the `white`
+keyword badge/select fills, the light striping `#ffffff`/`#f8f8f8`/`#f5f5f5`, and
+the translucent-white glass overlays.
+
+No custom property was removed and no rule was deleted; this packet is a pure
+value-preserving extraction. No document-wide `:has()` selector was introduced.
+
+### Deferred findings (not in this packet)
+
+Two hygiene opportunities were identified and intentionally left for a later
+pass to keep this diff a safe, byte-identical extraction:
+
+- The file carries many `#weekly-summary-container` / `#weekly-summary-table`
+  selector arms that are dead on the only page that loads it (those ids exist
+  only in `weekly_summary.html`, which loads its own `pages-weekly-summary.css`).
+- Two parallel dark table systems style the shared `.summary-*` classes
+  (`.table-striped` `#252525`/`#2d2d2d` vs `.summary-tables` `#212529`/`#343a40`).
+
+Removing either requires selector-list surgery / a browser declaration-owner
+audit and is better handled alongside the WP4.3g Weekly Summary packet or a
+shared-frame dedupe, not folded into this extraction.
+
+## Rendered equivalence
+
+The focused Session Summary visual suite renders all six Windows variants
+(desktop / tablet / mobile × light / dark) **byte-identical** to their committed
+baselines, update-free — a strict superset of a sampled computed-value audit,
+proving zero rendered change in either theme. All twelve committed Session
+Summary images (six Linux + six Windows) are byte-identical to base.
+
+## Contract lock
+
+`test_session_summary_tokens_extract_exact_values_value_preserving` pins:
+
+- stylesheet load order (a11y before the page bundle, page bundle before
+  `motion.css` before `theme-dark.css`) and the absence of document-wide
+  `html:has()`;
+- each of the eleven new tokens defined once and consumed by the exact count of
+  the repeated literal it replaced;
+- every extracted literal surviving only in its single token definition
+  (`#495057` twice, for its two distinct-role tokens);
+- `color: #fff` no longer appearing outside the token definition;
+- the shared volume-badge colors, the light striping `#ffffff`, all nine
+  `@media` blocks, and the `id="session-summary-container"` template hook intact.
+
+The combined selector/cascade + visual-selector contract gate is now **18/18**.
+
+## Stylelint measurement
+
+Pinned Stylelint `16.11.0` parsed all measured sources with zero parse errors,
+invalid-option warnings, or errored files.
+
+| Measurement | pre-edit (HEAD) | WP4.3f final | Delta |
+| --- | ---: | ---: | ---: |
+| Focused Session Summary warnings | 183 | 146 | -37 |
+| Focused hardcoded-value (`declaration-property-value-disallowed-list`) | 76 | 39 | -37 |
+| Focused `declaration-no-important` | 55 | 55 | 0 |
+| Focused `no-descending-specificity` | 50 | 50 | 0 |
+| Focused `no-duplicate-selectors` | 2 | 2 | 0 |
+| Total warnings (all CSS/SCSS) | 6,331 | 6,294 | -37 |
+
+No monitored important, specificity, or duplicate category increased. Cumulative
+delta vs the WP4.1 pinned baseline (7,202) is -908.
+
+## Verification
+
+| Gate | Result |
+| --- | --- |
+| `git diff --check` | passed |
+| selector/cascade + visual contracts | 18/18 passed |
+| blocking Flake8 selection (changed test) | 0 findings |
+| TypeScript `tsc --noEmit` | passed |
+| Vitest | 105/105 passed |
+| focused Session Summary Chromium visual | 6/6 passed update-free |
+| required CI Chromium functional list (2-shard) | 215/215 + 211/211 = 426/426 passed |
+| tracked-file pytest | 1,739 passed + 2 permitted catalog reds |
+
+The only pytest failures were the unchanged visual-seed catalog invariants (633
+null/blank `primary_muscle_group`, 454 null/blank `movement_pattern`). The
+additional Python pass relative to WP4.3e is the new Session Summary cascade
+contract.
+
+Every visual command used `PW_VISUAL_SEED=1`; no command used
+`--update-snapshots`.
+
+| Visual suite | Result |
+| --- | --- |
+| all six Windows Session Summary variants | 6/6 passed update-free |
+| complete `visual.spec.ts` | 59 passed + only workout-plan desktop-dark at exactly 1,039 pixels (initial 1,046, settling to 1,039 on retry) |
+| complete thumbnail suite | 1 passed + only plan-desktop-light-advanced at exactly 6,262 pixels (initial 6,276, settling to 6,262 on retry) + 16 not run |
+
+Both persistent reds are the exact WP4.0 known reds on the workout-plan page,
+which this Session-Summary-only change does not touch.
+
+## Integrity locks
+
+- Screenshot manifest: **156 files, 0 mismatches** against main.
+- Generated Bootstrap SHA-256: main checkout
+  `24CC9F443D2D0933F1C89DC7203B0618063C4706ADE17627F0A03934C73D75D4`;
+  isolated worktree
+  `0F9E198319318E2DB274D7AA15CECD0CF536727D25A925B7C8C71BE6F9DEA68B`
+  (the established worktree-vs-main generated-bundle divergence recorded since
+  WP4.3a; the CSS change does not touch it).
+- Target worktree and visual-fixture DB SHA-256:
+  `6477B2AC0F91248F7022D1B7AAE60B98586CB13EC4D94CC37294D4115F0AE6E3`.
+- Main live DB SHA-256:
+  `36ECD8B4EBF747DFA8CFCECF1D1C1C54A6ABFEDF89B66C3AD33B73ABC852071F`.
+
+The twelve committed Session Summary images remained byte-identical:
+
+| Platform / variant | SHA-256 |
+| --- | --- |
+| Linux desktop dark | `64340708ADA6926C99716A4F23575BDF18BE9989CB2C149BD17FB687A9FB7612` |
+| Linux desktop light | `64B23002713EC92FF09E2744DCBE15E3371D7654657847DA731A68725FBE1DD6` |
+| Linux mobile dark | `F5036468E1F9CE659F8ECEE91C8D1835EA39EA57B395D9AC3294E9637A030C43` |
+| Linux mobile light | `227A5E35DD0B1BD4808D76BAC89A0CCBDE74AB997E838BEDCE52C420BED9A0A6` |
+| Linux tablet dark | `65D22A6887F1D479717D2259CC5E96F93B835DD4033525678B74A8FF05D2AD39` |
+| Linux tablet light | `96E0356928C5DEE976C5C082A0E026ADEAF8BD45DB33F3106594673832767494` |
+| Windows desktop dark | `3ADE310CED838F26C202CA559A9E4935D1B0EB13CC8DC49C2764285D07A80081` |
+| Windows desktop light | `8A5C325B62701ACC61F62764ED6456E768ED9827FD2889E0245318FD0A205989` |
+| Windows mobile dark | `E1E6DE038B2C3719A9C5A02EFE162972D9CA372DAC6CC24CB49C573C97C28184` |
+| Windows mobile light | `8A900834B2F094177E0AA9A441EE5EFD2026DC7F23E717423F96D308FEDAED76` |
+| Windows tablet dark | `F81807CF6B724BE6CD48CC816FE4774D6B6356C53ABB7A0DA9674FB3A3945ABB` |
+| Windows tablet light | `2143992EFE8BD6B7C988267304F1E4080583D607B4CD87DBD54309BCD78B10DB` |
+
+## Next action
+
+WP4.3f is complete in isolated `wt/wp4-3-session-summary-dark-token-cleanup` and
+shipped via PR to `main`. The next packet in order is WP4.3g Weekly Summary
+(a good place to also resolve the deferred dead `#weekly-*` arms and the two
+parallel dark table systems). Do not begin it without explicit direction.

--- a/docs/REFACTOR_PLAN.md
+++ b/docs/REFACTOR_PLAN.md
@@ -5,9 +5,9 @@ WP4.0, WP4.1, WP4.2, WP4.3a, WP4.3b, WP4.3c, and WP4.3d are complete. WP2.2 is c
 committed as `0cbedac`. WP4.0 measurement provenance remains unchanged head
 `e46b67e`, with its ledger committed as `ca725c2`. Local integration verification
 is complete through WP4.3d: its history-preserving local merge is `40bc09f` and
-the narrow post-merge gates passed. Nothing was pushed. WP4.3e (Welcome) is
-complete in isolated `wt/wp4-3-welcome-dark-token-cleanup` and awaits owner
-integration direction; Session Summary and later packets have not started.
+the narrow post-merge gates passed. Nothing was pushed through WP4.3d. WP4.3e (Welcome) shipped to origin/main via
+PR #160 (`5e7d290`), and WP4.3f (Session Summary) shipped via PR on top of it;
+Weekly Summary and later packets have not started.
 Track B is mostly shipped; WPB.4 remains unimplemented
 and product-risk gated.**
 
@@ -1025,10 +1025,35 @@ Welcome variants pass; all twelve committed Welcome images and every integrity
 lock are unchanged. Full visuals reproduce only the exact WP4.0 known reds
 (workout-plan desktop-dark 1,039 px; plan-desktop-light-advanced 6,262 px).
 Evidence: [`CSS_PHASE4_WP4_3E_EVIDENCE.md`](CSS_PHASE4_WP4_3E_EVIDENCE.md). The
-packet is committed on its isolated branch and **not yet integrated**; awaiting
-owner direction on the history-preserving merge and whether to push. Leave the
-worktree and branch for review and wait for explicit direction before Session
-Summary or another packet.
+packet shipped to origin/main via PR #160 (squash `5e7d290`, all 14 CI checks
+green).
+
+**WP4.3f Session Summary completed 2026-07-19 in isolated
+`wt/wp4-3-session-summary-dark-token-cleanup`.** The repeated solid-color
+dark-mode, ink, and border literals in the session-summary-only bundle now use
+eleven page-local semantic tokens (a `:root` block for the two light tokens and a
+`[data-theme='dark']` block for the nine dark tokens, mirroring the WP4.3d
+volume-splitter pattern). Distinct roles keep distinct tokens even when values
+coincide (`#495057` backs both `--ss-label-ink` light ink and
+`--ss-dark-border-strong` dark border, split by CSS property). Pure value-
+preserving extraction — no custom property removed, no rule deleted; the shared
+volume-badge colors, light striping, glass overlays, and all nine breakpoints
+stay untouched. Two hygiene findings were **deferred** (documented, not acted on):
+the dead `#weekly-summary-container`/`-table` selector arms (those ids live only
+in `weekly_summary.html`, which loads its own bundle) and the two parallel dark
+table systems on the shared `.summary-*` classes — both better handled with
+WP4.3g Weekly Summary or a shared-frame dedupe. Pinned Stylelint falls
+**6,331 → 6,294** (focused Session Summary **183 → 146**, all -37 in hardcoded
+values), with important, specificity, and duplicate counts unchanged. Contracts
+**18/18**, focused Session Summary Chromium visual **6/6** update-free, required
+Chromium **426/426**, and pytest **1,739 + 2 catalog known-reds** match the
+expected gates. All six Windows Session Summary variants pass; all twelve
+committed Session Summary images and every integrity lock are unchanged. Full
+visuals reproduce only the exact WP4.0 known reds (workout-plan desktop-dark
+1,039 px; plan-desktop-light-advanced 6,262 px). Evidence:
+[`CSS_PHASE4_WP4_3F_EVIDENCE.md`](CSS_PHASE4_WP4_3F_EVIDENCE.md). Shipped to
+origin/main via PR. Next is WP4.3g Weekly Summary; wait for explicit direction
+before starting it.
 
 ### WP4.4 Shared bundles, navbar, and `theme-dark.css`
 

--- a/static/css/pages-session-summary.css
+++ b/static/css/pages-session-summary.css
@@ -1,6 +1,24 @@
 /* Shared volume status tokens, badges, and legend content.
    Summary pages and the volume splitter can both depend on this file
    without redefining the indicator colors or badge chrome locally. */
+
+:root {
+    --ss-table-border: #d0d0d0;
+    --ss-label-ink: #495057;
+}
+
+[data-theme='dark'] {
+    --ss-dark-ink: #e0e0e0;
+    --ss-dark-ink-bright: #fff;
+    --ss-dark-border: #404040;
+    --ss-dark-border-strong: #495057;
+    --ss-dark-surface: #212529;
+    --ss-dark-surface-deep: #1a1a1a;
+    --ss-dark-elevated: #343a40;
+    --ss-dark-cell: #2d2d2d;
+    --ss-dark-hover: #3d3d3d;
+}
+
 .volume-indicator {
     width: clamp(16px, 1.5vw, 20px);
     height: clamp(16px, 1.5vw, 20px);
@@ -57,27 +75,27 @@
 
 /* Dark mode for volume legend */
 [data-theme='dark'] .volume-legend {
-    color: #e0e0e0;
+    color: var(--ss-dark-ink);
 }
 
 [data-theme='dark'] .volume-legend h5,
 [data-theme='dark'] .volume-legend .text-muted,
 [data-theme='dark'] .volume-legend span {
-    color: #e0e0e0 !important;
+    color: var(--ss-dark-ink) !important;
 }
 
 [data-theme='dark'] .volume-legend .legend-item span {
-    color: #e0e0e0;
+    color: var(--ss-dark-ink);
 }
 
 /* Dark mode volume indicator border */
 [data-theme='dark'] .volume-indicator {
-    border: 1px solid #404040;
+    border: 1px solid var(--ss-dark-border);
 }
 
 /* Dark mode volume classification text */
 [data-theme='dark'] .volume-classification span:not(.volume-badge) {
-    color: #e0e0e0;
+    color: var(--ss-dark-ink);
 }
 
 /*
@@ -107,7 +125,7 @@
 #session-summary-container .table td,
 #weekly-summary-container .table th,
 #weekly-summary-container .table td {
-    border: 1px solid #d0d0d0 !important;
+    border: 1px solid var(--ss-table-border) !important;
 }
 
 /* Override Bootstrap's table-striped box-shadow approach with solid backgrounds */
@@ -141,7 +159,7 @@
     --bs-table-accent-bg: transparent !important;
     box-shadow: none !important;
     background: #252525 !important;
-    color: #e0e0e0 !important;
+    color: var(--ss-dark-ink) !important;
 }
 
 [data-theme='dark'] .summary-frame .table-striped > tbody > tr:nth-of-type(even) > *,
@@ -149,8 +167,8 @@
 [data-theme='dark'] .summary-tables .table-striped > tbody > tr:nth-of-type(even) > * {
     --bs-table-accent-bg: transparent !important;
     box-shadow: none !important;
-    background: #2d2d2d !important;
-    color: #e0e0e0 !important;
+    background: var(--ss-dark-cell) !important;
+    color: var(--ss-dark-ink) !important;
 }
 
 /* Dark mode table headers */
@@ -159,9 +177,9 @@
 [data-theme='dark'] .summary-tables .table thead th,
 [data-theme='dark'] #session-summary-container .table thead th,
 [data-theme='dark'] #weekly-summary-container .table thead th {
-    background: #1a1a1a !important;
-    color: #e0e0e0 !important;
-    border-color: #404040 !important;
+    background: var(--ss-dark-surface-deep) !important;
+    color: var(--ss-dark-ink) !important;
+    border-color: var(--ss-dark-border) !important;
     box-shadow: none !important;
 }
 
@@ -171,9 +189,9 @@
 [data-theme='dark'] .summary-tables .table td,
 [data-theme='dark'] #session-summary-container .table td,
 [data-theme='dark'] #weekly-summary-container .table td {
-    background: #2d2d2d !important;
-    color: #e0e0e0 !important;
-    border-color: #404040 !important;
+    background: var(--ss-dark-cell) !important;
+    color: var(--ss-dark-ink) !important;
+    border-color: var(--ss-dark-border) !important;
     box-shadow: none !important;
 }
 
@@ -182,14 +200,14 @@
 [data-theme='dark'] #session-summary-container .table td,
 [data-theme='dark'] #weekly-summary-container .table th,
 [data-theme='dark'] #weekly-summary-container .table td {
-    border: 1px solid #404040 !important;
+    border: 1px solid var(--ss-dark-border) !important;
 }
 
 /* Dark mode table hover */
 [data-theme='dark'] .summary-frame .table tbody tr:hover td,
 [data-theme='dark'] .summary-section .table tbody tr:hover td,
 [data-theme='dark'] .summary-tables .table tbody tr:hover td {
-    background-color: #3d3d3d !important;
+    background-color: var(--ss-dark-hover) !important;
 }
 
 /* Dark mode volume legend */
@@ -219,14 +237,14 @@
 
 /* Dark mode summary frame */
 [data-theme='dark'] .summary-frame {
-    background-color: #1a1a1a !important;
-    border-color: #404040 !important;
+    background-color: var(--ss-dark-surface-deep) !important;
+    border-color: var(--ss-dark-border) !important;
 }
 
 /* Dark mode method selector */
 [data-theme='dark'] .method-selector label,
 [data-theme='dark'] .method-selector .form-label {
-    color: #e0e0e0 !important;
+    color: var(--ss-dark-ink) !important;
 }
 
 [data-theme='dark'] .method-selector .form-text {
@@ -287,8 +305,8 @@
 .summary-frame .table,
 .summary-section .table,
 .summary-tables .table {
-    border-color: #d0d0d0 !important;
-    --bs-table-border-color: #d0d0d0 !important;
+    border-color: var(--ss-table-border) !important;
+    --bs-table-border-color: var(--ss-table-border) !important;
     border-collapse: separate;
     border-spacing: 0;
 }
@@ -296,7 +314,7 @@
 .summary-frame .table > :not(caption) > * > *,
 .summary-section .table > :not(caption) > * > *,
 .summary-tables .table > :not(caption) > * > * {
-    border-color: #d0d0d0 !important;
+    border-color: var(--ss-table-border) !important;
 }
 
 .summary-frame .table th,
@@ -305,7 +323,7 @@
 .summary-section .table td,
 .summary-tables .table th,
 .summary-tables .table td {
-    border-color: #d0d0d0 !important;
+    border-color: var(--ss-table-border) !important;
 }
 
 .summary-section .table-container {
@@ -321,7 +339,7 @@
 /* Table Header Styling */
 .summary-section thead th {
     background-color: #f5f5f5;
-    border-bottom: 2px solid #d0d0d0;
+    border-bottom: 2px solid var(--ss-table-border);
     padding: 1rem;
     font-weight: 600;
     text-transform: uppercase;
@@ -433,21 +451,21 @@
     -webkit-backdrop-filter: blur(12px) saturate(180%);
     border-color: rgba(255, 255, 255, 0.1);
     box-shadow: 0 4px 20px rgba(0, 0, 0, 0.3), inset 0 1px 0 rgba(255, 255, 255, 0.05);
-    color: #fff;
+    color: var(--ss-dark-ink-bright);
 }
 
 [data-theme='dark'] .summary-header label,
 [data-theme='dark'] .summary-header .form-label,
 [data-theme='dark'] .summary-header h5,
 [data-theme='dark'] .summary-header .text-muted {
-    color: #fff !important;
+    color: var(--ss-dark-ink-bright) !important;
 }
 
 [data-theme='dark'] .summary-header select,
 [data-theme='dark'] .summary-header .form-select {
-    background-color: #343a40;
-    border-color: #495057;
-    color: #fff;
+    background-color: var(--ss-dark-elevated);
+    border-color: var(--ss-dark-border-strong);
+    color: var(--ss-dark-ink-bright);
 }
 
 [data-theme='dark'] .summary-header .volume-legend {
@@ -465,7 +483,7 @@
 
 .method-selector .form-label {
     font-weight: 600;
-    color: #495057;
+    color: var(--ss-label-ink);
     margin-bottom: 0.5rem;
 }
 
@@ -486,7 +504,7 @@
 }
 
 .volume-legend h5 {
-    color: #495057;
+    color: var(--ss-label-ink);
     margin-bottom: 1rem;
     font-weight: 600;
 }
@@ -523,31 +541,31 @@
 
 /* Dark mode for summary tables */
 [data-theme='dark'] .summary-tables {
-    background: #212529 !important;
-    border-color: #495057 !important;
-    color: #fff !important;
+    background: var(--ss-dark-surface) !important;
+    border-color: var(--ss-dark-border-strong) !important;
+    color: var(--ss-dark-ink-bright) !important;
 }
 
 [data-theme='dark'] .summary-tables .table {
-    background-color: #212529 !important;
+    background-color: var(--ss-dark-surface) !important;
 }
 
 [data-theme='dark'] .summary-tables .table thead th {
-    background: #343a40 !important;
-    color: #fff !important;
-    border-color: #495057 !important;
+    background: var(--ss-dark-elevated) !important;
+    color: var(--ss-dark-ink-bright) !important;
+    border-color: var(--ss-dark-border-strong) !important;
     box-shadow: none !important;
 }
 
 [data-theme='dark'] .summary-tables .table tbody td {
-    background: #212529 !important;
-    color: #fff !important;
-    border-color: #495057 !important;
+    background: var(--ss-dark-surface) !important;
+    color: var(--ss-dark-ink-bright) !important;
+    border-color: var(--ss-dark-border-strong) !important;
     box-shadow: none !important;
 }
 
 [data-theme='dark'] .summary-tables .table tbody tr:hover td {
-    background-color: #3d3d3d !important;
+    background-color: var(--ss-dark-hover) !important;
 }
 
 [data-theme='dark'] .summary-tables .table tbody tr:nth-of-type(odd) td {
@@ -555,28 +573,28 @@
 }
 
 [data-theme='dark'] .summary-tables .card {
-    background-color: #343a40;
-    border-color: #495057;
+    background-color: var(--ss-dark-elevated);
+    border-color: var(--ss-dark-border-strong);
 }
 
 [data-theme='dark'] .summary-tables .card-header {
     background-color: #2c3034;
-    border-color: #495057;
-    color: #fff;
+    border-color: var(--ss-dark-border-strong);
+    color: var(--ss-dark-ink-bright);
 }
 
 [data-theme='dark'] .summary-tables .card-body {
-    color: #fff;
+    color: var(--ss-dark-ink-bright);
 }
 
 /* Dark mode for section titles */
 [data-theme='dark'] .text-center.mb-4 {
-    color: #fff;
+    color: var(--ss-dark-ink-bright);
 }
 
 /* Dark mode for table section headers */
 [data-theme='dark'] h4.text-center.mb-4 {
-    color: #fff;
+    color: var(--ss-dark-ink-bright);
     font-weight: 600;
 }
 
@@ -593,11 +611,11 @@
     background: rgba(40, 44, 52, 0.6) !important;
     backdrop-filter: blur(8px);
     -webkit-backdrop-filter: blur(8px);
-    color: #fff !important;
+    color: var(--ss-dark-ink-bright) !important;
 }
 
 [data-theme='dark'] .summary-section h2,
 [data-theme='dark'] .summary-section h3,
 [data-theme='dark'] .summary-section h4 {
-    color: #fff;
+    color: var(--ss-dark-ink-bright);
 }

--- a/tests/test_css_cascade_contracts.py
+++ b/tests/test_css_cascade_contracts.py
@@ -560,3 +560,66 @@ def test_welcome_tokens_extract_exact_values_without_dead_custom_properties() ->
     for breakpoint in ("1024px", "768px", "480px"):
         assert css.count(f"@media (max-width: {breakpoint})") == 1
     assert 'id="welcome" data-page="welcome"' in template
+
+
+def test_session_summary_tokens_extract_exact_values_value_preserving() -> None:
+    base = (ROOT / "templates" / "base.html").read_text(encoding="utf-8")
+    template = (ROOT / "templates" / "session_summary.html").read_text(
+        encoding="utf-8"
+    )
+    css = (ROOT / "static" / "css" / "pages-session-summary.css").read_text(
+        encoding="utf-8"
+    )
+
+    # Route bundle loads in the page_css block, after a11y and before the late
+    # motion/theme boundary; no document-wide :has() scope is introduced.
+    assert base.index("css/a11y.css") < base.index("{% block page_css %}")
+    assert base.index("{% block page_css %}") < base.index("css/motion.css")
+    assert base.index("css/motion.css") < base.index("css/theme-dark.css")
+    assert "html:has(" not in css
+
+    # New page-local semantic tokens: each defined once and consumed by the exact
+    # count of the repeated literal it replaced. Distinct roles keep distinct
+    # tokens even when values coincide (--ss-label-ink vs --ss-dark-border-strong
+    # are both #495057 but light label ink vs dark border).
+    for token, consumers in (
+        ("--ss-table-border", 6),
+        ("--ss-label-ink", 2),
+        ("--ss-dark-ink", 9),
+        ("--ss-dark-ink-bright", 12),
+        ("--ss-dark-border", 5),
+        ("--ss-dark-border-strong", 6),
+        ("--ss-dark-surface", 3),
+        ("--ss-dark-surface-deep", 2),
+        ("--ss-dark-elevated", 3),
+        ("--ss-dark-cell", 2),
+        ("--ss-dark-hover", 2),
+    ):
+        assert css.count(f"{token}:") == 1
+        assert css.count(f"var({token})") == consumers
+
+    # Every extracted literal now survives only in its single token definition;
+    # #495057 backs two distinct-role tokens so it appears exactly twice.
+    for literal in (
+        "#e0e0e0",
+        "#404040",
+        "#d0d0d0",
+        "#212529",
+        "#343a40",
+        "#2d2d2d",
+        "#3d3d3d",
+        "#1a1a1a",
+    ):
+        assert css.count(literal) == 1
+    assert css.count("#495057") == 2
+    assert "--ss-dark-ink-bright: #fff;" in css
+    assert "color: #fff;" not in css
+    assert "color: #fff !important;" not in css
+
+    # Shared volume-badge classification colors and the light striping/glass
+    # literals are deliberately left untouched (single-use / shared semantics).
+    for shared in ("#dc3545", "#fd7e14", "#198754", "#6f42c1"):
+        assert shared in css
+    assert "background-color: #ffffff !important;" in css
+    assert css.count("@media") == 9
+    assert 'id="session-summary-container"' in template


### PR DESCRIPTION
## WP4.3f — Session Summary page dark-mode/token cleanup

Sixth page in the Phase-4 WP4.3 per-page cleanup line (after backup, body composition, progression, volume splitter, welcome). **Pure value-preserving token extraction** on the session-summary-only bundle `static/css/pages-session-summary.css`.

The repeated solid-color dark-mode, ink, and border literals now use **eleven page-local semantic tokens** — a `:root` block for the two light tokens (`--ss-table-border`, `--ss-label-ink`) and a `[data-theme='dark']` block for the nine dark tokens (`--ss-dark-ink`, `--ss-dark-ink-bright`, `--ss-dark-border`, `--ss-dark-border-strong`, `--ss-dark-surface`, `--ss-dark-surface-deep`, `--ss-dark-elevated`, `--ss-dark-cell`, `--ss-dark-hover`), mirroring the WP4.3d volume-splitter pattern. Distinct roles keep distinct tokens even when values coincide (`#495057` backs both `--ss-label-ink` and `--ss-dark-border-strong`, split by CSS property).

No custom property removed and no rule deleted — shared volume-badge colors, light striping, glass overlays, and all breakpoints are untouched.

### Deferred (documented, not acted on)
- Dead `#weekly-summary-container` / `-table` selector arms (those ids exist only in `weekly_summary.html`, which loads its own bundle).
- Two parallel dark table systems on the shared `.summary-*` classes.

Both are better handled with WP4.3g Weekly Summary or a shared-frame dedupe, not folded into this byte-identical extraction.

### Migration notes
No core-workflow behavior changes: CSS-only + its cascade contract test. No template/JS/API/schema/calculation/shared-CSS/`theme-dark.css` change.

### Verification (Windows local)
| Gate | Result |
|---|---|
| Contracts (cascade + visual-selector) | 18/18 |
| Focused Session Summary Chromium visual (6 win32 variants) | 6/6 byte-identical, update-free |
| Required Chromium functional list (2-shard) | 215 + 211 = 426/426 |
| pytest | 1,739 + 2 permitted visual-seed catalog reds |
| Vitest / tsc | 105/105 / pass |
| Focused Stylelint | 183 → 146 (−37 hardcoded; no important/specificity/dup increase) |
| Total Stylelint warnings | 6,331 → 6,294 |
| Complete visual deep suite | only the 2 pre-existing WP4.0 known reds (workout-plan desktop-dark 1,039px; plan-desktop-light-advanced 6,262px) |
| 156 screenshots / 12 Session Summary images vs base | 0 mismatches |

Evidence: `docs/CSS_PHASE4_WP4_3F_EVIDENCE.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)