### PR TITLE
refactor(css): close out Workout Plan dead CSS packets

### DIFF
--- a/docs/CSS_PHASE4_WP4_3I_DEAD_EVIDENCE.md
+++ b/docs/CSS_PHASE4_WP4_3I_DEAD_EVIDENCE.md
@@ -1,0 +1,197 @@
+# WP4.3i-dead — Workout Plan overridden rest-state declaration removal
+
+Packet: WP4.3i-dead (Phase 4 CSS, page #9 Workout Plan)
+Base: `main` @ `bfadf9d`, branch `wt/css-wp4-3i-dead`, isolated worktree
+Date: 2026-07-25
+
+## Scope
+
+Deletion only, in `static/css/pages-workout-plan.css`. Removed 14 declarations that a browser
+sweep proved never reach the rendered page. **0 insertions, 33 deletions.**
+
+No tokenization. The Page Header section was not touched and the shipped WP4.3i-c contract was not
+modified. No `!important` was edited in place, no selector rewritten, no declaration reordered, no
+layer boundary moved, no duplicate-selector cleanup, no formatting churn.
+
+## How liveness was established
+
+### Stage 1 — sentinel sweep
+
+Every ramp literal (`rgba(255,255,255,α)` / `rgba(0,0,0,α)` / `rgba(79,140,255,α)`) in the five
+candidate sections was replaced with a **unique opaque `rgb()` sentinel** — 97 in total — and the
+page was loaded with both themes and with `hover` / `focus` / `focus-visible` / `active` /
+`disabled` forced via CDP on each candidate component. A sentinel that appears in any computed
+style is live; one that never appears is overridden.
+
+| Section | Live | Total |
+|---|---|---|
+| 829 Page Header | 15 | 15 |
+| 934 Collapse Toggles | 0 | 2 |
+| 1078 Filters | 0 | 1 |
+| 1157 Inline Controls | 0 | 21 |
+| 2275 Workout Plan Table | 42 | 58 |
+| **Total** | **57** | **97** |
+
+Coherence check: **zero declarations showed mixed liveness** across all 63 declarations — liveness
+is a per-declaration property, exactly as the cascade requires.
+
+### Stage 2 — computed-style differential, and why the scope shrank to 14
+
+The sweep nominated 24 declarations. Before deleting them, a full computed-style differential was
+run old-vs-new across every element (plus `::before` / `::after`) over the 37 longhands the deleted
+shorthands can set — `background-*`, `border-*` including `border-image-*`, `box-shadow`, `color`,
+`text-shadow`, `outline-*`, `opacity`, `visibility`, `backdrop-filter`, `filter`.
+
+**A control run with identical CSS produced 52 differing records.** The interaction states on this
+page animate, so forced-state snapshots are not a stable oracle and cannot certify anything. The
+rest state, by contrast, is perfectly stable.
+
+The 24 were therefore split by whether their rule carries an interaction pseudo-class:
+
+- **14 rest-state declarations — shipped here**, certified by the rest-state differential.
+- **10 interaction-state declarations — deferred**, because the only evidence available for them is
+  the sweep, and the differential cannot corroborate it. They are left in place rather than deleted
+  on weaker evidence.
+
+### Stage 3 — certification of the 14
+
+| Comparison | Records | Differ |
+|---|---|---|
+| Control (same CSS, two runs) | 31,074 | **0** |
+| Old vs new (14 declarations deleted) | 31,074 | **0** |
+
+Both themes, transitions and animations disabled, every element plus `::before`/`::after`. The
+control proves the harness is stable; the old-vs-new run proves the deletion is inert.
+
+## Declarations removed (14)
+
+| Rule | Property | Literals | `!important` |
+|---|---|---|---|
+| `#workout[data-page="workout-plan"] .selection-actions` | `background` | 3 | no |
+| `#workout[data-page="workout-plan"] .selection-actions` | `border` | 1 | no |
+| `#workout[data-page="workout-plan"] .selection-actions` | `box-shadow` | 4 | no |
+| `[data-theme='dark'] … .selection-actions` | `border` | 1 | no |
+| `[data-theme='dark'] … .selection-actions` | `box-shadow` | 4 | no |
+| `#workout[data-page="workout-plan"] .workout-plan-table thead th` | `background` | 3 | yes |
+| `#workout[data-page="workout-plan"] .workout-plan-table thead th` | `border-bottom` | 1 | yes |
+| `#workout[data-page="workout-plan"] .workout-plan-table thead th` | `border-top` | 1 | yes |
+| `#workout[data-page="workout-plan"] .workout-plan-table thead th` | `box-shadow` | 3 | yes |
+| `#workout[data-page="workout-plan"] .workout-plan-table thead th` | `text-shadow` | 1 | no |
+| `[data-theme='dark'] … .workout-plan-table thead th` | `color` | 1 | yes |
+| `[data-theme='dark'] … .workout-plan-table thead th` | `text-shadow` | 1 | no |
+| `#workout[data-page="workout-plan"] .workout-plan-table tbody td` | `background` | 2 | yes |
+| `#workout[data-page="workout-plan"] .workout-plan-table tbody td` | `box-shadow` | 1 | yes |
+
+## The actual owners
+
+These declarations lose to rules in `static/css/components.css`, which are unlayered, later, more
+specific, and `!important`:
+
+- **Plan table** → the Calm-Glass table system,
+  `:is(#workout[data-page="workout-plan"], .workout-log-page, …) .table.table-calm thead th`
+  and `… .table.table-calm tbody td` (plus their `[data-theme='dark']` twins).
+- **Selection actions** →
+  `#workout[data-page="workout-plan"] #exercise-selection-frame #action-buttons-row.selection-actions`,
+  which carries three ids and `!important` on every declaration.
+
+The page bundle's own `2026 Glass/Neumorphic` versions have been dead ever since the Calm-Glass
+system landed.
+
+## Declarations deferred (10) — NOT removed
+
+| Rule | Property | Literals |
+|---|---|---|
+| `… .collapse-toggle:focus-visible` | `box-shadow` | 2 |
+| `… .collapse-toggle:disabled` | `box-shadow` | 1 |
+| `… .filter-dropdown:focus, … .form-select:focus` | `box-shadow` | 1 |
+| `… .selection-actions:hover` | `background` | 3 |
+| `… .selection-actions:hover` | `border-color` | 1 |
+| `… .selection-actions:hover` | `box-shadow` | 4 |
+| `[data-theme='dark'] … .selection-actions:hover` | `box-shadow` | 4 |
+| `… .workout-plan-table tbody tr:hover td` | `background` | 2 |
+| `… .workout-plan-table tbody tr:hover td` | `box-shadow` | 1 |
+| `[data-theme='dark'] … .workout-plan-table tbody tr:hover td` | `background` | 2 |
+
+Note: `… .workout-plan-table tbody tr:hover td` has **both** of its declarations in the deferred
+set, so if they are ever certified, the whole rule goes rather than just its declarations.
+
+## Deltas
+
+| Metric | Before | After | Delta |
+|---|---|---|---|
+| File lines | 5,880 | 5,847 | **−33** |
+| CSS rules | 760 | 760 | 0 |
+| Declarations | 2,537 | 2,523 | −14 |
+| Colour literals removed | — | — | **27** (22 ramp + 5 co-located) |
+| `!important` | 520 | 513 | **−7** |
+
+Diff is deletion-only: `0` insertions, `33` deletions. `git diff --check` clean.
+
+### Stylelint — focused (`static/css/pages-workout-plan.css`)
+
+| Rule | Before | After | Delta |
+|---|---|---|---|
+| `declaration-property-value-disallowed-list` | 481 | 471 | **−10** |
+| `declaration-no-important` | 520 | 513 | **−7** |
+| `no-descending-specificity` | 61 | 61 | 0 |
+| `selector-max-id` | 75 | 75 | 0 |
+| `selector-max-specificity` | 77 | 77 | 0 |
+| `no-duplicate-selectors` | 7 | 7 | 0 |
+| **TOTAL** | **1,221** | **1,204** | **−17** |
+
+### Stylelint — total (`static/css/*.css` + `scss/**/*.scss`)
+
+5,877 → 5,860 (**−17**), same −10 / −7 split, every other category flat.
+**No category increased**, focused or total.
+
+## Cascade-layer integrity
+
+| | Before | After |
+|---|---|---|
+| `@layer workout-dropdowns` | 468–571 | 468–571 (unchanged) |
+| `@layer workout` | 718–1713 | 718–1697 |
+
+The `workout` layer shrank by exactly the 16 lines deleted inside it (the Selection Actions
+declarations); the other 17 deleted lines are in the unlayered Table section. Layer names, order,
+and nesting are unchanged, and no rule crossed the boundary. No rule was emptied — brace count
+holds at 813/813 and the file is still pure CRLF.
+
+## Contract lock
+
+`tests/test_css_cascade_contracts.py::test_workout_plan_drops_overridden_rest_state_declarations`
+asserts, per rule body rather than by fragile file-wide string match:
+
+1. the 14 dropped properties are absent from the exact rules that carried them;
+2. the surviving declarations in those same rules are still present;
+3. the real owners in `components.css` still own the painted surface;
+4. the 10 interaction-state twins are still present — deliberately deferred, so a future packet
+   cannot quietly delete them on the same weaker evidence;
+5. no rule is empty and the layer split is unchanged.
+
+## Gates
+
+| Gate | Result |
+|---|---|
+| CSS parse (postcss) | PASS — 760 rules / 53 at-rules / 2,523 decls; braces 813/813; pure CRLF |
+| `git diff --check` | CLEAN |
+| Cascade/selector contracts | **26/26 pass** (25 + 1 new) |
+| Rest-state computed-style differential | **0 diffs / 31,074 records**, control **0** |
+| Full pytest (canonical catalog) | **1,752 passed / 0 failed** (1,751 baseline + 1 new contract) |
+| Focused Workout Plan visual, no `--update-snapshots` | **5 passed, 1 failed** — `workout-plan desktop dark` at **exactly 1,039 pixels**, the established WP4.0 animated-logo signature |
+
+The pytest gate used the canonical tracked catalog (`HEAD:data/database.db`, blob `b8c7bd0b`,
+sha256 `e7665b3e…`) swapped into the worktree for the run only; the visual seed was restored
+afterwards (sha256 `6477b2ac…`) and `data/database.db` stayed `skip-worktree` throughout.
+
+**No visual baseline was updated.** `git status -- e2e/__screenshots__` is empty. No Bootstrap
+output, SCSS, or database file is in the diff.
+
+## Findings recorded, not acted on
+
+1. **The sentinel sweep over-reports deadness in animated states.** Its 24-declaration verdict
+   reduced to 14 once a stable oracle was demanded. Any future dead-CSS packet on this page must
+   pair the sweep with a rest-state differential, and must treat interaction states as unproven.
+2. **Page Header (section 829) is fully live** — 15/15 literals render — and remains locked against
+   tokenization by the WP4.3i-c contract. Untouched here.
+3. The superset dark-tint gap and the dead `body.dark-mode` in `static/css/layout.css:1120` remain
+   deferred, unchanged.

--- a/docs/CSS_PHASE4_WP4_3I_FILTER_BTN_EVIDENCE.md
+++ b/docs/CSS_PHASE4_WP4_3I_FILTER_BTN_EVIDENCE.md
@@ -1,0 +1,178 @@
+# WP4.3i-filter-btn — Workout Plan dead `#filter-btn` family removal
+
+Packet: WP4.3i-filter-btn (Phase 4 CSS, page #9 Workout Plan)
+Base: `main` @ `db23801`, branch `wt/css-wp4-3i-filter-btn`, isolated worktree
+Date: 2026-07-25
+
+## Scope
+
+Deletion only, in `static/css/pages-workout-plan.css`. Removed the five rules gated exclusively on
+`#filter-btn` — an element that exists nowhere in the application. **0 insertions, 48 deletions.**
+
+No tokenization of the remaining white values. No i-n work, no Page Header change, no edit to the
+WP4.3i-c contract, no unrelated declarations, no layer movement, no formatting churn.
+
+## Why the family is dead
+
+### Selector searches — zero consumers
+
+Searched `templates/`, `static/js/`, `routes/`, `utils/`, `e2e/`, `tests/`, `scripts/` and `app.py`
+across `*.html`, `*.js`, `*.ts`, `*.py`, `*.json`, `*.jinja`:
+
+| Search | Hits |
+|---|---|
+| `id="filter-btn"` | **0** |
+| `getElementById('filter-btn')` / `("filter-btn")` | **0** |
+| `#filter-btn` selector in JS/TS | **0** |
+| any `filter-btn` string outside this stylesheet | only `backup-filter-btn` — a different, live control on the Backup page |
+
+### Runtime DOM count — zero, before and after using the filters
+
+Loaded `/workout_plan` against the running app and counted, then changed a filter dropdown, fired
+its `change` handler, waited 1.5 s and recounted, in case anything injects an apply button lazily:
+
+| Probe | Before | After filtering |
+|---|---|---|
+| `document.getElementById('filter-btn')` | 0 | 0 |
+| `querySelectorAll('#filter-btn')` | 0 | 0 |
+| `#workout[data-page="workout-plan"] #filter-btn.btn` | 0 | 0 |
+
+The filter change did take effect (`primary_muscle_group_button` moved to `Abs` and gained
+`filter-active`), so the UI was genuinely exercised.
+
+### The live filter hooks — what actually exists
+
+Every element on the page whose id contains `filter`: `filters-content`, `filters-form`,
+`clear-filters-btn`. The real filter controls are:
+
+- **12 dropdown triggers** `button.wpdd-button.wpdd-filter` (`primary_muscle_group_button`,
+  `equipment_button`, `difficulty_button`, …);
+- **`#clear-filters-btn`** — "Clear Filters" (`templates/workout_plan.html:261`, wired at
+  `static/js/modules/filters.js:123`).
+
+**There is no Apply Filters button.** Filtering is change-driven: `filters.js` exports
+`filterExercises()` and calls it from the debounced change handler (`filters.js:93`, `:137`, `:347`).
+The deleted rules are a leftover from a UI generation that had an apply button; the page moved to
+auto-apply and the CSS was never removed.
+
+### Rule-level check — no live grouped arms
+
+All five rules were parsed and every comma-separated arm inspected:
+
+| Lines | Layer | Arms | All arms dead? |
+|---|---|---|---|
+| 1891–1899 | unlayered | 2 | yes |
+| 1901–1909 | unlayered | 2 | yes |
+| 1911–1918 | unlayered | 2 | yes |
+| 2130–2138 | unlayered | 2 | yes |
+| 2140–2146 | unlayered | 2 | yes |
+
+10 arms total, every one gated on `#filter-btn`, **zero live grouped arms**. Each rule pairs a
+`#filter-btn.btn` arm with a `#filter-btn.btn.btn-primary` arm, in light and dark, for base / hover
+/ active states.
+
+Also removed: the comment `/* Apply Filters Button - Blue - High Contrast */`, which described only
+this family, and the blank separator lines that belonged to the deleted blocks.
+
+## Deltas
+
+| Metric | Before | After | Delta |
+|---|---|---|---|
+| File lines | 5,847 | 5,799 | **−48** |
+| CSS rules | 760 | 755 | **−5** |
+| Declarations | 2,523 | 2,496 | **−27** |
+| `!important` | 513 | 488 | **−25** |
+| Colour literals | — | — | **−37** |
+| `#filter-btn` references | 5 rules | **0** | — |
+| `clear-filters-btn` references | 5 | 5 | **0 (untouched)** |
+
+Diff is deletion-only: `0` insertions, `48` deletions. `git diff --check` clean. No rule emptied,
+braces balanced 808/808, file still pure CRLF.
+
+### Stylelint — focused (`static/css/pages-workout-plan.css`)
+
+| Rule | Before | After | Delta |
+|---|---|---|---|
+| `declaration-no-important` | 513 | 488 | **−25** |
+| `declaration-property-value-disallowed-list` | 471 | 452 | **−19** |
+| `selector-max-id` | 75 | 65 | **−10** |
+| `selector-max-specificity` | 77 | 67 | **−10** |
+| `no-descending-specificity` | 61 | 59 | **−2** |
+| `no-duplicate-selectors` | 7 | 7 | 0 |
+| **TOTAL** | **1,204** | **1,138** | **−66** |
+
+### Stylelint — total (`static/css/*.css` + `scss/**/*.scss`)
+
+5,860 → 5,794 (**−66**), with the same per-rule deltas. **No category increased**, focused or total.
+
+This is the largest single lint reduction of the WP4.3i arc, and the only one to move
+`selector-max-id` and `selector-max-specificity` — those rules carried three ids each.
+
+## Cascade-layer integrity
+
+| | Before | After |
+|---|---|---|
+| `@layer workout-dropdowns` | 468–571 | 468–571 |
+| `@layer workout` | 718–1697 | 718–1697 |
+
+**Byte-identical** — every deleted line sits above the layered region (first deletion at L1891, the
+`workout` layer ends at L1697), so nothing layered was touched and no rule crossed a boundary.
+
+## Contract lock
+
+`tests/test_css_cascade_contracts.py::test_workout_plan_drops_dead_filter_button_family` pins both
+halves of the argument:
+
+1. `#filter-btn` is absent from the page bundle;
+2. no template, `static/js` script, e2e spec, or `app.py` supplies a `#filter-btn` consumer — so
+   reintroducing the element forces a deliberate restyle rather than silently reviving dead CSS
+   (`backup-filter-btn` and `clear-filters-btn` are masked out, being different live controls);
+3. the live hooks survive — `#clear-filters-btn` in the template, `filterExercises()` and the
+   `clear-filters-btn` wiring in `filters.js`, and both `#clear-filters-btn.btn` rules (light and
+   dark) in this bundle;
+4. no empty rule, layer split unchanged.
+
+Red path proven **twice**: re-adding a `#filter-btn` CSS rule fails the test, and independently,
+renaming the template's `clear-filters-btn` to `filter-btn` also fails it.
+
+## Gates
+
+| Gate | Result |
+|---|---|
+| CSS parse (postcss) | PASS — 755 rules / 53 at-rules / 2,496 decls; braces 808/808; pure CRLF |
+| `git diff --check` | CLEAN |
+| Cascade/selector contracts | **27/27 pass** (26 + 1 new) |
+| Workout Plan Chromium (`workout-plan` + `exercise-interactions`) | **56 passed** |
+| Full pytest (canonical catalog) | **1,753 passed / 0 failed** (1,752 baseline + 1 new contract) |
+| Focused Workout Plan visual, no `--update-snapshots` | **5 passed, 1 failed** — the established known red; see drift note |
+
+The pytest gate used the canonical tracked catalog (`HEAD:data/database.db`, blob `b8c7bd0b`,
+sha256 `e7665b3e…`) swapped in for the run only; the visual seed was restored afterwards
+(sha256 `6477b2ac…`, verified pristine) and `data/database.db` stayed `skip-worktree` throughout.
+
+## Known baseline drift
+
+`workout-plan desktop dark` failed at **1,039 pixels** on the first attempt and **1,046 pixels** on
+the retry within the same run. This is the established WP4.0 animated-navbar-logo red, and the
+±7 px is drift *within* the animation: the logo is captured at a marginally different frame per
+attempt. Earlier packets (i-h, i-dead) happened to land on 1,039 both times.
+
+Diff-image inspection confirms the character is unchanged: red pixels appear **only** on the
+animated navbar logo (two instances, top-right and lower-right of the tall capture). The filter
+panel, controls, exercise-selection block and plan table are all ghosted-unchanged, and there is no
+red anywhere near the filter or button regions this packet touched. Animated-media drift, not
+layout or cascade drift.
+
+The other five — `desktop light`, `tablet light`, `tablet dark`, `mobile light`, `mobile dark` —
+are byte-identical. **No baseline was updated**; `git status -- e2e/__screenshots__` is empty.
+
+## Findings recorded, not acted on
+
+1. The remaining white literals (`#fff` / `#ffffff`) are **not** tokenized here. After this deletion
+   only a handful of raw consumers remain and, per the i-o investigation, just two are both live and
+   semantically equivalent — far too few to justify a token.
+2. The superset dark-tint gap and the dead `body.dark-mode` in `static/css/layout.css:1120` remain
+   deferred, unchanged.
+3. The 10 interaction-state declarations deferred by WP4.3i-dead remain deferred; per owner
+   instruction they must not be removed without a same-CSS control reaching zero differing records
+   after animations are stabilized.

--- a/docs/MASTER_HANDOVER.md
+++ b/docs/MASTER_HANDOVER.md
@@ -4,7 +4,166 @@
 
 ## Current State
 
-> **2026-07-21 (LATEST) — WP4.3e/f/g SHIPPED; everything below is PUSHED;
+> **2026-07-25 (LATEST) — WP4.3i-h PUSHED; WP4.3i-dead and WP4.3i-filter-btn
+> INTEGRATED LOCALLY ONLY. `origin/main` == `bfadf9d`; local `main` ==
+> `cb5ff6e`, two commits ahead and NOT pushed.** The 2026-07-24 note below is
+> superseded as to HEAD (`00eb6f9` is no longer HEAD) but remains accurate for
+> the WP4.3h + i-i/i-b…i-g arc it records. Exact ladder:
+>
+> | Packet | Commit | State |
+> |---|---|---|
+> | WP4.3i-h | `bfadf9d` | on `origin/main` (PR #164, squash) |
+> | WP4.3i-dead | `db23801` | local `main` only — cherry-pick of `93a3134` |
+> | WP4.3i-filter-btn | `cb5ff6e` | local `main` only — fast-forward, current HEAD |
+>
+> **WP4.3i-h — obsolete theme-selector rule removal (`bfadf9d`, PR #164).**
+> Pure deletion in `static/css/pages-workout-plan.css`: 18 dead
+> `[data-bs-theme]` / `.dark-mode` rules, **−113 lines**, zero insertions. The
+> authoritative pytest run used the canonical tracked catalog
+> (`HEAD:data/database.db`) and returned **1,751 passed / 0 failed**. Worktree
+> and branch were cleaned after merge. Owner ruling recorded for the token
+> track: page-local value-scale tokens (`--wp-white-a05`…) carrying exact rgba,
+> priority i-j/i-m/i-n/i-o, with i-k/i-l deferred.
+>
+> **WP4.3i-dead — overridden rest-state declaration removal (`db23801`).**
+> Deletion only: **14** declarations, 33 lines, 0 insertions;
+> `!important` 520 → 513. The sweep nominated **24**; scope shrank to 14 because
+> a same-CSS CONTROL run over the forced interaction states produced **52
+> differing records** — those states animate, so forced-state snapshots are not
+> a stable oracle. The rest-state differential is stable: control **0 diffs /
+> 31,074 records**, old-vs-new **0 diffs / 31,074 records**. **The 10
+> interaction-state declarations are DEFERRED, not dead** — they are left in
+> place deliberately and the contract test asserts they are still present.
+> Gates: cascade/selector contracts **26/26**, full pytest **1,752 / 0**,
+> focused Stylelint **1,221 → 1,204 (−17)**, total **5,877 → 5,860**, no
+> category increased. Evidence:
+> `docs/CSS_PHASE4_WP4_3I_DEAD_EVIDENCE.md`.
+> **Method rule established here: a sentinel sweep alone over-reports deadness.
+> Every future dead-CSS packet on this page must pair the sweep with a
+> rest-state differential AND a same-CSS control run.**
+>
+> **WP4.3i-filter-btn — dead `#filter-btn` family removal (`cb5ff6e`,
+> integrated into local `main` 2026-07-25 by fast-forward from branch
+> `wt/css-wp4-3i-filter-btn`, base `db23801`).** Deletion only: the **five**
+> rules gated exclusively on `#filter-btn`, an element that exists nowhere in
+> the application — **48 lines, 27 declarations, 25 `!important`, 37 colour
+> literals**, 0 insertions. All 10 comma-separated arms were inspected; every
+> one is `#filter-btn`-gated, so no live grouped arm was lost. There is no Apply
+> Filters button: filtering is change-driven through `filterExercises()` in
+> `static/js/modules/filters.js`, and the live hooks (`#clear-filters-btn`, the
+> 12 `button.wpdd-button.wpdd-filter` triggers) are untouched. Runtime DOM
+> probes returned 0 both before and after exercising a filter. Gates:
+> cascade/selector contracts **27/27** (new
+> `test_workout_plan_drops_dead_filter_button_family`, red path proven twice),
+> Workout Plan Chromium (`workout-plan` + `exercise-interactions`) **56
+> passed**, full pytest **1,753 / 0** on the canonical catalog. Focused
+> Stylelint **1,204 → 1,138 (−66)** — the largest single lint reduction of the
+> WP4.3i arc and the only packet to move `selector-max-id` and
+> `selector-max-specificity` (**−10 each**); total **5,860 → 5,794**, no
+> category increased. Cascade layers byte-identical (every deletion sits above
+> the layered region). Evidence:
+> `docs/CSS_PHASE4_WP4_3I_FILTER_BTN_EVIDENCE.md`.
+>
+> **Known animated-logo visual red — the pixel count is NOT an invariant.**
+> `workout-plan desktop dark` is the established WP4.0 animated-navbar-logo red.
+> In the i-filter-btn run it failed at **1,039 px on the first attempt and
+> 1,046 px on the retry within the same run**; i-h and i-dead happened to land
+> on 1,039 twice. Diff-image inspection confirms red pixels appear **only** on
+> the animated navbar logo — the filter panel, controls, exercise-selection
+> block and plan table are all ghosted-unchanged. Treat this as animated-media
+> drift in a band, not a fixed signature; do not gate on the exact number. The
+> other five variants (`desktop light`, `tablet light/dark`, `mobile
+> light/dark`) are byte-identical. **No visual baseline was updated in any
+> packet**; `git status -- e2e/__screenshots__` is empty, and no Bootstrap
+> output, SCSS, or database file appears in any diff.
+>
+> **Attempted and deliberately NOT committed — do not re-dispatch:**
+> - **WP4.3i-jm** — stopped, nothing committed. The sentinel sweep proved 40 of
+>   97 packet literals never render (Inline Controls **0/21**), and the Page
+>   Header is contract-locked by the shipped WP4.3i-c. The best legal variant
+>   was net-zero Stylelint.
+> - **WP4.3i-o** — not committed. The premise (11 tokenizable `#fff` uses)
+>   collapsed to **2** verified-live, semantically-equivalent uses: 3 dead by
+>   selector, 1 surface-not-ink, 4 unverified/JS-created, 1 white-on-white
+>   latent. Two consumers do not justify a token.
+>
+> **NEXT-STATE CONSTRAINTS — all owner-gated, none started:**
+> 1. **Do not remove the 10 deferred interaction-state declarations.** They
+>    require animation stabilization plus a same-CSS control reaching **zero**
+>    differing records before any deletion is permissible.
+> 2. **Do not touch the WP4.3i-c Page Header contract.**
+> 3. **Do not tokenize the remaining white literals** merely to remove
+>    literals — the i-o investigation found only two live, semantically
+>    equivalent consumers.
+> 4. The remaining Workout Plan **raw-literal → token extraction and
+>    `!important` weighting review** is redesign-sized and has **not started**.
+> 5. **WP4.3j (Workout Log** — `pages-workout-log.css`, 2,185 lines /
+>    293 `!important`, still uncovered**)** and **WP4.4 (shared bundles /
+>    navbar / `theme-dark.css`)** have **not started**.
+> 6. Two findings stay DEFERRED and unacted: the superset dark-tint gap
+>    (`--superset-bg-1..4` has no live dark override) and the dead
+>    `body.dark-mode` in `static/css/layout.css:1120` (→ WP4.4).
+> 7. Before dispatching any next packet, check `gh pr list` and existing
+>    `wt/css-wp4-3i-*` / `wt/wp4-3-*` branches — WP4.3g was once duplicated.
+>
+> **Wait for explicit direction before the next packet, and before pushing.**
+>
+> **2026-07-24 — WP4.3h User Profile + the full WP4.3i Workout Plan
+> dead-CSS/dead-fallback arc SHIPPED (superseded as to HEAD by the 2026-07-25
+> note above; `00eb6f9` is no longer HEAD).** Both landed after the 2026-07-21
+> WP4.3g note below. Both are on `origin/main` and reached it before the i-h /
+> i-dead / i-filter-btn packets recorded above; the "local `main` ==
+> `origin/main`" claim in this entry was true on 2026-07-24 only.
+>
+> **WP4.3h — User Profile dark/token cleanup (2026-07-22, base `bc9da14`; merge
+> `e34d254`).** Only `static/css/pages-user-profile.css` changed, plus the
+> cascade-contract test. Audit finding: unlike the summary bundles, this 1,843-line
+> bundle (**zero** `!important`) was already authored on the shared token
+> vocabulary — nearly every hex is a `var(--token, #fallback)`, deliberately left
+> intact exactly as WP4.3a–g left shared-token fallbacks. Only the genuinely
+> repeated **raw** literals (color-mix operands and a few direct `fill:`/
+> `box-shadow:` values) were extracted into eight page-local semantic tokens (six
+> theme-independent `:root`, two `[data-theme='dark']` dark-only). Every
+> substitution is exact-value → byte-identical render. Evidence:
+> `docs/CSS_PHASE4_WP4_3H_EVIDENCE.md`.
+>
+> **WP4.3i — Workout Plan non-`--bs-*` dead-*fallback* arc COMPLETE (2026-07-22 →
+> 2026-07-24; base `e34d254` → `00eb6f9`). The wider dead-*CSS* sweep continued
+> afterwards in i-h / i-dead / i-filter-btn — see the 2026-07-25 note above.**
+> A multi-packet sweep of
+> `pages-workout-plan.css`. The original **i-a** (tokenize the "2026 Glass Style"
+> filter cluster) was **abandoned and reverted** (`354fa4d`) once a browser
+> sentinel sweep proved none of those values rendered; owner direction was to
+> **delete browser-proven-dead CSS** rather than formalize tokens a later packet
+> would remove. Shipped sub-packets:
+> - **i-i** (`3e8624c`) — removed the dormant filter glass cluster (deletion-only, supersedes i-a).
+> - **i-b** (`cd49703`) — removed dormant `wpdd` duplicate rules.
+> - **i-c** (`db691d9`) — cleaned header/frame ownership.
+> - **i-d** (`2522272`) — dropped dead Muscle Selector local-token fallbacks.
+> - **i-e** (`011d59e`) — dropped dead dropdown-popover local-token fallbacks.
+> - **i-f** (`6593a8d`) — dropped dead table global-token fallbacks.
+> - **i-g** (`392d7e3`, HEAD merge `00eb6f9`) — stripped the seven remaining dead **defined-token** fallbacks, keeping two live ones intact: `--superset-row-color` (assigned dynamically inline per superset row) and `--wpdd-shadow-lg`. Closes the non-`--bs-*` dead-fallback arc.
+>
+> i-g gates: cascade/selector contracts **24/24** (new
+> `test_workout_plan_drops_remaining_dead_defined_token_fallbacks` locks the
+> "no non-`--bs-*` dead fallback remains except the two live tokens" milestone
+> invariant), Vitest **105/105**, full pytest **1,750 passed**, focused Workout
+> Plan visual **5 passed + 1 known red** (`workout-plan desktop-dark` **1,039 px**,
+> the exact WP4.0 baseline — pre-existing animated-media drift, computed-value-inert;
+> light desktop/tablet/mobile byte-identical). Evidence:
+> `docs/CSS_PHASE4_WP4_3I_EVIDENCE.md` (i-i) plus `_B`/`_C`/`_D`/`_E`/`_F`/`_G`.
+>
+> **Remaining on `pages-workout-plan.css` as measured on 2026-07-24: ~218
+> hardcoded hex / 520 `!important`** — the harder redesign-sized work
+> (raw-literal→exact-value token extraction plus the `!important` weighting
+> review), multi-packet, NOT started. *(The `!important` figure has since fallen
+> to **513** at `db23801` and **488** at `cb5ff6e`; see the 2026-07-25 note
+> above for current counts.)* Then **WP4.3j (Workout Log** —
+> `pages-workout-log.css`, 2,185 lines / 293 `!important`, still uncovered**)**
+> and **WP4.4 (shared bundles / navbar / theme-dark)**. **Wait for explicit
+> direction before beginning any.**
+>
+> **2026-07-21 — WP4.3e/f/g SHIPPED; everything below is PUSHED;
 > `main` == `origin/main` at `bc9da14`.** The three remaining WP4.3 route
 > packets reached `origin/main` as squash-merges — **WP4.3e Welcome** via
 > **PR #160** (`5e7d290`), **WP4.3f Session Summary** via **PR #161**

--- a/docs/REFACTOR_PLAN.md
+++ b/docs/REFACTOR_PLAN.md
@@ -1,16 +1,67 @@
 # Deep Refactor Plan — v3 (2026-07-04, full-scan grounded)
 
-**Status: Track A, Phases -1 through 3, and Phase-4 packets WP4.-1, WP4.0a,
-WP4.0, WP4.1, WP4.2, WP4.3a, WP4.3b, WP4.3c, and WP4.3d are complete. WP2.2 is committed as `c461840`; optional WP3.6 is
-committed as `0cbedac`. WP4.0 measurement provenance remains unchanged head
-`e46b67e`, with its ledger committed as `ca725c2`. Local integration verification
-is complete through WP4.3d: its history-preserving local merge is `40bc09f` and
-the narrow post-merge gates passed. Nothing was pushed through WP4.3d. WP4.3e (Welcome) shipped to origin/main via
-PR #160 (`5e7d290`), WP4.3f (Session Summary) shipped via PR #161 (`08256f0`),
-and WP4.3g (Weekly Summary) shipped via PR on top of it;
-User Profile and later packets have not started.
-Track B is mostly shipped; WPB.4 remains unimplemented
-and product-risk gated.**
+**Status (2026-07-25): Track A, Phases -1 through 3, and Phase-4 packets
+WP4.-1, WP4.0a, WP4.0, WP4.1, WP4.2, and WP4.3a–WP4.3h are complete, as is the
+WP4.3i Workout Plan dead-CSS arc through WP4.3i-filter-btn.** WP2.2 is committed
+as `c461840`; optional WP3.6 is committed as `0cbedac`. WP4.0 measurement
+provenance remains unchanged head `e46b67e`, with its ledger committed as
+`ca725c2`. Local integration verification through WP4.3d is complete
+(history-preserving merge `40bc09f`); nothing was pushed through WP4.3d.
+WP4.3e (Welcome) shipped to `origin/main` via PR #160 (`5e7d290`), WP4.3f
+(Session Summary) via PR #161 (`08256f0`), WP4.3g (Weekly Summary) via PR #162
+(`bc9da14`), and WP4.3h (User Profile) plus WP4.3i-i/i-b…i-g via PR up to
+`00eb6f9`. Track B is mostly shipped; WPB.4 remains unimplemented and
+product-risk gated.
+
+**Phase-4 frontier — WP4.3i Workout Plan dead-CSS sweep.** Three packets sit
+past `00eb6f9`; only the first is pushed:
+
+| Packet | Commit | State | Headline |
+|---|---|---|---|
+| WP4.3i-h | `bfadf9d` | **on `origin/main`** (PR #164, squash) | 18 dead `[data-bs-theme]`/`.dark-mode` rules deleted, −113 lines, pure deletion; pytest **1,751 / 0** |
+| WP4.3i-dead | `db23801` | local `main` only (cherry-pick of `93a3134`) | 14 overridden **rest-state** declarations deleted, −33 lines, `!important` 520 → 513; contracts **26/26**, pytest **1,752 / 0**, focused Stylelint **1,221 → 1,204** |
+| WP4.3i-filter-btn | `cb5ff6e` | local `main` only (fast-forward from `wt/css-wp4-3i-filter-btn`); **current HEAD** | 5 rules gated on the non-existent `#filter-btn` deleted — 48 lines / 27 decls / 25 `!important` / 37 literals; contracts **27/27**, Workout Plan Chromium **56 passed**, pytest **1,753 / 0**, focused Stylelint **1,204 → 1,138 (−66)**, first packet to move `selector-max-id` and `selector-max-specificity` (−10 each) |
+
+Local `main` is therefore **two commits ahead of `origin/main` and unpushed**.
+Evidence: [`CSS_PHASE4_WP4_3I_DEAD_EVIDENCE.md`](CSS_PHASE4_WP4_3I_DEAD_EVIDENCE.md)
+and [`CSS_PHASE4_WP4_3I_FILTER_BTN_EVIDENCE.md`](CSS_PHASE4_WP4_3I_FILTER_BTN_EVIDENCE.md).
+No visual baseline was updated in any packet, and no Bootstrap output, SCSS, or
+database file appears in any diff.
+
+**Known animated-logo visual red — not a fixed pixel count.** `workout-plan
+desktop dark` remains the WP4.0 animated-navbar-logo red. It failed at **1,039 px
+first attempt and 1,046 px on retry within the same i-filter-btn run**; i-h and
+i-dead happened to land on 1,039 twice. Red pixels appear only on the animated
+navbar logo. Treat it as drift in a band, not an invariant, and do not gate on
+the exact number. The other five variants are byte-identical.
+
+**Method rule established by WP4.3i-dead:** a browser sentinel sweep alone
+**over-reports deadness**. Its 24-declaration verdict reduced to 14 once a stable
+oracle was demanded, because a same-CSS control run over forced interaction
+states produced 52 differing records — those states animate. Every future
+dead-CSS packet on this page must pair the sweep with a rest-state differential
+**and** a same-CSS control.
+
+**Next-state constraints — all owner-gated, none started:**
+
+1. **Do not remove the 10 deferred interaction-state declarations** from
+   WP4.3i-dead. They require animation stabilization plus a same-CSS control
+   reaching **zero** differing records; the i-dead contract asserts they are
+   still present.
+2. **Do not modify the WP4.3i-c Page Header contract.** Section 829 is 15/15
+   live and locked.
+3. **Do not tokenize the remaining white literals** merely to remove literals —
+   the i-o investigation found only **two** live, semantically equivalent
+   consumers.
+4. The remaining Workout Plan **raw-literal → token extraction and `!important`
+   weighting review** is redesign-sized, multi-packet, and **has not started**.
+5. **WP4.3j (Workout Log)** and **WP4.4 (shared bundles / navbar /
+   `theme-dark.css`)** have **not started**.
+6. Deferred and unacted: the superset dark-tint gap (`--superset-bg-1..4` has no
+   live dark override) and the dead `body.dark-mode` in
+   `static/css/layout.css:1120` (→ WP4.4).
+7. **WP4.3i-jm and WP4.3i-o were attempted and deliberately not committed** —
+   do not re-dispatch them. See `docs/MASTER_HANDOVER.md` for why.
 
 This supersedes v2. It incorporates:
 
@@ -1086,8 +1137,15 @@ committed Weekly Summary images and every integrity lock are unchanged. Full
 visuals reproduce only the exact WP4.0 known reds (workout-plan desktop-dark
 1,039 px; plan-desktop-light-advanced 6,262 px). Evidence:
 [`CSS_PHASE4_WP4_3G_EVIDENCE.md`](CSS_PHASE4_WP4_3G_EVIDENCE.md). Shipped to
-origin/main via PR. Next is WP4.3h User Profile (audit/minimal); wait for
-explicit direction before starting it.
+origin/main via PR #162 (`bc9da14`).
+
+**WP4.3h User Profile and the WP4.3i Workout Plan dead-CSS arc followed and are
+complete through WP4.3i-filter-btn (`cb5ff6e`).** Their per-packet evidence docs
+are `CSS_PHASE4_WP4_3H_EVIDENCE.md` and `CSS_PHASE4_WP4_3I_EVIDENCE.md` plus
+`_B`/`_C`/`_D`/`_E`/`_F`/`_G`, `_DEAD`, and `_FILTER_BTN`. The current-status
+section at the top of this document carries the commit ladder, gates, the
+animated-logo known red, and the next-state constraints; `docs/MASTER_HANDOVER.md`
+carries the narrative. **Wait for explicit direction before the next packet.**
 
 ### WP4.4 Shared bundles, navbar, and `theme-dark.css`
 

--- a/static/css/pages-workout-plan.css
+++ b/static/css/pages-workout-plan.css
@@ -1887,36 +1887,6 @@ select.filter-dropdown:focus {
     inset 0 2px 4px rgba(0, 109, 119, 0.1);
 }
 
-/* Apply Filters Button - Blue - High Contrast */
-#workout[data-page="workout-plan"] #filter-btn.btn,
-#workout[data-page="workout-plan"] #filter-btn.btn.btn-primary {
-  background: linear-gradient(135deg, #1e40af 0%, #1e3a8a 100%) !important;
-  color: #ffffff !important;
-  font-weight: 700 !important;
-  text-shadow: 0 1px 3px rgba(0, 0, 0, 0.3), 0 0 1px rgba(0, 0, 0, 0.5) !important;
-  box-shadow: 0 4px 12px rgba(30, 64, 175, 0.5), 0 2px 4px rgba(30, 64, 175, 0.4) !important;
-  border: 1px solid rgba(255, 255, 255, 0.2) !important;
-}
-
-#workout[data-page="workout-plan"] #filter-btn.btn:hover:not(:disabled),
-#workout[data-page="workout-plan"] #filter-btn.btn.btn-primary:hover:not(:disabled) {
-  background: linear-gradient(135deg, #2563eb 0%, #1e40af 100%) !important;
-  color: #ffffff !important;
-  text-shadow: 0 1px 3px rgba(0, 0, 0, 0.3), 0 0 1px rgba(0, 0, 0, 0.5) !important;
-  box-shadow: 0 6px 16px rgba(30, 64, 175, 0.55), 0 3px 6px rgba(30, 64, 175, 0.45) !important;
-  border: 1px solid rgba(255, 255, 255, 0.3) !important;
-  transform: translateY(-2px);
-}
-
-#workout[data-page="workout-plan"] #filter-btn.btn:active:not(:disabled),
-#workout[data-page="workout-plan"] #filter-btn.btn.btn-primary:active:not(:disabled) {
-  background: linear-gradient(135deg, #1e3a8a 0%, #172554 100%) !important;
-  color: #ffffff !important;
-  text-shadow: 0 1px 2px rgba(0, 0, 0, 0.4), 0 0 1px rgba(0, 0, 0, 0.6) !important;
-  transform: translateY(0) scale(0.98);
-  box-shadow: 0 2px 6px rgba(30, 64, 175, 0.5), 0 1px 2px rgba(30, 64, 175, 0.4) !important;
-}
-
 /* Clear Filters Button - Midnight Blue Glass */
 #workout[data-page="workout-plan"] #clear-filters-btn.btn {
   background: linear-gradient(135deg,
@@ -2125,24 +2095,6 @@ select.filter-dropdown:focus {
     0 8px 24px rgba(152, 223, 214, 0.2),
     0 4px 10px rgba(152, 223, 214, 0.14),
     inset 0 1px 0 rgba(255, 255, 255, 0.08);
-}
-
-[data-theme='dark'] #workout[data-page="workout-plan"] #filter-btn.btn,
-[data-theme='dark'] #workout[data-page="workout-plan"] #filter-btn.btn.btn-primary {
-  background: linear-gradient(135deg, rgba(37, 99, 235, 0.4) 0%, rgba(30, 64, 175, 0.4) 100%) !important;
-  color: #bfdbfe !important;
-  font-weight: 700 !important;
-  text-shadow: 0 1px 2px rgba(0, 0, 0, 0.5), 0 0 2px rgba(0, 0, 0, 0.3) !important;
-  box-shadow: 0 4px 12px rgba(37, 99, 235, 0.4), 0 2px 4px rgba(37, 99, 235, 0.3) !important;
-  border: 1px solid rgba(191, 219, 254, 0.2) !important;
-}
-
-[data-theme='dark'] #workout[data-page="workout-plan"] #filter-btn.btn:hover:not(:disabled),
-[data-theme='dark'] #workout[data-page="workout-plan"] #filter-btn.btn.btn-primary:hover:not(:disabled) {
-  background: linear-gradient(135deg, rgba(59, 130, 246, 0.5) 0%, rgba(37, 99, 235, 0.5) 100%) !important;
-  color: #dbeafe !important;
-  text-shadow: 0 1px 2px rgba(0, 0, 0, 0.5), 0 0 2px rgba(0, 0, 0, 0.3) !important;
-  border: 1px solid rgba(191, 219, 254, 0.3) !important;
 }
 
 [data-theme='dark'] #workout[data-page="workout-plan"] #clear-filters-btn.btn {

--- a/static/css/pages-workout-plan.css
+++ b/static/css/pages-workout-plan.css
@@ -1308,17 +1308,7 @@ select.filter-dropdown:focus {
   #workout[data-page="workout-plan"] .selection-actions {
     width: 100% !important;
     padding: calc(var(--wp-gap) * 1.5) calc(var(--wp-gap) * 2);
-    background: linear-gradient(135deg,
-      rgba(255, 255, 255, 0.95) 0%,
-      rgba(248, 250, 252, 0.98) 50%,
-      rgba(241, 245, 249, 0.95) 100%);
-    border: 1px solid rgba(79, 140, 255, 0.15);
     border-radius: 18px;
-    box-shadow:
-      0 8px 32px rgba(79, 140, 255, 0.08),
-      0 4px 12px rgba(0, 0, 0, 0.04),
-      inset 0 2px 0 rgba(255, 255, 255, 0.9),
-      inset 0 -1px 0 rgba(0, 0, 0, 0.03);
     transition: all 0.3s cubic-bezier(0.4, 0, 0.2, 1);
   }
 
@@ -1341,12 +1331,6 @@ select.filter-dropdown:focus {
       rgba(30, 41, 59, 0.95) 0%,
       rgba(15, 23, 42, 0.98) 50%,
       rgba(10, 15, 30, 0.95) 100%);
-    border: 1px solid rgba(79, 140, 255, 0.2);
-    box-shadow:
-      0 8px 32px rgba(0, 0, 0, 0.3),
-      0 4px 12px rgba(0, 0, 0, 0.2),
-      inset 0 1px 0 rgba(255, 255, 255, 0.05),
-      inset 0 -1px 0 rgba(0, 0, 0, 0.2);
   }
 
   [data-theme='dark'] #workout[data-page="workout-plan"] .selection-actions:hover {
@@ -2428,10 +2412,6 @@ select.filter-dropdown:focus {
 }
 
 #workout[data-page="workout-plan"] .workout-plan-table thead th {
-  background: linear-gradient(180deg,
-    rgba(255, 255, 255, 0.98) 0%,
-    rgba(248, 250, 252, 0.95) 50%,
-    rgba(241, 245, 249, 0.92) 100%) !important;
   color: var(--wp-text) !important;
   font-weight: var(--wp-fw-semibold);
   font-size: var(--wp-table-fs);
@@ -2439,17 +2419,10 @@ select.filter-dropdown:focus {
   text-transform: none !important;
   letter-spacing: normal !important;
   padding: var(--wp-table-cell-padding);
-  border-bottom: 2px solid rgba(79, 140, 255, 0.2) !important;
-  border-top: 1px solid rgba(255, 255, 255, 0.9) !important;
   position: sticky;
   top: 0;
   z-index: var(--wp-z-base);
   white-space: nowrap;
-  box-shadow:
-    inset 0 1px 0 rgba(255, 255, 255, 0.95),
-    inset 0 -1px 0 rgba(79, 140, 255, 0.1),
-    0 4px 12px rgba(79, 140, 255, 0.08) !important;
-  text-shadow: 0 1px 1px rgba(255, 255, 255, 0.8);
 }
 
 [data-theme='dark'] #workout[data-page="workout-plan"] .workout-plan-table thead th {
@@ -2457,26 +2430,20 @@ select.filter-dropdown:focus {
     rgba(40, 48, 64, 0.98) 0%,
     rgba(32, 40, 54, 0.95) 50%,
     rgba(26, 32, 44, 0.92) 100%) !important;
-  color: rgba(255, 255, 255, 0.95) !important;
   border-bottom: 2px solid rgba(79, 140, 255, 0.25) !important;
   border-top: 1px solid rgba(255, 255, 255, 0.08) !important;
   box-shadow:
     inset 0 1px 0 rgba(255, 255, 255, 0.06),
     inset 0 -1px 0 rgba(79, 140, 255, 0.15),
     0 4px 12px rgba(0, 0, 0, 0.2) !important;
-  text-shadow: 0 1px 2px rgba(0, 0, 0, 0.4);
 }
 
 #workout[data-page="workout-plan"] .workout-plan-table tbody td {
   padding: var(--wp-table-cell-padding);
   border-bottom: 1px solid rgba(229, 231, 235, 0.4) !important;
   color: var(--wp-text);
-  background: linear-gradient(180deg,
-    rgba(255, 255, 255, 0.98) 0%,
-    rgba(252, 253, 255, 0.95) 100%) !important;
   transition: background var(--wp-transition-fast), box-shadow var(--wp-transition-fast);
   font-size: var(--wp-table-fs);
-  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.6) !important;
 }
 
 [data-theme='dark'] #workout[data-page="workout-plan"] .workout-plan-table tbody td {

