### PR TITLE
packaging: verify staged assets by SHA-256 and smoke the real bootloader

### DIFF
--- a/.github/workflows/deep-gate.yml
+++ b/.github/workflows/deep-gate.yml
@@ -284,6 +284,57 @@ jobs:
             con.close()
         PY
 
+  frozen-windows:
+    name: Frozen executable (real bootloader, Windows)
+    # The half the development machine cannot run. Smart App Control there
+    # refuses to launch a freshly built, unsigned bootloader (WinError 4551),
+    # so the local smoke falls back to --mode payload, which exercises the
+    # packaged files but NOT the bootloader. GitHub's Windows runners do not
+    # enforce Smart App Control, so this job launches the executable an end
+    # user actually double-clicks. Disabling Smart App Control locally is not
+    # an option that was ever on the table.
+    runs-on: windows-latest
+
+    steps:
+    - name: Checkout code
+      uses: actions/checkout@v4
+
+    - name: Set up Python
+      uses: actions/setup-python@v5
+      with:
+        python-version: '3.11'
+        cache: 'pip'
+
+    - name: Install runtime and pinned build dependencies
+      run: |
+        python -m pip install --upgrade pip
+        pip install -r requirements.txt
+        pip install -r requirements-build.txt
+        python -c "import PyInstaller; print('PyInstaller ' + PyInstaller.__version__)"
+
+    # Staging is what the spec calls too; running it first fails a broken
+    # manifest in seconds instead of after a full build, and writes the
+    # manifest.sha256 the smoke verifies the built tree against.
+    - name: Stage tracked package assets
+      run: python scripts/stage_package_assets.py
+
+    - name: Build via the canonical spec
+      run: pyinstaller --clean --noconfirm Hypertrophy-Toolbox.spec
+
+    # --mode bootloader is the entire point of this job. Do not weaken it to
+    # payload mode to make a red run green: a payload pass says nothing about
+    # whether the executable starts.
+    - name: Smoke the real bootloader
+      run: |
+        python scripts/smoke_packaged_app.py --mode bootloader
+
+    - name: Upload distribution inventory on failure
+      if: failure()
+      run: |
+        Get-ChildItem -Recurse dist/Hypertrophy-Toolbox/_internal/data |
+          Select-Object FullName, Length | Format-Table -AutoSize
+      shell: pwsh
+
   visual-linux:
     name: Visual regression (Linux baselines)
     # Opt-in only: a normal deep-gate run skips this unless run_visual=true. This

--- a/app_launcher.py
+++ b/app_launcher.py
@@ -64,13 +64,20 @@ def main():
         print("  Application loaded successfully!")
         print()
         
-        # Start browser opener in background thread
-        browser_thread = threading.Thread(target=open_browser, args=(port, 2))
-        browser_thread.daemon = True
-        browser_thread.start()
-        
+        # Start browser opener in background thread. Automated packaged smokes
+        # set HT_NO_BROWSER so a CI runner does not spawn a browser it cannot
+        # close.
+        headless = os.getenv('HT_NO_BROWSER', '0') == '1'
+        if not headless:
+            browser_thread = threading.Thread(
+                target=open_browser, args=(port, 2)
+            )
+            browser_thread.daemon = True
+            browser_thread.start()
+
         print(f"  Server running at: http://127.0.0.1:{port}")
-        print("  Browser will open automatically...")
+        if not headless:
+            print("  Browser will open automatically...")
         print("\n  Press Ctrl+C to stop the server")
         print("="*50 + "\n")
         

--- a/docs/rootdircleanup.md
+++ b/docs/rootdircleanup.md
@@ -909,20 +909,27 @@ Two gaps remain:
 Packet A3 closes both and is deliberately small: it changes no packaging
 inputs, no allowlist, and no application behavior.
 
-- [ ] Compare staged content by SHA-256, not by size and mtime.
-- [ ] Keep a size fast path so the common case does not hash twice for nothing;
+- [x] Compare staged content by SHA-256, not by size and mtime.
+- [x] Keep a size fast path so the common case does not hash twice for nothing;
       equal sizes must fall through to the digest.
-- [ ] Make a content mismatch self-healing in `sync_staging_tree()` (restage)
+- [x] Make a content mismatch self-healing in `sync_staging_tree()` (restage)
       and fatal in `verify_staging_tree()` (fail closed). A stale staging tree
       must not be able to poison every later build.
-- [ ] Emit `manifest.sha256` in standard `sha256sum` format beside the staging
+- [x] Emit `manifest.sha256` in standard `sha256sum` format beside the staging
       root, so `sha256sum -c` and any reviewer can re-verify independently.
-- [ ] Write it beside the staging root, never inside it: the staging tree must
+- [x] Write it beside the staging root, never inside it: the staging tree must
       keep matching the manifest exactly, and an extra file inside would be
       rejected as unexpected.
