### PR TITLE
refactor(css): drop obsolete theme-selector rules (WP4.3i-h)

### DIFF
--- a/docs/CSS_PHASE4_WP4_3I_H_EVIDENCE.md
+++ b/docs/CSS_PHASE4_WP4_3I_H_EVIDENCE.md
@@ -1,0 +1,192 @@
+# WP4.3i-h — Workout Plan obsolete theme-selector removal
+
+Packet: WP4.3i-h (Phase 4 CSS, page #9 Workout Plan)
+Base: `main` @ `00eb6f9`, branch `wt/css-wp4-3i-h`, isolated worktree
+Date: 2026-07-25
+
+## Scope
+
+Deletion only, in `static/css/pages-workout-plan.css`. Every rule gated exclusively on
+`[data-bs-theme="dark"]` or `.dark-mode` was removed. These are obsolete theme mechanisms that
+cannot match at runtime.
+
+No token extraction, no `!important` removal, no layer movement, no duplicate-selector
+consolidation, no selector rewriting, no formatting changes. The diff is **113 deletions,
+0 insertions** in the CSS.
+
+## Why these rules are dead
+
+1. **`data-bs-theme` is never written.** `static/js/darkMode.js:64,66` is the only theme writer and
+   it sets `data-theme` (`'dark'` / `'light'`). A repo-wide search over `*.js`, `*.ts`, `*.html`,
+   `*.py`, `*.css`, `*.json` (excluding `node_modules`) found `data-bs-theme` in
+   `pages-workout-plan.css` **and nowhere else** — not in the Bootstrap build, not in any template,
+   not in any script.
+2. **`.dark-mode` is never applied as a class.** No template, page script, or test calls
+   `classList.add/toggle/replace` with it, and no `class="…"` attribute contains it. The only
+   occurrences are: an unrelated `data-testid="dark-mode-toggle"` and `id="darkModeToggle"` in
+   `templates/base.html:217`; a defensive *read* in `e2e/fatigue-stage4-smokes.spec.ts:39`
+   (`classList.contains('dark-mode')`, a fallback that never fires because `data-theme` is present);
+   and a `body.dark-mode` rule in `static/css/layout.css:1120` — a shared bundle, out of scope for
+   this packet, flagged below.
+3. **No mixed rules.** All 18 rules are gated *exclusively* on the dead mechanisms: every
+   comma-separated arm of every rule carries one of them. Zero rules had a live arm, and zero of the
+   deleted rules reference `[data-theme=`.
+
+## Rules removed (18)
+
+Superset token block (was line 3512):
+
+| # | Selector |
+|---|---|
+| 1 | `[data-bs-theme="dark"]` (dark override of `--superset-bg-1..4`) |
+
+Muscle Selector dark block (was lines 5473–5577):
+
+| # | Selector |
+|---|---|
+| 2 | `[data-bs-theme="dark"] .muscle-selector-container, .dark-mode .muscle-selector-container` |
+| 3 | `[data-bs-theme="dark"] .muscle-selector-content, .dark-mode .muscle-selector-content` |
+| 4 | `[data-bs-theme="dark"] .svg-container, .dark-mode .svg-container` |
+| 5 | `[data-bs-theme="dark"] .body-outline, .dark-mode .body-outline` |
+| 6 | `[data-bs-theme="dark"] .muscle-region, .dark-mode .muscle-region` |
+| 7 | `[data-bs-theme="dark"] .muscle-region:hover, …:hover/.hover ×4 arms` |
+| 8 | `[data-bs-theme="dark"] .muscle-region.selected, .dark-mode .muscle-region.selected` |
+| 9 | `[data-bs-theme="dark"] .muscle-region.selected:hover, … ×4 arms` |
+| 10 | `[data-bs-theme="dark"] .muscle-region.partial, .dark-mode .muscle-region.partial` |
+| 11 | `[data-bs-theme="dark"] .legend-item:hover, … ×4 arms` |
+| 12 | `[data-bs-theme="dark"] .legend-checkbox, .dark-mode .legend-checkbox` |
+| 13 | `[data-bs-theme="dark"] .legend-key, .dark-mode .legend-key` |
+| 14 | `[data-bs-theme="dark"] .legend-items::-webkit-scrollbar-thumb, .dark-mode …` |
+| 15 | `[data-bs-theme="dark"] .legend-items::-webkit-scrollbar-thumb:hover, .dark-mode …` |
+| 16 | `[data-bs-theme="dark"] .selection-summary, .dark-mode .selection-summary` |
+| 17 | `[data-bs-theme="dark"] .muscle-body-tabs .nav-link:hover, .dark-mode …` |
+| 18 | `[data-bs-theme="dark"] .muscle-body-tabs .nav-link.active, .dark-mode …` |
+
+Also removed: the 7 comments that exclusively described these rules
+(`/* Dark mode superset colors */`, `/* Dark mode SVG body outline */`, `/* Dark mode muscle regions */`,
+`/* Dark mode legend */`, `/* Dark mode scrollbar */`, `/* Dark mode summary */`, `/* Dark mode tabs */`)
+and 17 blank lines that separated them. The `DARK MODE` section banner was **kept** — the region
+still contains a live `[data-theme='dark'] .workout-estimate-provenance` rule.
+
+## Deltas
+
+| Metric | Before | After | Delta |
+|---|---|---|---|
+| File lines | 5,993 | 5,880 | **−113** |
+| CSS rules (postcss walk) | 778 | 760 | −18 |
+| Declarations removed | — | — | 30 |
+| Raw color literals | 840 | 808 | **−32** (12 hex, 20 rgba) |
+| `!important` | 520 | 520 | **0** (none were present in the deleted rules) |
+
+Diff is deletion-only: `113 deletions(-)`, `0` added lines.
+
+### Stylelint — focused (`static/css/pages-workout-plan.css`)
+
+| Rule | Before | After | Delta |
+|---|---|---|---|
+| `declaration-property-value-disallowed-list` (hardcoded color) | 511 | 481 | **−30** |
+| `no-descending-specificity` | 73 | 61 | **−12** |
+| `declaration-no-important` | 520 | 520 | 0 |
+| `selector-max-id` | 75 | 75 | 0 |
+| `selector-max-specificity` | 77 | 77 | 0 |
+| `no-duplicate-selectors` | 7 | 7 | 0 |
+| **TOTAL** | **1,263** | **1,221** | **−42** |
+
+### Stylelint — total (`static/css/*.css` + `scss/**/*.scss`)
+
+| Rule | Before | After | Delta |
+|---|---|---|---|
+| `declaration-property-value-disallowed-list` | 2,580 | 2,550 | −30 |
+| `no-descending-specificity` | 659 | 647 | −12 |
+| `declaration-no-important` | 2,252 | 2,252 | 0 |
+| `selector-max-id` | 191 | 191 | 0 |
+| `selector-max-specificity` | 187 | 187 | 0 |
+| `no-duplicate-selectors` | 46 | 46 | 0 |
+| `declaration-block-no-duplicate-properties` | 2 | 2 | 0 |
+| `property-no-unknown` | 2 | 2 | 0 |
+| **TOTAL** | **5,919** | **5,877** | **−42** |
+
+**No category increased**, focused or total.
+
+## Contract lock
+
+`tests/test_css_cascade_contracts.py::test_workout_plan_drops_obsolete_theme_selector_mechanisms`
+(new). It asserts the *premises* as well as the outcome, so the lock stays honest if the runtime
+changes:
+
+- `darkMode.js` still writes `data-theme` and still never writes `data-bs-theme`;
+- no template, `static/js` script, or e2e spec applies `dark-mode` as a class;
+- the bundle contains neither `data-bs-theme` nor `.dark-mode`;
+- the live `[data-theme='dark']` mechanism is still present in the bundle.
+
+Red-path proven twice: reinserting a `[data-bs-theme="dark"] .svg-container` rule fails the test,
+and so does reinserting a `.dark-mode .svg-container` rule. The `class="…dark-mode"` guard was
+verified to match a real class attribute while ignoring `data-testid="dark-mode-toggle"` and
+`class="dark-mode-toggle"`.
+
+## Gates
+
+| Gate | Result |
+|---|---|
+| CSS parse (postcss) | PASS — 760 rules / 53 at-rules / 2,537 decls; braces balanced 813/813; pure CRLF; trailing newline intact |
+| Cascade/selector contracts | **25/25 pass** (24 baseline + 1 new) |
+| Vitest | **105/105 pass**, 9 files (no JS touched) |
+| Full pytest (authoritative) | **1,751 passed, 0 failed** in 298s — 1,750 baseline + 1 new contract, exactly as predicted |
+| Focused Workout Plan visual (`visual.spec.ts -g workout-plan`, no `--update-snapshots`) | **5 passed, 1 failed** — see below |
+
+The authoritative pytest run used the canonical tracked catalog
+(`HEAD:data/database.db`, blob `b8c7bd0b`, sha256 `e7665b3e…`, 798,720 bytes), swapped into this
+isolated worktree for the duration of the run only.
+
+*Diagnostic note, superseded.* An earlier run in this worktree reported 1,749 passed / 2 failed.
+Both failures were `test_catalog_invariants.py` NULL-column assertions
+(`primary_muscle_group`, `movement_pattern`), caused by the worktree being seeded from
+`e2e/fixtures/database.visual.seed.db`, whose reduced catalog has 454 rows with a blank
+`movement_pattern`. They reproduced identically with this packet stashed, so they were never
+attributable to the change — and on the canonical catalog they do not occur at all. No catalog
+cleanup script was run and no test was weakened; the seed DB was restored byte-for-byte
+(sha256 `6477b2ac…`, 765,952 bytes) after the run, with `data/database.db` remaining
+`skip-worktree` throughout and the tracked blob untouched.
+
+### Visual known-red comparison
+
+`workout-plan desktop dark` failed at **exactly 1,039 pixels (ratio 0.01)** — the established
+WP4.0 signature, byte-for-byte the same pixel count as the i-e / i-f / i-g runs.
+
+Diff-image inspection: red pixels appear **only** on the animated navbar logo (two instances, top
+right and bottom right of the tall capture). Every layout, control, filter, and table region is
+ghosted-unchanged. No red in any region this packet touched. This is animated-media drift, not
+layout or cascade drift.
+
+The other five — `desktop light`, `tablet light`, `tablet dark`, `mobile light`, `mobile dark` —
+are byte-identical. Both dark viewports that *do* pass confirm the deletion is computed-value-inert
+in dark mode, which is the mode these rules nominally targeted.
+
+No snapshot was updated. `git status -- e2e/__screenshots__` is empty.
+
+### Artifact protection
+
+`git status --short` at the end of the run shows exactly two modified files
+(`static/css/pages-workout-plan.css`, `tests/test_css_cascade_contracts.py`).
+`static/css/bootstrap.custom.min.css` and `scss/` are untouched (no `build:css` was run).
+`data/database.db` remains `skip-worktree` (`git ls-files -v` → `S`).
+
+## Findings recorded, not acted on
+
+1. **Latent dark-mode gap (pre-existing, unchanged by this packet).** The deleted
+   `[data-bs-theme="dark"]` block was the *only* dark override for `--superset-bg-1..4`. Because it
+   never matched, superset row tints already render with the light `:root` values (alpha `0.08`) in
+   dark mode. Deleting the block is inert — it changes nothing — but the gap is real. Adding a
+   working `[data-theme='dark']` override would be a deliberate visual change and needs owner
+   sign-off; it is not part of this packet.
+2. **`body.dark-mode` at `static/css/layout.css:1120`** is dead by the same argument. It lives in a
+   shared bundle, so it belongs to WP4.4, not here.
+3. **`DARK MODE` section banner** (was line 5469) now heads a region whose first rule is the
+   light-mode `.workout-estimate-provenance`. Pre-existing mislabelling (that trailing content was
+   appended under the banner); left alone as out-of-scope formatting.
+
+## Evidence contradicting the dead-selector conclusion
+
+None found. Every check pointed the same way: no writer for `data-bs-theme` anywhere in the repo,
+no applier for `.dark-mode`, zero mixed rules, and both dark-mode visual snapshots that pass are
+unchanged by the deletion.

--- a/static/css/pages-workout-plan.css
+++ b/static/css/pages-workout-plan.css
@@ -3508,14 +3508,6 @@ select.filter-dropdown:focus {
   --superset-bg-4: rgba(217, 119, 6, 0.08);
 }
 
-/* Dark mode superset colors */
-[data-bs-theme="dark"] {
-  --superset-bg-1: rgba(124, 58, 237, 0.15);
-  --superset-bg-2: rgba(8, 145, 178, 0.15);
-  --superset-bg-3: rgba(5, 150, 105, 0.15);
-  --superset-bg-4: rgba(217, 119, 6, 0.15);
-}
-
 /* Superset action buttons container */
 .superset-actions {
   display: flex;
@@ -5470,111 +5462,6 @@ svg[id^="body-posterior-hypertrophy-advanced"] .muscle-region.partial {
    DARK MODE
    ============================================================================ */
 
-[data-bs-theme="dark"] .muscle-selector-container,
-.dark-mode .muscle-selector-container {
-    background: var(--bs-body-bg, #1a1d21);
-    border-color: var(--bs-border-color, #495057);
-}
-
-[data-bs-theme="dark"] .muscle-selector-content,
-.dark-mode .muscle-selector-content {
-    background: var(--bs-body-bg, #212529);
-    border-color: var(--bs-border-color, #495057);
-}
-
-[data-bs-theme="dark"] .svg-container,
-.dark-mode .svg-container {
-    background: #2b3035;
-}
-
-/* Dark mode SVG body outline */
-[data-bs-theme="dark"] .body-outline,
-.dark-mode .body-outline {
-    stroke: #8c99a4;
-}
-
-/* Dark mode muscle regions */
-[data-bs-theme="dark"] .muscle-region,
-.dark-mode .muscle-region {
-    fill: rgba(100, 181, 246, 0.2);
-    stroke: rgba(100, 181, 246, 0.4);
-}
-
-[data-bs-theme="dark"] .muscle-region:hover,
-[data-bs-theme="dark"] .muscle-region.hover,
-.dark-mode .muscle-region:hover,
-.dark-mode .muscle-region.hover {
-    fill: rgba(100, 181, 246, 0.45);
-    stroke: rgba(100, 181, 246, 0.8);
-}
-
-[data-bs-theme="dark"] .muscle-region.selected,
-.dark-mode .muscle-region.selected {
-    fill: rgba(129, 199, 132, 0.5);
-    stroke: rgba(102, 187, 106, 0.85);
-}
-
-[data-bs-theme="dark"] .muscle-region.selected:hover,
-[data-bs-theme="dark"] .muscle-region.selected.hover,
-.dark-mode .muscle-region.selected:hover,
-.dark-mode .muscle-region.selected.hover {
-    fill: rgba(129, 199, 132, 0.65);
-    stroke: rgba(102, 187, 106, 0.95);
-}
-
-[data-bs-theme="dark"] .muscle-region.partial,
-.dark-mode .muscle-region.partial {
-    fill: rgba(255, 213, 79, 0.4);
-    stroke: rgba(255, 193, 7, 0.75);
-}
-
-/* Dark mode legend */
-[data-bs-theme="dark"] .legend-item:hover,
-[data-bs-theme="dark"] .legend-item.hover,
-.dark-mode .legend-item:hover,
-.dark-mode .legend-item.hover {
-    background-color: rgba(100, 181, 246, 0.12);
-}
-
-[data-bs-theme="dark"] .legend-checkbox,
-.dark-mode .legend-checkbox {
-    background: var(--bs-body-bg, #212529);
-    border-color: var(--bs-border-color, #495057);
-}
-
-[data-bs-theme="dark"] .legend-key,
-.dark-mode .legend-key {
-    background: rgba(255, 255, 255, 0.08);
-}
-
-/* Dark mode scrollbar */
-[data-bs-theme="dark"] .legend-items::-webkit-scrollbar-thumb,
-.dark-mode .legend-items::-webkit-scrollbar-thumb {
-    background: rgba(255, 255, 255, 0.15);
-}
-
-[data-bs-theme="dark"] .legend-items::-webkit-scrollbar-thumb:hover,
-.dark-mode .legend-items::-webkit-scrollbar-thumb:hover {
-    background: rgba(255, 255, 255, 0.25);
-}
-
-/* Dark mode summary */
-[data-bs-theme="dark"] .selection-summary,
-.dark-mode .selection-summary {
-    background: rgba(255, 255, 255, 0.05);
-}
-
-/* Dark mode tabs */
-[data-bs-theme="dark"] .muscle-body-tabs .nav-link:hover,
-.dark-mode .muscle-body-tabs .nav-link:hover {
-    background-color: rgba(255, 255, 255, 0.05);
-}
-
-[data-bs-theme="dark"] .muscle-body-tabs .nav-link.active,
-.dark-mode .muscle-body-tabs .nav-link.active {
-    background-color: var(--bs-body-bg, #212529);
-    border-color: var(--bs-border-color, #495057) var(--bs-border-color, #495057) var(--bs-body-bg, #212529);
-}
 .workout-estimate-provenance {
     color: var(--ink-3);
     font-size: 0.82rem;

--- a/tests/test_css_cascade_contracts.py
+++ b/tests/test_css_cascade_contracts.py
@@ -1218,3 +1218,44 @@ def test_workout_plan_drops_remaining_dead_defined_token_fallbacks() -> None:
         if "--superset-row-color" not in f and "--wpdd-shadow-lg" not in f
     ]
     assert offenders == [], offenders
+
+
+def test_workout_plan_drops_obsolete_theme_selector_mechanisms() -> None:
+    """WP4.3i-h: `[data-bs-theme]` and `.dark-mode` never match at runtime.
+
+    The app toggles dark mode with `data-theme` only. Rules gated on Bootstrap's
+    `data-bs-theme` attribute or on a `.dark-mode` class could never render, so
+    the Workout Plan bundle must not reintroduce either mechanism.
+    """
+    css = (ROOT / "static" / "css" / "pages-workout-plan.css").read_text(
+        encoding="utf-8"
+    )
+    dark_mode_js = (ROOT / "static" / "js" / "darkMode.js").read_text(
+        encoding="utf-8"
+    )
+
+    # Premise 1: the runtime writes data-theme and never data-bs-theme.
+    assert "setAttribute('data-theme', 'dark')" in dark_mode_js
+    assert "data-bs-theme" not in dark_mode_js
+
+    # Premise 2: nothing applies `dark-mode` as a class.
+    applies_class = re.compile(
+        r"classList\.(?:add|toggle|replace)\([^)]*['\"]dark-mode(?![\w-])"
+    )
+    class_attr = re.compile(r"class\s*=\s*['\"][^'\"]*\bdark-mode(?![\w-])")
+    sources = [
+        *(ROOT / "templates").rglob("*.html"),
+        *(ROOT / "static" / "js").rglob("*.js"),
+        *(ROOT / "e2e").rglob("*.ts"),
+    ]
+    for path in sources:
+        text = path.read_text(encoding="utf-8")
+        assert not applies_class.search(text), path
+        assert not class_attr.search(text), path
+
+    # Contract: no rule in the bundle is gated on either dead mechanism.
+    assert "data-bs-theme" not in css
+    assert ".dark-mode" not in css
+
+    # ...while the live dark-mode mechanism is untouched.
+    assert "[data-theme='dark']" in css


### PR DESCRIPTION
## WP4.3i-h — Workout Plan obsolete theme-selector removal

Phase 4 CSS, page #9 (Workout Plan). **Deletion only** in `static/css/pages-workout-plan.css`:
every rule gated *exclusively* on `[data-bs-theme="dark"]` or `.dark-mode`.

### Why these rules are dead

- `static/js/darkMode.js:64,66` is the only theme writer, and it sets **`data-theme`** only.
- A repo-wide sweep over `*.js`/`*.ts`/`*.html`/`*.py`/`*.css`/`*.json` (excluding `node_modules`)
  found **`data-bs-theme` in `pages-workout-plan.css` and nowhere else** — not in the Bootstrap
  build, not in any template, not in any script.
- **`.dark-mode` is never applied as a class.** No `classList.add/toggle/replace` and no
  `class="…"` attribute contains it. The only occurrences are an unrelated
  `data-testid="dark-mode-toggle"` / `id="darkModeToggle"` in `templates/base.html:217`, and a
  defensive *read* (`classList.contains`) in `e2e/fatigue-stage4-smokes.spec.ts:39` that never
  fires because `data-theme` is always present.
- **Zero mixed rules**: every comma-arm of all 18 rules carries a dead gate, and none of the
  deleted rules reference `[data-theme=`.

### Rules removed (18)

1 superset token block — `[data-bs-theme="dark"]` (dark override of `--superset-bg-1..4`).

17 Muscle Selector rules, each with a `[data-bs-theme="dark"]` and a `.dark-mode` arm:
`.muscle-selector-container`, `.muscle-selector-content`, `.svg-container`, `.body-outline`,
`.muscle-region` (+ `:hover/.hover`, `.selected`, `.selected:hover/.selected.hover`, `.partial`),
`.legend-item:hover/.hover`, `.legend-checkbox`, `.legend-key`,
`.legend-items::-webkit-scrollbar-thumb` (+ `:hover`), `.selection-summary`,
`.muscle-body-tabs .nav-link:hover`, `.muscle-body-tabs .nav-link.active`.

Also removed: the 7 comments that exclusively described these rules, and 17 separating blank lines.
The `DARK MODE` section banner was **kept** — that region still contains a live
`[data-theme='dark'] .workout-estimate-provenance` rule.

### Deltas

| | Before | After | Δ |
|---|---|---|---|
| File lines | 5,993 | 5,880 | **−113** |
| CSS rules (postcss walk) | 778 | 760 | −18 |
| Declarations removed | — | — | 30 |
| Raw color literals | 840 | 808 | **−32** (12 hex / 20 rgba) |
| `!important` | 520 | 520 | **0** |

CSS diff is `0` insertions / `113` deletions — pure deletion.

**Stylelint — focused (`static/css/pages-workout-plan.css`)**

| Rule | Before | After | Δ |
|---|---|---|---|
| `declaration-property-value-disallowed-list` | 511 | 481 | **−30** |
| `no-descending-specificity` | 73 | 61 | **−12** |
| `declaration-no-important` | 520 | 520 | 0 |
| `selector-max-id` | 75 | 75 | 0 |
| `selector-max-specificity` | 77 | 77 | 0 |
| `no-duplicate-selectors` | 7 | 7 | 0 |
| **TOTAL** | **1,263** | **1,221** | **−42** |

**Stylelint — total (`static/css/*.css` + `scss/**/*.scss`)**: 5,919 → 5,877 (**−42**), with the
same −30 / −12 split and every other category flat.

**No category increased**, focused or total.

### Contract lock

New `tests/test_css_cascade_contracts.py::test_workout_plan_drops_obsolete_theme_selector_mechanisms`
asserts the *premises* as well as the outcome, so the lock stays honest if the runtime changes:
`darkMode.js` still writes `data-theme` and never `data-bs-theme`; nothing applies `dark-mode` as a
class; the bundle contains neither mechanism; the live `[data-theme='dark']` mechanism is still
present.

Red path proven independently for **both** mechanisms — reinserting a `[data-bs-theme="dark"]` rule
fails the test, and so does reinserting a `.dark-mode` rule.

### Gates

| Gate | Result |
|---|---|
| CSS parse (postcss) | PASS — 760 rules / 53 at-rules / 2,537 decls; braces balanced 813/813; pure CRLF |
| Cascade/selector contracts | **25/25 pass** (24 baseline + 1 new) |
| Vitest | **105/105 pass**, 9 files (no JS touched) |
| Full pytest | **1,751 passed / 0 failed** (298s) — 1,750 baseline + 1 new contract |
| Focused Workout Plan visual (`visual.spec.ts -g workout-plan`, no `--update-snapshots`) | **5 passed, 1 failed** — the established known red, below |

The pytest gate was run against the canonical tracked catalog (`HEAD:data/database.db`, blob
`b8c7bd0b`). An earlier run in the isolated worktree showed 1,749/2 — both failures were
`test_catalog_invariants.py` NULL-column assertions caused by the reduced `database.visual.seed.db`
catalog, reproduced identically with this packet stashed and therefore never attributable to the
change. No catalog cleanup script was run and no test was weakened.

### Visual known-red comparison

`workout-plan desktop dark` failed at **exactly 1,039 pixels (ratio 0.01)** — the established WP4.0
signature, the same pixel count as the i-e / i-f / i-g runs.

Diff-image inspection: red pixels appear **only** on the animated navbar logo (two instances). Every
layout, control, filter and table region is ghosted-unchanged, with no red in any region this packet
touched. **Animated-media drift, not layout or cascade drift.**

The other five — `desktop light`, `tablet light`, `tablet dark`, `mobile light`, `mobile dark` — are
byte-identical. The two passing *dark* viewports are the strongest inertness proof available for a
dark-mode deletion.

**No snapshot was updated.** No Bootstrap output, SCSS, or database file is in this diff.

### Deferred findings (recorded, not acted on)

1. **Superset dark-tint gap.** The deleted `[data-bs-theme="dark"]` block was the only dark override
   for `--superset-bg-1..4`. Because it never matched, superset row tints already render with the
   light `:root` alpha `0.08` values in dark mode. Deleting it is inert, but the gap is real —
   adding a working `[data-theme='dark']` override is a deliberate visual change needing owner
   sign-off, out of scope here.
2. **`body.dark-mode` at `static/css/layout.css:1120`** is dead by the same argument. It lives in a
   shared bundle, so it belongs to WP4.4.

Evidence: `docs/CSS_PHASE4_WP4_3I_H_EVIDENCE.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