--- a/tests/test_css_cascade_contracts.py
+++ b/tests/test_css_cascade_contracts.py
@@ -1259,3 +1259,93 @@ def test_workout_plan_drops_obsolete_theme_selector_mechanisms() -> None:
 
     # ...while the live dark-mode mechanism is untouched.
     assert "[data-theme='dark']" in css
+
+
+def _wp_rule_body(css: str, selector: str) -> str:
+    """Return the declaration block that follows an exact selector line."""
+    marker = selector + " {"
+    start = css.index(marker) + len(marker)
+    depth, i = 1, start
+    while depth:
+        if css[i] == "{":
+            depth += 1
+        elif css[i] == "}":
+            depth -= 1
+        i += 1
+    return css[start:i - 1]
+
+
+def test_workout_plan_drops_overridden_rest_state_declarations() -> None:
+    """WP4.3i-dead: 14 permanently-overridden rest-state declarations are gone.
+
+    A sentinel sweep plus a rest-state computed-style differential proved these
+    never reached the rendered page -- the Calm-Glass table system and the
+    exercise-selection action bar in components.css out-specify and !important
+    them. Deleting them left all 31,074 computed-style records byte-identical in
+    both themes. This contract pins the removals AND the rules that actually
+    win, so a future cascade change forces a revisit instead of a silent re-add.
+    """
+    css = (ROOT / "static" / "css" / "pages-workout-plan.css").read_text(
+        encoding="utf-8"
+    )
+    components = (ROOT / "static" / "css" / "components.css").read_text(
+        encoding="utf-8"
+    )
+    wp = '#workout[data-page="workout-plan"]'
+    dark = "[data-theme='dark'] " + wp
+
+    # --- 1. Dormant declarations are gone from the rules that carried them. ---
+    dropped = {
+        f"{wp} .selection-actions": ("background:", "border:", "box-shadow:"),
+        f"{dark} .selection-actions": ("border:", "box-shadow:"),
+        f"{wp} .workout-plan-table thead th": (
+            "background:", "border-bottom:", "border-top:", "box-shadow:",
+            "text-shadow:",
+        ),
+        f"{dark} .workout-plan-table thead th": ("color:", "text-shadow:"),
+        f"{wp} .workout-plan-table tbody td": ("background:", "box-shadow:"),
+    }
+    for selector, props in dropped.items():
+        body = _wp_rule_body(css, selector)
+        for prop in props:
+            assert prop not in body, f"{selector} still declares {prop}"
+
+    # --- 2. Surviving declarations in those same rules are untouched. ---
+    kept = {
+        f"{wp} .workout-plan-table tbody td": (
+            "padding:", "border-bottom: 1px solid rgba(229, 231, 235, 0.4)",
+            "color: var(--wp-text);",
+        ),
+        f"{wp} .workout-plan-table thead th": ("position: sticky;", "z-index:"),
+        f"{wp} .selection-actions": ("border-radius: 18px;", "width: 100%"),
+    }
+    for selector, props in kept.items():
+        body = _wp_rule_body(css, selector)
+        for prop in props:
+            assert prop in body, f"{selector} lost {prop}"
+
+    # --- 3. The real owners still own the painted surface. ---
+    for owner in (".table.table-calm thead th {", ".table.table-calm tbody td {"):
+        assert owner in components, owner
+    assert '#workout[data-page="workout-plan"], .workout-log-page' in components
+    assert (
+        '#workout[data-page="workout-plan"] #exercise-selection-frame '
+        '#action-buttons-row.selection-actions {'
+    ) in components
+
+    # --- 4. Interaction-state twins are deliberately NOT removed. ---
+    # Those states animate, so the differential could not certify them; they are
+    # deferred rather than deleted on weaker evidence.
+    for deferred in (
+        f"{wp} .selection-actions:hover {{",
+        f"{wp} .workout-plan-table tbody tr:hover td {{",
+        f"{wp} .collapse-toggle:focus-visible {{",
+        f"{wp} .collapse-toggle:disabled {{",
+    ):
+        assert deferred in css, deferred
+    assert "box-shadow:" in _wp_rule_body(css, f"{wp} .selection-actions:hover")
+
+    # --- 5. No empty rule, and the layer split is unchanged. ---
+    assert not re.search(r"\{\s*\}", css)
+    assert css.count("@layer workout {") == 1
+    assert css.count("@layer workout-dropdowns {") == 1