-- [ ] Add the mutation regression test: stage, rewrite a staged file with
+- [x] Add the mutation regression test: stage, rewrite a staged file with
       equal-length content, restore its mtime exactly, and assert both that
       restaging repairs it and that verification rejects it.
+
+**Line endings are part of the contract.** Writing the record through Windows
+text mode produced CRLF, and `sha256sum -c` then looked for paths with a
+trailing carriage return and failed on all 997. The writer pins `newline="\n"`
+and a test asserts the bytes contain no `\r` — found only because the record was
+checked with the external tool it claims compatibility with, not just with the
+reader that wrote it.
 
 **Hashing cost is accepted.** The tracked asset tree is about 61 MB. Staging
 reads it roughly three times per build (copy decision, copy, verification)
@@ -966,12 +973,38 @@ Standing decisions:
   bootloader validation machine-independent and repeatable, which one
   developer's host policy never was in either direction.
 
-- [ ] Add a `windows-latest` deep-gate job that builds via the canonical spec.
-- [ ] Launch the real `.exe`, not the payload, and assert it serves the app.
-- [ ] Assert the packaged data allowlist and absence of ignored content in the
+- [x] Add a `windows-latest` deep-gate job that builds via the canonical spec.
+- [x] Launch the real `.exe`, not the payload, and assert it serves the app.
+- [x] Assert the packaged data allowlist and absence of ignored content in the
       built tree.
-- [ ] Verify the built assets against `manifest.sha256`.
-- [ ] Label the local payload smoke explicitly in code and documentation.
+- [x] Verify the built assets against `manifest.sha256`.
+- [x] Label the local payload smoke explicitly in code and documentation.
+
+The smoke itself is now committed as `scripts/smoke_packaged_app.py` rather than
+reconstructed by hand each packet, which is what let A2's environment note go
+unchallenged for a day. Static checks run against the untouched build output;
+the server runs from a throwaway copy, so first-run writes never dirty `dist/`.
+
+`frozen-windows` lives in the manual deep gate beside the other packaged and
+cold-start smokes, so it does not add ten minutes to every PR. Promoting it to a
+required PR check is an owner decision: it needs a branch-protection change, and
+required-check names are exact-match.
+
+#### Recorded A3 results
+
+Base `origin/main` `906b2fe` (plan-doc merge), itself on the `631f61a` verified
+starting point. pytest baseline **1,785 passed / 1 skipped**; after the change
+**1,792 passed / 1 skipped** — the seven new staging contracts.
+
+A real `build_exe.bat` build completed (exit 0, pinned PyInstaller 6.21.0) and
+regenerated both the staging tree and `build/manifest.sha256` after
+`--clean` wiped `build/`. Against that distribution:
+
+- Static inspection passed all eight checks, including **997 packaged assets
+  matching `manifest.sha256`** and the two-file `data/` allowlist.
+- `sha256sum -c` verified all 997 staged files independently.
+- The **real bootloader** passed the full 22-check runtime smoke, three runs out
+  of three, and payload mode passed once for comparison.
 
 ---
 
@@ -1539,9 +1572,9 @@ Every packet starts from freshly fetched `origin/main`, records its actual
 starting SHA and test baseline, ships as one PR declaring its behavior and
 schema changes, and merges only on green CI.
 
