### PR TITLE
build(packaging): pin PyInstaller build environment (Packet A0)

### DIFF
--- a/Hypertrophy-Toolbox.spec
+++ b/Hypertrophy-Toolbox.spec
@@ -1,7 +1,11 @@
 # -*- mode: python ; coding: utf-8 -*-
 from PyInstaller.utils.hooks import collect_submodules
 
-hiddenimports = ['flask', 'jinja2', 'werkzeug', 'pandas', 'numpy', 'openpyxl', 'xlsxwriter']
+# pandas/numpy were dropped when the exporters moved to XlsxWriter directly
+# (see routes/exports.py and utils/export_utils.py) and are not declared in
+# requirements.txt; listing them here only produced build-time resolution errors.
+# xlsxwriter is imported lazily inside functions, so it must stay declared here.
+hiddenimports = ['flask', 'jinja2', 'werkzeug', 'openpyxl', 'xlsxwriter']
 hiddenimports += collect_submodules('werkzeug')
 hiddenimports += collect_submodules('jinja2')
 

--- a/build_exe.bat
+++ b/build_exe.bat
@@ -26,6 +26,12 @@ for /f "tokens=*" %%i in ('python --version 2^>^&1') do set PYVER=%%i
 echo [OK] %PYVER% found
 echo.
 