--- a/tests/test_css_cascade_contracts.py
+++ b/tests/test_css_cascade_contracts.py
@@ -1349,3 +1349,63 @@ def test_workout_plan_drops_overridden_rest_state_declarations() -> None:
     assert not re.search(r"\{\s*\}", css)
     assert css.count("@layer workout {") == 1
     assert css.count("@layer workout-dropdowns {") == 1
+
+
+def test_workout_plan_drops_dead_filter_button_family() -> None:
+    """WP4.3i-filter-btn: the `#filter-btn` rule family is gone and stays gone.
+
+    Workout Plan has no "Apply Filters" button. Filtering is change-driven --
+    `filters.js` reacts to the filter dropdowns -- and the only real filter
+    button is `#clear-filters-btn`. The five rules styling `#filter-btn` could
+    never match, so they were deleted. This contract pins both halves: the dead
+    family is absent, and the route still supplies no `#filter-btn` consumer, so
+    reintroducing the element forces a deliberate restyle rather than silently
+    reviving dead CSS.
+    """
+    css = (ROOT / "static" / "css" / "pages-workout-plan.css").read_text(
+        encoding="utf-8"
+    )
+
+    # --- 1. The dead family is gone from the page bundle. ---
+    assert "#filter-btn" not in css
+
+    # --- 2. No route surface creates the element. ---
+    # (`backup-filter-btn` on the Backup page is a different, live control.)
+    sources = [
+        *(ROOT / "templates").rglob("*.html"),
+        *(ROOT / "static" / "js").rglob("*.js"),
+        *(ROOT / "e2e").rglob("*.ts"),
+        ROOT / "app.py",
+    ]
+    for path in sources:
+        text = path.read_text(encoding="utf-8")
+        stripped = text.replace("backup-filter-btn", "").replace("clear-filters-btn", "")
+        assert 'id="filter-btn"' not in stripped, path
+        assert "getElementById('filter-btn')" not in stripped, path
+        assert 'getElementById("filter-btn")' not in stripped, path
+        assert "#filter-btn" not in stripped, path
+
+    # --- 3. The live filter hooks are untouched. ---
+    template = (ROOT / "templates" / "workout_plan.html").read_text(encoding="utf-8")
+    assert 'id="clear-filters-btn"' in template
+    assert 'id="filters-form"' in template
+    assert "filter-dropdown" in template
+    filters_js = (ROOT / "static" / "js" / "modules" / "filters.js").read_text(
+        encoding="utf-8"
+    )
+    assert "getElementById('clear-filters-btn')" in filters_js
+    assert "export async function filterExercises" in filters_js
+
+    # The Clear Filters styling in this bundle must survive the deletion.
+    assert (
+        '#workout[data-page="workout-plan"] #clear-filters-btn.btn {' in css
+    )
+    assert (
+        "[data-theme='dark'] #workout[data-page=\"workout-plan\"] "
+        "#clear-filters-btn.btn {"
+    ) in css
+
+    # --- 4. Nothing was emptied and the layer split is unchanged. ---
+    assert not re.search(r"\{\s*\}", css)
+    assert css.count("@layer workout {") == 1
+    assert css.count("@layer workout-dropdowns {") == 1