-1. [ ] This document records the accepted decisions and closes the Packet B
-       authorization checklist.
-2. [ ] **A3** — staging SHA-256 hardening and the real frozen gate.
+1. [x] This document records the accepted decisions and closes the Packet B
+       authorization checklist. (PR #171.)
+2. [x] **A3** — staging SHA-256 hardening and the real frozen gate.
 3. [ ] **B1** — resolver, config, and logging foundation, without switching the
        frozen database path.
 4. [ ] **B2** — frozen runtime database path, legacy migration, and backup

--- a/scripts/smoke_packaged_app.py
+++ b/scripts/smoke_packaged_app.py
@@ -1,0 +1,334 @@
+"""Smoke a built distribution: inspect the tree, then serve from it.
+
+Two modes, and the difference matters:
+
+``bootloader``
+    Launches ``Hypertrophy-Toolbox.exe`` — the PyInstaller bootloader an end
+    user actually double-clicks. This is the real packaged-application test.
+
+``payload``
+    Runs the packaged application modules with an external interpreter over the
+    distribution's own ``_internal/`` tree. It exercises the packaged
+    templates, static assets, catalog seed, and compiled modules, and **not**
+    the bootloader. It exists because Windows Smart App Control refuses to
+    launch a freshly built, unsigned bootloader on the development machine
+    (``WinError 4551``). Never read a passing payload run as evidence that the
+    executable starts.
+
+Static checks always run against the untouched build output; the server runs
+from a throwaway copy, so first-run writes never dirty ``dist/``.
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import shutil
+import subprocess
+import sys
+import tempfile
+import time
+import urllib.error
+import urllib.request
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(REPO_ROOT))
+
+from scripts.stage_package_assets import (  # noqa: E402
+    DIGEST_FILENAME,
+    STAGING_RELATIVE,
+    file_digest,
+    verify_against_digest_manifest,
+)
+
+APPROVED_DATA_FILES = {"catalog.seed.db", "free_exercise_db_mapping.csv"}
+FORBIDDEN_NAME_PREFIXES = (".personal",)
+SIDECAR_SUFFIXES = ("-wal", "-shm", "-journal")
+
+EXPECTED_EXERCISES = 1897
+EXPECTED_BARBELL_MATCHES = 225
+
+PAGES = (
+    "/",
+    "/workout_plan",
+    "/workout_log",
+    "/weekly_summary",
+    "/session_summary",
+    "/progression",
+)
+ASSETS = {
+    "/static/css/base.css": "text/css",
+    "/static/css/bootstrap.custom.min.css": "text/css",
+    "/static/js/app.js": "javascript",
+    "/static/js/modules/fetch-wrapper.js": "javascript",
+    "/static/images/favicon.ico": None,
+    "/static/bodymaps/hypertrophy-advanced/body_anterior.svg": "svg",
+    "/static/vendor/free-exercise-db/exercises.json": "json",
+    "/static/vendor/free-exercise-db/LICENSE": None,
+    "/static/vendor/musclemap/VERSION": None,
+    "/static/vendor/free-exercise-db/exercises/Barbell_Squat/0.jpg": "image",
+}
+
+
+class SmokeError(RuntimeError):
+    """Raised when the distribution or the running packaged app is wrong."""
+
+
+def _check(condition: bool, message: str) -> None:
+    if not condition:
+        raise SmokeError(message)
+    print(f"  ok  {message}")
+
+
+def inspect_distribution(dist: Path, digest_manifest: Path | None) -> None:
+    """Assert the built tree carries only approved, tracked, intact content."""
+    internal = dist / "_internal"
+    _check(internal.is_dir(), f"distribution has _internal/: {internal}")
+
+    data_files = sorted(path.name for path in (internal / "data").iterdir())
+    _check(
+        set(data_files) == APPROVED_DATA_FILES,
+        f"data/ holds exactly the allowlist: {data_files}",
+    )
+
+    everything = list(dist.rglob("*"))
+    _check(
+        not [p for p in everything if p.is_dir() and p.name == ".git"],
+        "no repository metadata anywhere in the distribution",
+    )
+    _check(
+        not [p for p in everything if p.is_dir() and p.name == "auto_backup"],
+        "no auto_backup directory",
+    )
+    _check(
+        not [
+            p
+            for p in everything
+            if p.name.startswith(FORBIDDEN_NAME_PREFIXES)
+        ],
+        "no personal export or utility files",
+    )
+    databases = sorted(
+        p.relative_to(dist).as_posix()
+        for p in everything
+        if p.suffix == ".db"
+    )
+    _check(
+        databases == ["_internal/data/catalog.seed.db"],
+        f"the catalog seed is the only database: {databases}",
+    )
+    _check(
+        not [
+            p
+            for p in everything
+            if p.is_file() and p.name.endswith(SIDECAR_SUFFIXES)
+        ],
+        "no SQLite sidecars",
+    )
+
+    if digest_manifest is not None:
+        verified = verify_against_digest_manifest(internal, digest_manifest)
+        _check(
+            len(verified) > 0,
+            f"{len(verified)} packaged assets match {digest_manifest.name}",
+        )
+
+
+def _get(url: str, timeout: float = 30.0):
+    request = urllib.request.Request(url, headers={"Accept": "*/*"})
+    return urllib.request.urlopen(request, timeout=timeout)
+
+
+def _post_json(url: str, payload: dict, timeout: float = 30.0):
+    request = urllib.request.Request(
+        url,
+        data=json.dumps(payload).encode("utf-8"),
+        headers={
+            "Content-Type": "application/json",
+            "X-Requested-With": "XMLHttpRequest",
+        },
+    )
+    return urllib.request.urlopen(request, timeout=timeout)
+
+
+def _launch(work_dir: Path, mode: str, payload_python: Path | None):
+    child_environment = {
+        **os.environ,
+        "HT_NO_BROWSER": "1",
+        "FLASK_USE_RELOADER": "0",
+    }
+
+    if mode == "bootloader":
+        executable = work_dir / "Hypertrophy-Toolbox.exe"
+        if not executable.is_file():
+            executable = work_dir / "Hypertrophy-Toolbox"
+        if not executable.is_file():
+            raise SmokeError(f"No bootloader executable in {work_dir}")
+        print(f"[SMOKE] launching the real bootloader: {executable}")
+        return subprocess.Popen(
+            [str(executable)],
+            cwd=str(work_dir),
+            env=child_environment,
+        )
+
+    interpreter = payload_python or Path(sys.executable)
+    entry = work_dir / "_internal" / "app.pyc"
+    if not entry.is_file():
+        raise SmokeError(f"No packaged application payload at {entry}")
+    print("[SMOKE] *** payload mode: the bootloader is NOT exercised ***")
+    print(f"[SMOKE] running {entry} with {interpreter}")
+    return subprocess.Popen(
+        [str(interpreter), "app.pyc"],
+        cwd=str(entry.parent),
+        env=child_environment,
+    )
+
+
+def _wait_for_server(base_url: str, process, attempts: int = 60) -> None:
+    for _ in range(attempts):
+        if process.poll() is not None:
+            raise SmokeError(
+                f"packaged app exited early with code {process.returncode}"
+            )
+        try:
+            with _get(f"{base_url}/", timeout=5) as response:
+                if response.status == 200:
+                    return
+        except (urllib.error.URLError, OSError, TimeoutError):
+            pass
+        time.sleep(2)
+    raise SmokeError(f"packaged app never served {base_url}/")
+
+
+def serve_and_check(
+    work_dir: Path,
+    mode: str,
+    payload_python: Path | None,
+    port: int,
+) -> None:
+    """Boot the distribution and assert it serves real catalog-backed pages."""
+    base_url = f"http://127.0.0.1:{port}"
+    runtime_db = work_dir / "_internal" / "data" / "database.db"
+    seed = work_dir / "_internal" / "data" / "catalog.seed.db"
+    seed_digest = file_digest(seed)
+
+    _check(not runtime_db.exists(), "no runtime database before first launch")
+
+    process = _launch(work_dir, mode, payload_python)
+    try:
+        _wait_for_server(base_url, process)
+        for route in PAGES:
+            with _get(f"{base_url}{route}") as response:
+                _check(response.status == 200, f"GET {route} -> 200")
+
+        for route, expected_type in ASSETS.items():
+            with _get(f"{base_url}{route}") as response:
+                content_type = response.headers.get("Content-Type", "")
+                _check(
+                    response.status == 200
+                    and (
+                        expected_type is None or expected_type in content_type
+                    ),
+                    f"GET {route} -> 200 ({content_type})",
+                )
+
+        with _get(f"{base_url}/get_all_exercises") as response:
+            exercises = json.loads(response.read())["data"]
+        _check(
+            len(exercises) == EXPECTED_EXERCISES,
+            f"/get_all_exercises -> {len(exercises)} exercises",
+        )
+
+        with _post_json(
+            f"{base_url}/filter_exercises", {"equipment": "Barbell"}
+        ) as response:
+            matches = json.loads(response.read())["data"]
+        _check(
+            len(matches) == EXPECTED_BARBELL_MATCHES,
+            f"/filter_exercises Barbell -> {len(matches)} exercises",
+        )
+    finally:
+        process.terminate()
+        try:
+            process.wait(timeout=30)
+        except subprocess.TimeoutExpired:
+            process.kill()
+
+    _check(runtime_db.is_file(), "first launch created the runtime database")
+    _check(
+        file_digest(seed) == seed_digest,
+        "the packaged catalog seed is byte-identical after first run",
+    )
+    _check(
+        not (work_dir / "_internal" / "data" / "auto_backup").exists(),
+        "no redundant first-run backup",
+    )
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--dist",
+        type=Path,
+        default=REPO_ROOT / "dist" / "Hypertrophy-Toolbox",
+    )
+    parser.add_argument(
+        "--mode",
+        choices=("bootloader", "payload"),
+        default="bootloader",
+        help="payload mode does NOT exercise the bootloader.",
+    )
+    parser.add_argument(
+        "--payload-python",
+        type=Path,
+        default=None,
+        help="Interpreter for payload mode; must match the build's version.",
+    )
+    parser.add_argument(
+        "--digest-manifest",
+        type=Path,
+        default=REPO_ROOT / STAGING_RELATIVE.parent / DIGEST_FILENAME,
+    )
+    parser.add_argument("--port", type=int, default=5000)
+    parser.add_argument(
+        "--skip-runtime",
+        action="store_true",
+        help="Inspect the built tree only.",
+    )
+    args = parser.parse_args()
+
+    dist = args.dist.resolve()
+    digest_manifest = (
+        args.digest_manifest.resolve()
+        if args.digest_manifest and args.digest_manifest.is_file()
+        else None
+    )
+
+    try:
+        print(f"[SMOKE] inspecting {dist}")
+        inspect_distribution(dist, digest_manifest)
+        if args.skip_runtime:
+            print("[SMOKE] PASS (static checks only)")
+            return
+
+        with tempfile.TemporaryDirectory(prefix="ht-smoke-") as temporary:
+            work_dir = Path(temporary) / dist.name
+            print(f"[SMOKE] copying distribution to {work_dir}")
+            shutil.copytree(dist, work_dir)
+            serve_and_check(
+                work_dir, args.mode, args.payload_python, args.port
+            )
+    except (SmokeError, OSError, ValueError) as exc:
+        raise SystemExit(f"[SMOKE] FAIL: {exc}") from exc
+
+    label = (
+        "real bootloader"
+        if args.mode == "bootloader"
+        else "packaged payload (bootloader NOT exercised)"
+    )
+    print(f"[SMOKE] PASS via {label}")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/stage_package_assets.py
+++ b/scripts/stage_package_assets.py
@@ -5,10 +5,16 @@ any ignored or untracked working-copy file could reach the distribution and had
 to be subtracted by name. The manifest comes from ``git ls-files`` instead, and
 the build reads a staging tree rebuilt from it: untracked content cannot enter
 the package by construction rather than by exclusion.
+
+Staged content is compared by SHA-256. Size and mtime agree on a file that was
+rewritten in place at the same length with its timestamp restored, which is what
+a timestamp-preserving tool, an unlucky partial write, and deliberate tampering
+all look like.
 """
 from __future__ import annotations
 
 import argparse
+import hashlib
 import os
 import shutil
 import stat
@@ -18,6 +24,8 @@ from pathlib import Path
 
 ASSET_ROOTS = ("static", "templates")
 STAGING_RELATIVE = Path("build") / "package-assets"
+DIGEST_FILENAME = "manifest.sha256"
+_DIGEST_CHUNK = 1024 * 1024
 
 
 class StagingError(RuntimeError):
@@ -72,15 +80,28 @@ def _reject_case_collisions(manifest: list[str]) -> None:
         )
 
 