+:: The build deliberately uses its own "venv", not the developer ".venv".
+:: .venv carries dev-only packages (pytest, playwright, pandas, numpy) that are
+:: not declared in requirements.txt, so building from it makes the result depend
+:: on incidental developer state. A dedicated environment built only from
+:: requirements.txt + requirements-build.txt is reproducible.
+
 :: Check if virtual environment exists, create if not
 if not exist "venv" (
     echo [SETUP] Creating virtual environment...
@@ -39,35 +45,30 @@ if not exist "venv" (
     echo.
 )
 
-:: Install dependencies if needed
-echo [INFO] Checking Flask...
-venv\Scripts\python.exe -c "import flask" >nul 2>&1
+:: Install runtime + build dependencies. Run unconditionally: the previous
+:: "install only if flask is missing" check left stale environments untouched,
+:: so a venv created before a requirements change silently kept building with
+:: the old dependency set. pip is a no-op when everything is already satisfied.
+echo [INFO] Installing runtime dependencies...
+venv\Scripts\pip.exe install -r requirements.txt
 if errorlevel 1 (
-    echo [SETUP] Installing dependencies...
-    venv\Scripts\pip.exe install -r requirements.txt
-    if errorlevel 1 (
-        echo [ERROR] Failed to install dependencies!
-        pause
-        exit /b 1
-    )
-    echo [OK] Dependencies installed
-    echo.
+    echo [ERROR] Failed to install runtime dependencies!
+    pause
+    exit /b 1
 )
+echo [OK] Runtime dependencies installed
+echo.
 
-:: Install PyInstaller if not present
-echo [INFO] Checking PyInstaller...
-venv\Scripts\python.exe -c "import PyInstaller" >nul 2>&1
+echo [INFO] Installing pinned build dependencies...
+venv\Scripts\pip.exe install -r requirements-build.txt
 if errorlevel 1 (
-    echo [SETUP] Installing PyInstaller...
-    venv\Scripts\pip.exe install pyinstaller
-    if errorlevel 1 (
-        echo [ERROR] Failed to install PyInstaller!
-        pause
-        exit /b 1
-    )
-    echo [OK] PyInstaller installed
-    echo.
+    echo [ERROR] Failed to install build dependencies!
+    pause
+    exit /b 1
 )
+venv\Scripts\python.exe -c "import PyInstaller; print('  PyInstaller ' + PyInstaller.__version__)"
+echo [OK] Build dependencies installed
+echo.
 
 :: Clean previous builds
 echo [INFO] Cleaning previous builds...
@@ -96,8 +97,6 @@ venv\Scripts\pyinstaller.exe --name "Hypertrophy-Toolbox" ^
     --hidden-import=flask ^
     --hidden-import=jinja2 ^
     --hidden-import=werkzeug ^
-    --hidden-import=pandas ^
-    --hidden-import=numpy ^
     --hidden-import=openpyxl ^
     --hidden-import=xlsxwriter ^
     --collect-submodules=werkzeug ^

--- a/build_exe.bat
+++ b/build_exe.bat
@@ -27,10 +27,11 @@ echo [OK] %PYVER% found
 echo.
 
 :: The build deliberately uses its own "venv", not the developer ".venv".
-:: .venv carries dev-only packages (pytest, playwright, pandas, numpy) that are
-:: not declared in requirements.txt, so building from it makes the result depend
-:: on incidental developer state. A dedicated environment built only from
-:: requirements.txt + requirements-build.txt is reproducible.
+:: .venv has accumulated packages that requirements.txt never declares (pandas,
+:: numpy), so building from it makes the artifact depend on incidental developer
+:: state -- that is how the stale pandas/numpy hidden imports appeared to work.
+:: A dedicated environment built only from the committed requirements files is
+:: reproducible.
 
 :: Check if virtual environment exists, create if not
 if not exist "venv" (

--- a/docs/rootdircleanup.md
+++ b/docs/rootdircleanup.md
@@ -379,7 +379,7 @@ Checklist:
       definition after confirming no application import path requires them.
 - [x] Keep genuine runtime/export dependencies such as XlsxWriter and openpyxl
       unless import analysis plus a packaged smoke proves otherwise.
-- [ ] Prove one clean build in a disposable, isolated worktree before changing
+- [x] Prove one clean build in a disposable, isolated worktree before changing
       the seed/bootstrap behavior.
 
 #### Recorded A0 decisions
@@ -390,11 +390,15 @@ Checklist:
   unrecorded version and its environment was discarded, so the version could not
   be recovered — hence the explicit pin plus a re-proved build.
 - **The build environment stays `venv/`, deliberately separate from `.venv`.**
-  `.venv` carries dev-only packages that `requirements.txt` never declares
-  (pytest, playwright, and incidentally pandas 3.0.3 / numpy 2.4.4). Building
-  from it would make the artifact depend on undeclared developer state, which is
-  exactly the reproducibility failure this packet exists to remove. `venv/` is
-  already gitignored.
+  `.venv` has accumulated packages `requirements.txt` never declares — pandas
+  3.0.3 and numpy 2.4.4 — which is precisely how the stale hidden imports
+  appeared to work. Building from it would make the artifact depend on
+  undeclared developer state. `venv/` is already gitignored.
+- **Observed, not fixed here:** `requirements.txt` mixes runtime and test
+  dependencies (`pytest`, `pytest-playwright`, `playwright`, `vulture`), so the
+  build environment installs test tooling it never needs. Splitting them is
+  Packet C's "decide whether PyInstaller belongs in a development requirements
+  file" item; A0 deliberately does not change the runtime dependency set.
 - **Dependency install is now unconditional.** The previous "install only if
   `flask` is missing" guard meant an environment created before a requirements
   change kept building against the stale set. pip is a no-op when satisfied.
@@ -407,6 +411,25 @@ Checklist:
   (`utils/export_utils.py`), so PyInstaller's static analysis will not find it.
   `openpyxl` is a module-level import in `utils/volume_splitter_service.py` and
   is kept as belt-and-braces.
+
+#### A0 re-probe result (2026-07-25)
+
+Built from a disposable `-Seed empty` worktree at commit `1155c06`, asserted
+clean of `data/database.db`, `data/auto_backup/` content, `.personal-*`, and
+`static/bodymaps/GPT/` before building.
+
+- `pyinstaller==6.21.0` resolved and installed; build exit code 0.
+- **Zero pandas/NumPy diagnostics** — the nonfatal build errors the first probe
+  reported are gone, confirming those hidden imports were the cause.
+- Distribution is 81 MB. `_internal/data/` contained **only**
+  `free_exercise_db_mapping.csv` and `youtube_curated_top_n.csv`. No
+  `auto_backup`, no `.personal-*`, no nested `.git`, no `static/bodymaps/GPT/`.
+- **`_internal/data/` contained no database at all.** Built from a clean
+  checkout the packaged app ships zero exercises, because the only catalog
+  source is the builder's own working-copy `data/database.db`. This is the
+  mirror image of the privacy defect and is independent confirmation that the
+  seed plus first-run bootstrap (decision 4A) is required, not merely tidier.
+- `youtube_curated_top_n.csv` is packaged today, confirming the allowlist need.
 
 Consolidating `build_exe.bat` onto the committed spec (D5) stays in Packet A;
 A0 changes only the dependency contract and the stale hidden imports, so the

--- a/docs/rootdircleanup.md
+++ b/docs/rootdircleanup.md
@@ -369,18 +369,48 @@ At review time:
 
 Checklist:
 
-- [ ] Add `requirements-build.txt` with an exact PyInstaller version validated
+- [x] Add `requirements-build.txt` with an exact PyInstaller version validated
       against the repository's supported Python version.
-- [ ] Make the build script install both runtime requirements and the pinned
+- [x] Make the build script install both runtime requirements and the pinned
       build requirements into its declared environment.
-- [ ] Decide whether the build environment remains `venv/` or becomes `.venv`;
+- [x] Decide whether the build environment remains `venv/` or becomes `.venv`;
       Packet A0 must resolve the inconsistency before Packet A relies on it.
-- [ ] Remove stale pandas/NumPy hidden imports from the canonical packaging
+- [x] Remove stale pandas/NumPy hidden imports from the canonical packaging
       definition after confirming no application import path requires them.
-- [ ] Keep genuine runtime/export dependencies such as XlsxWriter and openpyxl
+- [x] Keep genuine runtime/export dependencies such as XlsxWriter and openpyxl
       unless import analysis plus a packaged smoke proves otherwise.
 - [ ] Prove one clean build in a disposable, isolated worktree before changing
       the seed/bootstrap behavior.
+
+#### Recorded A0 decisions
+
+- **PyInstaller pinned to `6.21.0`** in `requirements-build.txt`. This machine
+  runs Python 3.14.4; 6.15.0 is the earliest release offered for 3.14, and
+  6.21.0 was the latest available at pin time. The first A0 probe ran with an
+  unrecorded version and its environment was discarded, so the version could not
+  be recovered — hence the explicit pin plus a re-proved build.
+- **The build environment stays `venv/`, deliberately separate from `.venv`.**
+  `.venv` carries dev-only packages that `requirements.txt` never declares
+  (pytest, playwright, and incidentally pandas 3.0.3 / numpy 2.4.4). Building
+  from it would make the artifact depend on undeclared developer state, which is
+  exactly the reproducibility failure this packet exists to remove. `venv/` is
+  already gitignored.
+- **Dependency install is now unconditional.** The previous "install only if
+  `flask` is missing" guard meant an environment created before a requirements
+  change kept building against the stale set. pip is a no-op when satisfied.
+- **`pandas` / `numpy` hidden imports removed** from both the spec and
+  `build_exe.bat`. Neither is imported by `app.py`, `app_launcher.py`,
+  `routes/`, or `utils/` — the exporters moved to XlsxWriter directly, and the
+  only surviving mentions are comments recording that migration. Neither is in
+  `requirements.txt`, so declaring them only produced resolution errors.
+- **`xlsxwriter` stays declared.** It is imported lazily inside functions
+  (`utils/export_utils.py`), so PyInstaller's static analysis will not find it.
+  `openpyxl` is a module-level import in `utils/volume_splitter_service.py` and
+  is kept as belt-and-braces.
+
+Consolidating `build_exe.bat` onto the committed spec (D5) stays in Packet A;
+A0 changes only the dependency contract and the stale hidden imports, so the
+two definitions still drift until §6.6 lands.
 
 The preflight build must not use the present main-checkout `data/` directory.
 Create a disposable worktree with `-Seed empty`, confirm it contains none of the

--- a/requirements-build.txt
+++ b/requirements-build.txt
@@ -1,0 +1,10 @@
+# Build-only requirements for producing the Windows/PyInstaller distribution.
+#
+# Kept separate from requirements.txt so the packaged application's runtime
+# dependency set stays minimal and auditable. Install both files into the build
+# environment (build_exe.bat does this).
+#
+# Pinned exactly: an unpinned PyInstaller makes "the build succeeded" a claim
+# about whatever version happened to be current that day, which is not a
+# reproducible result. 6.15.0 is the first release supporting Python 3.14.
+pyinstaller==6.21.0


### PR DESCRIPTION
Completes **Packet A0** of [docs/rootdircleanup.md](docs/rootdircleanup.md) — the reproducible build environment that Packet A's packaged-smoke gate depends on. No application code, tests, or CI touched.

## Why

The first A0 probe built successfully but its PyInstaller version was never recorded and its environment was discarded, so "the build works" was a claim about an unreproducible toolchain. A0's committed deliverables had also been reclassified as Packet A work, which would have left Packet A's build gate testing the packaging patch and the build environment at the same time.

## Changes

- **`requirements-build.txt`** pinning `pyinstaller==6.21.0` (6.15.0 is the earliest release offered for this machine's Python 3.14.4).
- **`build_exe.bat`** installs `requirements.txt` + `requirements-build.txt` **unconditionally**. The previous "install only if `flask` is missing" guard meant an environment created before a requirements change kept building against the stale set.
- **Build env stays `venv/`**, deliberately separate from `.venv`, with the rationale recorded: `.venv` carries pandas 3.0.3 / numpy 2.4.4 that `requirements.txt` never declares — which is exactly how the stale hidden imports appeared to work.
- **`pandas` / `numpy` hidden imports dropped** from the spec and `build_exe.bat`. Neither is imported by `app.py`, `app_launcher.py`, `routes/`, or `utils/`; the exporters moved to XlsxWriter directly and the only surviving mentions are comments recording that migration.
- **`xlsxwriter` kept** — imported lazily inside functions (`utils/export_utils.py`), so static analysis will not find it.

## Verification

Built from a disposable `-Seed empty` worktree at `1155c06`, asserted clean of `data/database.db`, `data/auto_backup/` content, `.personal-*`, and `static/bodymaps/GPT/` before building.

- `pyinstaller 6.21.0`, exit code 0, **zero pandas/NumPy diagnostics** — the nonfatal errors the first probe reported are gone.
- 81 MB dist; `_internal/data/` contained only the two CSVs. No `auto_backup`, `.personal-*`, nested `.git`, or GPT scratch.
- Probe worktree, venv, and artifact removed afterward.

Two findings recorded in the plan: a clean-checkout build ships **no database at all** (independently confirming the seed + bootstrap decision), and `youtube_curated_top_n.csv` is packaged today (confirming the allowlist need).

Scope guard: `build_exe.bat` still overwrites the committed spec — consolidating them is Packet A §6.6, deliberately not done here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)