### PR DESCRIPTION
Closes out the Workout Plan dead-CSS sweep with the two packets that were verified locally but never published, plus the documentation sync.

## Packets

| Packet | Commit | Change |
|---|---|---|
| **WP4.3i-dead** | `db23801` | 14 overridden **rest-state** declarations deleted (−33 lines); `!important` 520 → 513 |
| **WP4.3i-filter-btn** | `cb5ff6e` | The 5 rules gated exclusively on `#filter-btn` deleted (−48 lines / 27 decls / 25 `!important` / 37 colour literals) |

### WP4.3i-dead — overridden rest-state declarations

The deleted declarations lose to unlayered, later, more specific `!important` rules in `components.css` (the Calm-Glass table system, and the three-id `#action-buttons-row.selection-actions` rule). The page bundle's own "2026 Glass/Neumorphic" versions have been dead since Calm-Glass landed.

A browser sentinel sweep nominated **24** declarations. Scope was cut to **14** because a same-CSS **control** run over the forced interaction states produced **52 differing records** — those states animate, so forced-state snapshots are not a stable oracle. The rest state is stable: control **0 diffs / 31,074 records**, old-vs-new **0 diffs / 31,074 records**.

### WP4.3i-filter-btn — dead `#filter-btn` family

`#filter-btn` exists nowhere in the application. Zero hits across templates, JS/TS, routes, utils, e2e, tests, scripts and `app.py`; runtime DOM probes returned 0 both before and after exercising a filter. All 10 comma-separated arms across the 5 rules were inspected and every one is `#filter-btn`-gated, so no live grouped arm was lost.