+def file_digest(path: Path) -> str:
+    """Return the SHA-256 of *path* as lowercase hex."""
+    digest = hashlib.sha256()
+    with path.open("rb") as handle:
+        for chunk in iter(lambda: handle.read(_DIGEST_CHUNK), b""):
+            digest.update(chunk)
+    return digest.hexdigest()
+
+
 def _needs_copy(source: Path, target: Path) -> bool:
+    """Decide whether *target* must be recopied from *source*.
+
+    Restaging is self-healing on purpose: a staged file that diverged for any
+    reason is replaced rather than reported, so a stale staging tree cannot
+    poison every later build. ``verify_staging_tree`` is where divergence is
+    fatal.
+    """
     if not target.exists():
         return True
-    source_stat = source.stat()
-    target_stat = target.stat()
-    return (
-        source_stat.st_size != target_stat.st_size
-        or int(source_stat.st_mtime) != int(target_stat.st_mtime)
-    )
+    if source.stat().st_size != target.stat().st_size:
+        return True
+    return file_digest(source) != file_digest(target)
 
 
 def _prune_staging_tree(staging_root: Path, wanted: set[str]) -> None:
@@ -119,6 +140,7 @@ def sync_staging_tree(repo_root: Path, staging_root: Path) -> list[str]:
             shutil.copy2(source, target)
     _prune_staging_tree(staging_root, set(manifest))
     verify_staging_tree(repo_root, staging_root, manifest)