There is no Apply Filters button — filtering is change-driven via `filterExercises()` in `static/js/modules/filters.js`. The live hooks (`#clear-filters-btn`, the 12 `button.wpdd-button.wpdd-filter` triggers) are untouched.

## Behavior preservation

**The CSS diff is deletion-only: 0 insertions, 81 deletions.** No selector rewritten, no declaration reordered, no `!important` edited in place, no layer boundary moved, no formatting churn. Cascade layers are unchanged (`@layer workout-dropdowns` 468–571; `@layer workout` 718–1697), no rule was emptied, braces balance 808/808, and the file is still pure CRLF.

## Gates (from the packet evidence)

| Gate | Result |
|---|---|
| Cascade/selector contracts | **27/27 pass** (25 + 1 per packet) |
| Workout Plan Chromium (`workout-plan` + `exercise-interactions`) | **56 passed** |
| Full pytest (canonical tracked catalog) | **1,753 passed / 0 failed** |
| CSS parse (postcss) | PASS — 755 rules / 53 at-rules / 2,496 decls |
| `git diff --check` | CLEAN |

Both new contract tests assert per rule body rather than by fragile file-wide string match. The filter-btn red path was proven **twice**: re-adding a `#filter-btn` rule fails the test, and independently, renaming the template's `clear-filters-btn` to `filter-btn` also fails it.

## Stylelint

Focused (`static/css/pages-workout-plan.css`) **1,221 → 1,138 (−83)** across the two packets:

| Rule | Before | After | Delta |
|---|---|---|---|
| `declaration-no-important` | 520 | 488 | **−32** |
| `declaration-property-value-disallowed-list` | 481 | 452 | **−29** |
| `selector-max-id` | 75 | 65 | **−10** |
| `selector-max-specificity` | 77 | 67 | **−10** |
| `no-descending-specificity` | 61 | 59 | **−2** |
| `no-duplicate-selectors` | 7 | 7 | 0 |

Total across `static/css/*.css` + `scss/**/*.scss`: **5,877 → 5,794**. **No category increased**, focused or total; zero parse errors. filter-btn is the only packet in the WP4.3i arc to move `selector-max-id` / `selector-max-specificity` — those rules carried three ids each.

## Known visual drift

`workout-plan desktop dark` is the established WP4.0 animated-navbar-logo red. In the filter-btn run it failed at **1,039 px on the first attempt and 1,046 px on retry within the same run**, so the pixel count is a band, not an invariant — do not gate on the exact number.

Diff-image inspection confirms red pixels appear **only** on the animated navbar logo (two instances). The filter panel, controls, exercise-selection block and plan table are all ghosted-unchanged, and there is no red anywhere near the regions these packets touched. Animated-media drift, not layout or cascade drift. The other five variants — `desktop light`, `tablet light/dark`, `mobile light/dark` — are byte-identical.

**No visual baseline was updated.** `git status -- e2e/__screenshots__` is empty. No database, generated Bootstrap output, or SCSS appears in this diff.

## Explicitly deferred — not in this PR

**The 10 interaction-state declarations remain deferred and are still present in the file.** The only evidence available for them is the sentinel sweep, which the same-CSS control showed cannot be corroborated while those states animate. They must not be removed without animation stabilization plus a control run reaching **zero** differing records. The WP4.3i-dead contract test asserts they are still present, so a future packet cannot quietly delete them on the same weaker evidence.

Also deferred, unchanged: the superset dark-tint gap (`--superset-bg-1..4` has no live dark override) and the dead `body.dark-mode` in `static/css/layout.css:1120` (→ WP4.4).

The remaining Workout Plan raw-literal → token extraction and `!important` weighting review is redesign-sized and has not started, as have WP4.3j (Workout Log) and WP4.4 (shared bundles).

Evidence: `docs/CSS_PHASE4_WP4_3I_DEAD_EVIDENCE.md`, `docs/CSS_PHASE4_WP4_3I_FILTER_BTN_EVIDENCE.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