+    write_digest_manifest(staging_root, manifest)
     return manifest
 
 
@@ -149,6 +171,10 @@ def verify_staging_tree(
         target = staging_root / relative
         if source.stat().st_size != target.stat().st_size:
             mismatched.append(f"  size: {relative}")
+        # Recomputed rather than reused from the copy decision: evidence that
+        # shares a failure mode with the thing it certifies is not evidence.
+        elif file_digest(source) != file_digest(target):
+            mismatched.append(f"  content: {relative}")
         elif os.name != "nt" and (
             stat.S_IMODE(source.stat().st_mode) & stat.S_IXUSR
             != stat.S_IMODE(target.stat().st_mode) & stat.S_IXUSR
@@ -159,6 +185,76 @@ def verify_staging_tree(
             "Staged assets differ from tracked sources:\n"
             + "\n".join(mismatched)
         )
+
+
+def digest_manifest_path(staging_root: Path) -> Path:
+    """Return the digest record's path: beside the staging root, never inside.
+
+    The staged tree must keep matching the manifest exactly, so a record of it
+    stored inside would be pruned as an unexpected file.
+    """
+    return staging_root.parent / DIGEST_FILENAME
+
+
+def write_digest_manifest(staging_root: Path, manifest: list[str]) -> Path:
+    """Record staged digests in ``sha256sum`` format and return the path."""
+    lines = [
+        f"{file_digest(staging_root / relative)}  {relative}"
+        for relative in manifest
+    ]
+    target = digest_manifest_path(staging_root)
+    target.parent.mkdir(parents=True, exist_ok=True)
+    # newline="\n" explicitly: Windows text mode would emit CRLF, and
+    # `sha256sum -c` then looks for paths with a trailing carriage return.
+    with target.open("w", encoding="utf-8", newline="\n") as handle:
+        handle.write("\n".join(lines) + "\n")
+    return target
+
+
+def read_digest_manifest(digest_path: Path) -> dict[str, str]:
+    """Parse a ``sha256sum``-format record into ``{relative path: digest}``."""
+    recorded = {}
+    for number, line in enumerate(
+        digest_path.read_text(encoding="utf-8").splitlines(), start=1
+    ):
+        if not line.strip():
+            continue
+        digest, separator, relative = line.partition("  ")
+        if not separator or len(digest) != 64:
+            raise StagingError(
+                f"Malformed digest record at {digest_path}:{number}: {line!r}"
+            )
+        recorded[relative] = digest
+    return recorded
+
+
+def verify_against_digest_manifest(
+    tree_root: Path,
+    digest_path: Path,
+) -> list[str]:
+    """Fail unless every recorded asset is present under *tree_root* and intact.
+
+    Runs against a staging tree or a built distribution, so a reviewer — or the
+    frozen build gate — can check a distribution without the source it came
+    from. Returns the verified paths.
+    """
+    recorded = read_digest_manifest(digest_path)
+    if not recorded:
+        raise StagingError(f"Digest record is empty: {digest_path}")
+
+    failures = []
+    for relative, expected in recorded.items():
+        candidate = tree_root / relative
+        if not candidate.is_file():
+            failures.append(f"  missing: {relative}")
+        elif file_digest(candidate) != expected:
+            failures.append(f"  content: {relative}")
+    if failures:
+        raise StagingError(
+            f"Tree at {tree_root} does not match {digest_path}:\n"
+            + "\n".join(failures)
+        )
+    return sorted(recorded)
 
 
 def staged_datas(
@@ -190,10 +286,40 @@ def main() -> None:
         action="store_true",
         help="Print the manifest instead of a per-root summary.",
     )
+    parser.add_argument(
+        "--verify-tree",
+        type=Path,
+        default=None,
+        help=(
+            "Verify an already-built tree (e.g. a distribution's _internal/) "
+            "against a recorded digest manifest instead of staging."
+        ),
+    )
+    parser.add_argument(
+        "--digest-manifest",
+        type=Path,
+        default=None,
+        help="Digest record for --verify-tree. Defaults beside --staging-root.",
+    )
     args = parser.parse_args()
 
     repo_root = args.repo_root.resolve()
     staging_root = args.staging_root or (repo_root / STAGING_RELATIVE)
+
+    if args.verify_tree is not None:
+        digest_path = args.digest_manifest or digest_manifest_path(staging_root)
+        try:
+            verified = verify_against_digest_manifest(
+                args.verify_tree, digest_path
+            )
+        except (StagingError, OSError) as exc:
+            raise SystemExit(f"[ASSET STAGING] ERROR: {exc}") from exc
+        print(
+            f"[ASSET STAGING] verified {len(verified)} files in "
+            f"{args.verify_tree} against {digest_path}"
+        )
+        return
+
     try:
         manifest = sync_staging_tree(repo_root, staging_root)
     except (StagingError, subprocess.CalledProcessError) as exc:
@@ -207,6 +333,10 @@ def main() -> None:
         count = sum(1 for path in manifest if path.startswith(f"{root}/"))
         print(f"[ASSET STAGING] {root}/: {count} tracked files")
     print(f"[ASSET STAGING] staged {len(manifest)} files into {staging_root}")
+    print(
+        "[ASSET STAGING] digests recorded in "
+        f"{digest_manifest_path(staging_root)}"
+    )
 
 
 if __name__ == "__main__":

--- a/tests/test_package_asset_staging.py
+++ b/tests/test_package_asset_staging.py
@@ -2,6 +2,7 @@
 from __future__ import annotations
 
 import os
+import shutil
 import stat
 import subprocess
 from pathlib import Path
@@ -10,13 +11,18 @@ import pytest
 
 from scripts.stage_package_assets import (
     ASSET_ROOTS,
+    DIGEST_FILENAME,
     STAGING_RELATIVE,
     StagingError,
     _reject_case_collisions,
     _reject_repository_metadata,
+    digest_manifest_path,
+    file_digest,
+    read_digest_manifest,
     staged_datas,
     sync_staging_tree,
     tracked_assets,
+    verify_against_digest_manifest,
     verify_staging_tree,
 )
 
@@ -253,6 +259,136 @@ def test_case_colliding_assets_are_rejected():
 def test_gitlinked_repository_metadata_is_rejected():
     with pytest.raises(StagingError, match="Repository metadata"):
         _reject_repository_metadata(["static/vendor/thing/.git/config"])
+
+
+def _mutate_preserving_size_and_mtime(path: Path, replacement: bytes) -> None:
+    """Rewrite *path* at its original length with its original timestamps."""
+    original = path.stat()
+    assert len(replacement) == original.st_size, "test must preserve size"
+    path.write_bytes(replacement)
+    os.utime(path, (original.st_atime, original.st_mtime))
+
+
+def test_equal_size_equal_mtime_mutation_is_detected_and_repaired(
+    asset_repo: Path, tmp_path: Path
+):
+    """The regression this packet exists for.
+
+    Size and integer mtime both agree on a staged file rewritten in place at
+    the same length with its timestamp restored, so the previous comparison
+    neither recopied nor rejected it.
+    """
+    staging_root = tmp_path / "staging"
+    manifest = sync_staging_tree(asset_repo, staging_root)
+    staged = staging_root / "static" / "css" / "base.css"
+    source = asset_repo / "static" / "css" / "base.css"
+    _mutate_preserving_size_and_mtime(staged, b"b{}")
+
+    assert staged.stat().st_size == source.stat().st_size
+    assert int(staged.stat().st_mtime) == int(source.stat().st_mtime)
+
+    with pytest.raises(StagingError, match="content: static/css/base.css"):
+        verify_staging_tree(asset_repo, staging_root, manifest)
+
+    # Restaging repairs it: a diverged staging tree must not be able to wedge
+    # every later build.
+    sync_staging_tree(asset_repo, staging_root)
+
+    assert staged.read_bytes() == source.read_bytes()
+    verify_staging_tree(asset_repo, staging_root, manifest)
+
+
+def test_digest_manifest_records_every_staged_asset(
+    asset_repo: Path, tmp_path: Path
+):
+    staging_root = tmp_path / "staging"
+    manifest = sync_staging_tree(asset_repo, staging_root)
+
+    recorded = read_digest_manifest(digest_manifest_path(staging_root))
+
+    assert sorted(recorded) == manifest
+    for relative, digest in recorded.items():
+        assert digest == file_digest(asset_repo / relative)
+
+
+def test_digest_manifest_is_stored_beside_the_staging_tree(
+    asset_repo: Path, tmp_path: Path
+):
+    """Inside the tree it would be pruned as an unexpected file."""
+    staging_root = tmp_path / "staging"
+    manifest = sync_staging_tree(asset_repo, staging_root)
+
+    digest_path = digest_manifest_path(staging_root)
+    assert digest_path == tmp_path / DIGEST_FILENAME
+    assert not list(staging_root.rglob(DIGEST_FILENAME))
+    verify_staging_tree(asset_repo, staging_root, manifest)
+
+
+def test_digest_manifest_is_sha256sum_verifiable(
+    asset_repo: Path, tmp_path: Path
+):
+    staging_root = tmp_path / "staging"
+    sync_staging_tree(asset_repo, staging_root)
+
+    lines = (
+        digest_manifest_path(staging_root)
+        .read_text(encoding="utf-8")
+        .splitlines()
+    )
+
+    assert lines == [
+        f"{file_digest(asset_repo / 'static/css/base.css')}  "
+        "static/css/base.css",
+        f"{file_digest(asset_repo / 'templates/base.html')}  "
+        "templates/base.html",
+    ]
+
+
+def test_digest_manifest_uses_lf_endings(asset_repo: Path, tmp_path: Path):
+    """Windows text mode would emit CRLF and break `sha256sum -c`."""
+    staging_root = tmp_path / "staging"
+    sync_staging_tree(asset_repo, staging_root)
+
+    raw = digest_manifest_path(staging_root).read_bytes()
+
+    assert b"\r" not in raw
+    assert raw.endswith(b"\n")
+
+
+def test_built_tree_verification_detects_tampering(
+    asset_repo: Path, tmp_path: Path
+):
+    """A distribution can be checked without the source it was built from."""
+    staging_root = tmp_path / "staging"
+    sync_staging_tree(asset_repo, staging_root)
+    digest_path = digest_manifest_path(staging_root)
+    built = tmp_path / "dist" / "_internal"
+    shutil.copytree(staging_root, built)
+
+    assert verify_against_digest_manifest(built, digest_path) == [
+        "static/css/base.css",
+        "templates/base.html",
+    ]
+
+    _mutate_preserving_size_and_mtime(built / "static" / "css" / "base.css", b"b{}")
+    with pytest.raises(StagingError, match="content: static/css/base.css"):
+        verify_against_digest_manifest(built, digest_path)
+
+    (built / "static" / "css" / "base.css").unlink()
+    with pytest.raises(StagingError, match="missing: static/css/base.css"):
+        verify_against_digest_manifest(built, digest_path)
+
+
+def test_malformed_digest_records_are_rejected(tmp_path: Path):
+    digest_path = tmp_path / DIGEST_FILENAME
+
+    digest_path.write_text("not-a-digest  static/css/base.css\n", encoding="utf-8")
+    with pytest.raises(StagingError, match="Malformed digest record"):
+        verify_against_digest_manifest(tmp_path, digest_path)
+
+    digest_path.write_text("", encoding="utf-8")
+    with pytest.raises(StagingError, match="Digest record is empty"):
+        verify_against_digest_manifest(tmp_path, digest_path)
 
 
 def test_spec_default_staging_root_is_ignored_build_output():


### PR DESCRIPTION
Packet A3 of `docs/rootdircleanup.md`. Base `origin/main` `906b2fe`, on the verified `631f61a` starting point.

## Behavior / schema changes

**None in the application.** No DB schema, no API response shapes, no calculation logic. Packaging *inputs* are unchanged — the manifest still resolves to the same 997 tracked files, and the built `data/` allowlist is still the same two files.

Two behavioral changes outside the app: staging now fails a build on staged-content divergence it previously accepted, and `app_launcher.py` honors `HT_NO_BROWSER=1`.

## The hole this closes

Packet A2 proved the staged tree is the tracked *set* — right names, sizes, executable bits. It never proved the staged *bytes* are the tracked bytes:

- `_needs_copy()` compared size and integer mtime.
- `verify_staging_tree()` compared size and the executable bit.

A staged file rewritten in place at the same length with its mtime restored passed both. That is the signature of a timestamp-preserving tool, an unlucky partial write, and deliberate tampering with `build/`.

Now content is compared by SHA-256. A size mismatch short-circuits, so equal sizes are what fall through to the digest. Divergence is **self-healing** in `sync_staging_tree()` and **fatal** in `verify_staging_tree()` — a stale staging tree must not be able to wedge every later build. Verification recomputes rather than reusing digests from the copy decision: evidence that shares a failure mode with what it certifies is not evidence.

## `manifest.sha256`

Written in standard `sha256sum` format *beside* the staging root — never inside, where the exact-match contract would reject it as unexpected. `--verify-tree` checks a built `_internal/` tree against it without needing the source it came from, which is what the CI gate uses.

Writing it needed `newline="\n"` pinned. Windows text mode emitted CRLF and `sha256sum -c` then looked for paths with a trailing carriage return and failed all 997. Found only by checking the record with the external tool it claims compatibility with, not just with the reader that wrote it. A test asserts the bytes contain no `\r`.

## Real frozen validation

`scripts/smoke_packaged_app.py` replaces the packaged smoke that was reconstructed by hand each packet. Two modes, and the difference is the point:

- `--mode bootloader` launches `Hypertrophy-Toolbox.exe` — what an end user double-clicks.
- `--mode payload` runs the packaged modules with an external interpreter and **does not exercise the bootloader**. Labelled in the `--mode` help, in the output, and in the plan.

`deep-gate.yml` gains `frozen-windows`: builds via the canonical spec on `windows-latest`, then runs `--mode bootloader`.

**Correction recorded in §6.11:** Packet A2's note that Smart App Control blocks the freshly built unsigned bootloader (`WinError 4551`) no longer reproduces. SAC is still in enforcement mode (`VerifiedAndReputablePolicyState = 1`), yet the real `.exe` passed the full smoke 3 runs out of 3. The block was conditional on something that has since changed. That is precisely why the gate belongs in CI: local success depends on a machine state this project neither controls nor asserts. Smart App Control was not disabled and payload mode is kept as the fallback for the next machine that does get blocked.

**One owner decision left open:** `frozen-windows` sits in the manual deep gate beside the other packaged and cold-start smokes, so it does not add ~10 minutes to every PR. Promoting it to a required PR check needs a branch-protection change, and required-check names are exact-match.

## Verification

- pytest **1,792 passed / 1 skipped** — baseline **1,785 / 1** at `631f61a`, plus 7 new staging contracts.
- Real `build_exe.bat` build, exit 0, pinned PyInstaller 6.21.0. Confirmed `--clean` wipes `build/` and the spec regenerates both the staging tree and `manifest.sha256`.
- Static distribution inspection 8/8: two-file `data/` allowlist, no `.git`, no `auto_backup`, no `.personal-*`, seed is the only `.db`, no SQLite sidecars, **997 packaged assets match `manifest.sha256`**.
- `sha256sum -c` green on all 997 staged files.
- **Real bootloader** smoke: 22 checks, 3 runs out of 3 — six pages, ten assets, 1,897 exercises, 225 Barbell matches, runtime DB created, seed byte-identical, no redundant first-run backup.
- Payload mode passed once for comparison.

The `frozen-windows` job itself is triggered on this branch before merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)