### PR TITLE
runtime: centralize path resolution and move logs out of the install directory

### DIFF
--- a/.claude/rules/database.md
+++ b/.claude/rules/database.md
@@ -70,10 +70,24 @@ tests and explicit empty-schema initialization remain empty.
 On corruption, `_attempt_database_recovery()` quarantines the bad file as
 `*.corrupted_<timestamp>` and a fresh empty DB is created on next init.
 
+## Runtime paths (`utils/runtime_paths.py`)
+One resolver owns every mutable path. Precedence, highest first: `DB_FILE`
+(database only) → `HT_RUNTIME_DIR` (whole runtime tree) → frozen per-user OS
+data directory → the repository. Never derive a runtime path from `__file__`,
+and never create runtime directories at import time — `get_db_connection()`
+creates a missing database parent, and logging creates its own directory.
+
+Logs already follow the resolver (`runtime_root()/logs`). The **database does
+not yet**: `DB_FILE` still defaults to `legacy_database_path()`
+(`<installation>/data/database.db`) even when frozen. Packet B2 repoints it
+atomically with legacy migration; `tests/test_runtime_paths.py` fails if that
+switch lands early.
+
 ## Env vars that affect DB (`utils/config.py`)
 | Variable | Default | Effect |
 |---|---|---|
-| `DB_FILE` | `data/database.db` | SQLite path. Tests patch `utils.config.DB_FILE` directly. |
+| `DB_FILE` | `data/database.db` | SQLite path; wins over every resolved path. Tests patch `utils.config.DB_FILE` directly. |
+| `HT_RUNTIME_DIR` | unset | Relocates the whole runtime tree (data + logs). Portable installs. |
 | `FLASK_DEBUG` | `'0'` in `app.py:259`; `'1'` in `database.py:90` | Controls Flask debug AND journal mode |
 | `TESTING` | unset | Set to `'1'` by `tests/conftest.py` for the shared pytest harness |
 

--- a/docs/rootdircleanup.md
+++ b/docs/rootdircleanup.md
@@ -1110,7 +1110,7 @@ Therefore:
 - **B1** introduces and tests the resolver, removes import-time directory
   creation, and relocates logging. It **must not** switch the frozen database
   path. The resolver may compute the frozen runtime path; nothing may use it
-  for `DB_FILE` yet.
+  for `DB_FILE` yet. **Shipped** — see §7.6.
 - **B2** activates the frozen `DB_FILE` switch **atomically with** legacy
   migration and backup copying — one PR, or not at all.
 - **B3** adds catalog versioning and additive upgrade behavior.
@@ -1234,6 +1234,52 @@ Cross-packet:
 - [ ] `DB_FILE` overrides remain deterministic.
 - [ ] Full pytest, E2E, cold-start, old-schema migration, packaged smoke, and
       recovery tests pass.
+
+### 7.6 Recorded B1 results
+
+`utils/runtime_paths.py` is the resolver. Before it, "where does state live" was
+answered independently by `utils/config.py` (from its own `__file__`),
+`utils/database.py` (from `DB_FILE`), and `utils/auto_backup.py` (from the
+database's parent). Three answers that happened to agree is not one policy, and
+a frozen build made them disagree — the installation directory is not writable
+in general, yet all three pointed at it.
+
+What B1 changed:
+
+- `runtime_root()` implements the §7.2 precedence. `HT_RUNTIME_DIR` is the
+  runtime-root override; it relocates the whole tree in one move and is the
+  supported portable-install mechanism.
+- **Logs moved**; the database did not. `logs_dir()` is `runtime_root()/logs`,
+  so a frozen install writes logs to `%LOCALAPPDATA%\HypertrophyToolbox\logs`
+  instead of needing write access to its own installation directory. Logs carry
+  nothing worth migrating, so relocating them cannot lose anything — which is
+  exactly why they can move a packet before the database.
+- **Import-time directory creation is gone.** `utils/config.py` used to
+  `os.makedirs` both `data/` and `logs/` at import, in whatever directory
+  happened to resolve — including during test collection. `get_db_connection()`
+  now creates a missing database parent directory at connection time, which
+  preserves the old guarantee for every entry point, and logging creates its own
+  directory when it initializes.
+- **`utils/database.py::DATA_DIR` removed.** Dead — recomputed from `DB_FILE` at
+  import and imported by nothing.
+- In a source checkout every resolved path is byte-for-byte what it was before.
+
+The sequencing constraint is enforced by tests, not by discipline.
+`TestPacketB1DoesNotMoveTheDatabase` asserts that a *frozen* process still
+resolves `DB_FILE` to `legacy_database_path()`, and an AST scan asserts that no
+module under `utils/` or `routes/` references `runtime_database_path()` at all.
+Those tests fail the moment the switch lands early; deleting them is part of
+B2's work, not a way to make B1 pass.
+
+Baseline at the packet's starting commit `e576cda`: **1,792 passed / 1 skipped**.
+After: **1,812 passed / 1 skipped** — 20 new resolver contracts, minus the
+`test_config` pair that asserted import-time directory creation and the
+`test_logger` case that asserted `os.makedirs` was called, both rewritten to
+assert behavior instead of implementation.
+
+Runtime check: `HT_RUNTIME_DIR` pointed at a throwaway directory, real `app.py`
+startup served `GET /` → 200 and wrote **both** `data/database.db` and
+`logs/app.log` under that root, leaving the repository's own `logs/` untouched.
 
 ---
 
@@ -1575,7 +1621,7 @@ schema changes, and merges only on green CI.
 1. [x] This document records the accepted decisions and closes the Packet B
        authorization checklist. (PR #171.)
 2. [x] **A3** — staging SHA-256 hardening and the real frozen gate.
-3. [ ] **B1** — resolver, config, and logging foundation, without switching the
+3. [x] **B1** — resolver, config, and logging foundation, without switching the
        frozen database path.
 4. [ ] **B2** — frozen runtime database path, legacy migration, and backup
        copying, activated atomically.

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -31,15 +31,23 @@ class TestConfigPaths:
         assert LOGS_DIR.startswith(BASE_DIR)
         assert LOGS_DIR.endswith("logs")
 
-    def test_data_dir_created(self):
-        """DATA_DIR should exist (created on import)."""
-        from utils.config import DATA_DIR
-        assert os.path.isdir(DATA_DIR)
+    def test_importing_config_creates_no_directories(self, tmp_path):
+        """Importing configuration must not touch the filesystem.
 
-    def test_logs_dir_created(self):
-        """LOGS_DIR should exist (created on import)."""
-        from utils.config import LOGS_DIR
-        assert os.path.isdir(LOGS_DIR)
+        It used to create data/ and logs/ under whatever directory resolved at
+        import, including during test collection and in unrelated scripts.
+        Consumers create what they need, where they need it.
+        """
+        import importlib
+        import utils.config
+
+        runtime_root = tmp_path / "runtime"
+        with patch.dict(os.environ, {"HT_RUNTIME_DIR": str(runtime_root)}):
+            importlib.reload(utils.config)
+            try:
+                assert not runtime_root.exists()
+            finally:
+                importlib.reload(utils.config)
 
 
 class TestDbFile:

--- a/tests/test_logger.py
+++ b/tests/test_logger.py
@@ -65,18 +65,31 @@ class TestSetupLogging:
     """Tests for setup_logging function."""
 
     @patch('utils.logger.RotatingFileHandler')
-    @patch('utils.logger.os.makedirs')
-    def test_creates_logs_directory(self, mock_makedirs, mock_handler):
-        """Should create logs directory."""
+    def test_creates_the_resolved_logs_directory(
+        self, mock_handler, tmp_path, monkeypatch
+    ):
+        """Should create the logs directory the resolver points at.
+
+        Asserted through the filesystem rather than through a mocked
+        os.makedirs: the point is that a relocated runtime root gets its logs
+        directory, not which call creates it.
+        """
         mock_handler.return_value = MagicMock()
-        
-        # Clear existing logger to force recreation
         import utils.logger
+        from utils.runtime_paths import RUNTIME_ROOT_ENV
+
+        runtime_root = tmp_path / "runtime"
+        monkeypatch.setenv(RUNTIME_ROOT_ENV, str(runtime_root))
         utils.logger._logger = None
-        
-        logger = utils.logger.setup_logging()
-        
-        mock_makedirs.assert_called()
+        original_handlers = logging.getLogger('hypertrophy_toolbox').handlers
+        logging.getLogger('hypertrophy_toolbox').handlers = []
+        try:
+            utils.logger.setup_logging()
+        finally:
+            logging.getLogger('hypertrophy_toolbox').handlers = original_handlers
+            utils.logger._logger = None
+
+        assert (runtime_root.resolve() / "logs").is_dir()
 
     @patch('utils.logger.RotatingFileHandler')
     @patch('utils.logger.os.makedirs')

--- a/tests/test_runtime_paths.py
+++ b/tests/test_runtime_paths.py
@@ -1,0 +1,284 @@
+"""Contracts for the centralized runtime-path resolver (Packet B1)."""
+from __future__ import annotations
+
+import ast
+import importlib
+import sys
+from pathlib import Path
+
+import pytest
+
+from utils import runtime_paths
+
+NEW_PATH_HELPER = "runtime_database_path"
+
+
+@pytest.fixture
+def clean_environment(monkeypatch):
+    """A process that inherits neither an override nor a frozen marker."""
+    monkeypatch.delenv(runtime_paths.RUNTIME_ROOT_ENV, raising=False)
+    monkeypatch.delattr(sys, "frozen", raising=False)
+    return monkeypatch
+
+
+def _freeze(monkeypatch):
+    monkeypatch.setattr(sys, "frozen", True, raising=False)
+
+
+class TestPrecedence:
+    def test_source_checkout_resolves_to_the_repository(self, clean_environment):
+        repository = Path(__file__).resolve().parents[1]
+
+        assert not runtime_paths.is_frozen()
+        assert runtime_paths.runtime_root() == repository
+        assert runtime_paths.runtime_data_dir() == repository / "data"
+        assert runtime_paths.logs_dir() == repository / "logs"
+
+    def test_override_relocates_the_whole_runtime_tree(
+        self, clean_environment, tmp_path
+    ):
+        root = tmp_path / "portable"
+        clean_environment.setenv(runtime_paths.RUNTIME_ROOT_ENV, str(root))
+
+        assert runtime_paths.runtime_root() == root.resolve()
+        assert runtime_paths.runtime_data_dir() == root.resolve() / "data"
+        assert runtime_paths.logs_dir() == root.resolve() / "logs"
+
+    def test_override_wins_over_the_frozen_user_data_directory(
+        self, clean_environment, tmp_path
+    ):
+        _freeze(clean_environment)
+        root = tmp_path / "usb"
+        clean_environment.setenv(runtime_paths.RUNTIME_ROOT_ENV, str(root))
+
+        assert runtime_paths.runtime_root() == root.resolve()
+
+    def test_frozen_build_resolves_to_a_per_user_directory(
+        self, clean_environment
+    ):
+        _freeze(clean_environment)
+
+        root = runtime_paths.runtime_root()
+
+        assert root == runtime_paths.user_data_root()
+        assert root != runtime_paths.installation_root()
+        assert runtime_paths.logs_dir() == root / "logs"
+
+    def test_override_expands_a_home_relative_path(
+        self, clean_environment
+    ):
+        clean_environment.setenv(runtime_paths.RUNTIME_ROOT_ENV, "~/ht-runtime")
+
+        assert runtime_paths.runtime_root() == (
+            Path.home() / "ht-runtime"
+        ).resolve()
+
+    @pytest.mark.parametrize(
+        "name", ["with spaces", "ünïcodé", "with spaces and ünïcodé"]
+    )
+    def test_awkward_path_characters_survive(
+        self, clean_environment, tmp_path, name
+    ):
+        root = tmp_path / name
+        clean_environment.setenv(runtime_paths.RUNTIME_ROOT_ENV, str(root))
+
+        resolved = runtime_paths.runtime_data_dir()
+        runtime_paths.ensure_directory(resolved)
+
+        assert resolved == root.resolve() / "data"
+        assert resolved.is_dir()
+
+
+class TestUserDataRoot:
+    def test_windows_prefers_local_over_roaming(self, clean_environment):
+        """A SQLite database must not be synchronized by a roaming profile."""
+        clean_environment.setattr(sys, "platform", "win32")
+        clean_environment.setenv("LOCALAPPDATA", r"C:\Users\test\AppData\Local")
+        clean_environment.setenv("APPDATA", r"C:\Users\test\AppData\Roaming")
+
+        root = runtime_paths.user_data_root()
+
+        assert root == Path(r"C:\Users\test\AppData\Local") / "HypertrophyToolbox"
+
+    def test_windows_falls_back_to_roaming_then_home(self, clean_environment):
+        clean_environment.setattr(sys, "platform", "win32")
+        clean_environment.delenv("LOCALAPPDATA", raising=False)
+        clean_environment.setenv("APPDATA", r"C:\Users\test\AppData\Roaming")
+
+        assert runtime_paths.user_data_root() == (
+            Path(r"C:\Users\test\AppData\Roaming") / "HypertrophyToolbox"
+        )
+
+        clean_environment.delenv("APPDATA", raising=False)
+
+        assert runtime_paths.user_data_root() == (
+            Path.home() / "AppData" / "Local" / "HypertrophyToolbox"
+        )
+
+    def test_macos_uses_application_support(self, clean_environment):
+        clean_environment.setattr(sys, "platform", "darwin")
+
+        assert runtime_paths.user_data_root() == (
+            Path.home()
+            / "Library"
+            / "Application Support"
+            / "HypertrophyToolbox"
+        )
+
+    def test_linux_honors_xdg_then_falls_back(self, clean_environment):
+        clean_environment.setattr(sys, "platform", "linux")
+        clean_environment.setenv("XDG_DATA_HOME", "/tmp/xdg")
+
+        assert runtime_paths.user_data_root() == Path(
+            "/tmp/xdg"
+        ) / "hypertrophy-toolbox"
+
+        clean_environment.delenv("XDG_DATA_HOME", raising=False)
+
+        assert runtime_paths.user_data_root() == (
+            Path.home() / ".local" / "share" / "hypertrophy-toolbox"
+        )
+
+
+class TestPacketB1DoesNotMoveTheDatabase:
+    """The sequencing constraint, as an executable contract.
+
+    Packet B2 activates the frozen database switch atomically with legacy
+    migration. If that switch lands first, an upgrading user boots onto a
+    freshly seeded empty database while their real one sits at the old path.
+    These tests fail the moment the switch happens early — deleting them is
+    part of B2's job, not a way to make B1 pass.
+    """
+
+    def test_legacy_database_path_is_installation_relative(
+        self, clean_environment
+    ):
+        _freeze(clean_environment)
+
+        assert runtime_paths.legacy_database_path() == (
+            runtime_paths.installation_root() / "data" / "database.db"
+        )
+
+    def test_configured_db_file_is_still_the_legacy_path_when_frozen(
+        self, clean_environment
+    ):
+        _freeze(clean_environment)
+        clean_environment.delenv("DB_FILE", raising=False)
+        import utils.config
+
+        try:
+            importlib.reload(utils.config)
+
+            assert (
+                Path(utils.config.DB_FILE)
+                == runtime_paths.legacy_database_path()
+            )
+            assert (
+                Path(utils.config.DB_FILE)
+                != runtime_paths.runtime_database_path()
+            )
+        finally:
+            clean_environment.undo()
+            importlib.reload(utils.config)
+
+    def test_nothing_in_the_application_reads_the_new_database_path(self):
+        """B1 computes runtime_database_path(); B2 is what wires it up.
+
+        Parsed rather than grepped: prose about the eventual switch is exactly
+        what this packet is supposed to contain.
+        """
+        repository = Path(__file__).resolve().parents[1]
+        readers = []
+        for directory in ("utils", "routes"):
+            for path in (repository / directory).rglob("*.py"):
+                if path.name == "runtime_paths.py":
+                    continue
+                tree = ast.parse(path.read_text(encoding="utf-8"))
+                referenced = any(
+                    (isinstance(node, ast.Name) and node.id == NEW_PATH_HELPER)
+                    or (
+                        isinstance(node, ast.Attribute)
+                        and node.attr == NEW_PATH_HELPER
+                    )
+                    for node in ast.walk(tree)
+                )
+                if referenced:
+                    readers.append(path.relative_to(repository).as_posix())
+
+        assert readers == []
+
+
+class TestEnvironmentOverride:
+    def test_db_file_wins_over_every_resolved_path(
+        self, clean_environment, tmp_path
+    ):
+        _freeze(clean_environment)
+        explicit = tmp_path / "explicit" / "chosen.db"
+        clean_environment.setenv("DB_FILE", str(explicit))
+        clean_environment.setenv(
+            runtime_paths.RUNTIME_ROOT_ENV, str(tmp_path / "ignored")
+        )
+        import utils.config
+
+        try:
+            importlib.reload(utils.config)
+
+            assert utils.config.DB_FILE == str(explicit)
+        finally:
+            clean_environment.undo()
+            importlib.reload(utils.config)
+
+
+class TestEnsureDirectory:
+    def test_creates_missing_parents_and_is_idempotent(self, tmp_path):
+        target = tmp_path / "a" / "b" / "c"
+
+        assert runtime_paths.ensure_directory(target) == target
+        assert target.is_dir()
+        assert runtime_paths.ensure_directory(target) == target
+
+    def test_logging_creates_its_own_directory(
+        self, clean_environment, tmp_path
+    ):
+        """A frozen install must not need write access to its own directory."""
+        root = tmp_path / "runtime"
+        clean_environment.setenv(runtime_paths.RUNTIME_ROOT_ENV, str(root))
+
+        assert not root.exists()
+        runtime_paths.ensure_directory(runtime_paths.logs_dir())
+
+        assert (root.resolve() / "logs").is_dir()
+
+
+class TestDatabaseDirectoryCreation:
+    def test_connecting_creates_a_missing_parent_directory(self, tmp_path):
+        """Import-time creation used to guarantee this; connection time does now."""
+        import utils.config
+        from utils.database import get_db_connection
+
+        target = tmp_path / "absent" / "nested" / "database.db"
+        original = utils.config.DB_FILE
+        utils.config.DB_FILE = str(target)
+        try:
+            connection = get_db_connection()
+            connection.close()
+        finally:
+            utils.config.DB_FILE = original
+
+        assert target.is_file()
+
+
+def test_config_paths_delegate_to_the_resolver():
+    """One policy, not three modules that happen to agree."""
+    import utils.config
+
+    assert Path(utils.config.DATA_DIR) == runtime_paths.legacy_data_dir()
+    assert Path(utils.config.LOGS_DIR) == runtime_paths.logs_dir()
+    assert Path(utils.config.BASE_DIR) == runtime_paths.installation_root()
+
+
+def test_dead_data_dir_constant_is_gone():
+    """utils/database.py recomputed a second, staler notion of the data dir."""
+    import utils.database
+
+    assert not hasattr(utils.database, "DATA_DIR")

--- a/utils/config.py
+++ b/utils/config.py
@@ -1,13 +1,23 @@
 import os
 
+from utils.runtime_paths import (
+    legacy_data_dir,
+    legacy_database_path,
+    logs_dir,
+)
+
 # Paths
-# Set BASE_DIR to the root of the project
-BASE_DIR = os.path.abspath(os.path.join(os.path.dirname(__file__), ".."))
-DATA_DIR = os.path.join(BASE_DIR, "data")  # Centralized data folder
-LOGS_DIR = os.path.join(BASE_DIR, "logs")  # Centralized logs folder
+# BASE_DIR is the installation root: the repository in a checkout, the bundle in
+# a frozen build. utils/runtime_paths.py owns every path derived from it.
+BASE_DIR = str(legacy_data_dir().parent)
+DATA_DIR = str(legacy_data_dir())  # Database and backups (Packet B2 moves these)
+LOGS_DIR = str(logs_dir())  # Per-user writable when frozen, repository-local otherwise
 
 # Database File
-DB_FILE = os.getenv("DB_FILE", os.path.join(DATA_DIR, "database.db"))  # Allow override via environment variable
+# Still installation-relative on purpose. Packet B2 repoints this to
+# runtime_paths.runtime_database_path() atomically with legacy migration; doing
+# it earlier would seed an empty database over an upgrading user's real data.
+DB_FILE = os.getenv("DB_FILE", str(legacy_database_path()))  # Allow override via environment variable
 
 # Application Constants
 APP_TITLE = "Workout Tracker"
@@ -25,6 +35,7 @@ MAX_FILENAME_LENGTH = 200
 # Streaming threshold - exports larger than this will use streaming (bytes)
 STREAMING_THRESHOLD = 5 * 1024 * 1024  # 5MB
 
-# Ensure required directories exist
-os.makedirs(DATA_DIR, exist_ok=True)  # Ensure the data directory exists
-os.makedirs(LOGS_DIR, exist_ok=True)  # Ensure the logs directory exists
+# Directories are NOT created here. Importing a configuration module should not
+# touch the filesystem: it ran during test collection and in any script that
+# imported utils, creating stray data/ and logs/ trees. Each consumer creates
+# what it needs via runtime_paths.ensure_directory().

--- a/utils/database.py
+++ b/utils/database.py
@@ -10,9 +10,9 @@ from datetime import date as _date, datetime as _datetime
 from pathlib import Path
 from typing import Any, Optional, Union
 
-from utils.config import DB_FILE
 import utils.config  # For dynamic DB_FILE access in tests
 from utils.logger import get_logger
+from utils.runtime_paths import ensure_directory
 
 logger = get_logger()
 
@@ -25,7 +25,6 @@ _DB_LOCK = threading.RLock()
 
 # Guard against double initialization during Flask auto-reload
 _INITIALIZATION_COMPLETE: dict[str, bool] = {}
-DATA_DIR = Path(DB_FILE).resolve().parent
 
 
 def _register_sqlite_converters() -> None:
@@ -246,6 +245,13 @@ def get_db_connection(database_path: Optional[str] = None) -> sqlite3.Connection
     """
     # Use dynamic config lookup to support test overrides
     db_path = str(Path(database_path or utils.config.DB_FILE))
+    # Importing utils.config used to create the data directory as a side
+    # effect. Creating it here instead keeps that guarantee for every entry
+    # point, including a configured DB_FILE under a directory that does not
+    # exist yet, without a filesystem write at import time.
+    target = Path(db_path)
+    if not target.exists():
+        ensure_directory(target.parent)
     attempted_recovery = False
     
     with _DB_LOCK:

--- a/utils/logger.py
+++ b/utils/logger.py
@@ -4,7 +4,7 @@ Structured logging configuration with request ID support.
 import logging
 import os
 from logging.handlers import RotatingFileHandler
-from utils.config import LOGS_DIR
+from utils.runtime_paths import ensure_directory, logs_dir
 
 
 class RequestIdFilter(logging.Filter):
@@ -30,9 +30,11 @@ def setup_logging(app=None):
     Args:
         app: Flask application instance (optional)
     """
-    # Ensure logs directory exists
-    os.makedirs(LOGS_DIR, exist_ok=True)
-    
+    # Resolved here rather than at import so a relocated runtime root and the
+    # frozen per-user path both take effect. A frozen install must never need
+    # write access to its own installation directory just to log.
+    log_directory = ensure_directory(logs_dir())
+
     # Create logger
     logger = logging.getLogger('hypertrophy_toolbox')
     logger.setLevel(logging.DEBUG)
@@ -45,7 +47,7 @@ def setup_logging(app=None):
     request_id_filter = RequestIdFilter()
     
     # File handler with rotation (10MB max, keep 5 backups)
-    log_file = os.path.join(LOGS_DIR, 'app.log')
+    log_file = os.path.join(log_directory, 'app.log')
     file_handler = RotatingFileHandler(
         log_file,
         maxBytes=10 * 1024 * 1024,  # 10MB

--- a/utils/runtime_paths.py
+++ b/utils/runtime_paths.py
@@ -1,0 +1,122 @@
+"""Single owner of every mutable runtime path.
+
+Before this module, "where does state live" was answered independently by
+``utils/config.py`` (from its own ``__file__``), ``utils/database.py`` (from
+``DB_FILE``), and ``utils/auto_backup.py`` (from the database's parent). Three
+answers that happened to agree is not one policy, and a frozen build made them
+disagree: the installation directory is not writable in general, yet that is
+where all three pointed.
+
+Precedence, highest first:
+
+1. ``DB_FILE`` — absolute authority over the database path alone. Resolved in
+   ``utils/config.py``; this module never overrides or infers from it.
+2. ``HT_RUNTIME_DIR`` — relocates the whole runtime tree in one move. The
+   supported answer for portable installs and for a launcher that wants a
+   per-worktree root.
+3. Frozen build — a per-user OS application-data directory. Local rather than
+   roaming on Windows: a SQLite database should not be synchronized between
+   machines by a roaming profile.
+4. Source checkout or worktree — the repository, exactly as before.
+
+**Packet B1 deliberately does not move the database.** ``runtime_database_path``
+is computed and tested, and nothing reads it yet; ``legacy_database_path`` is
+what ``DB_FILE`` still defaults to. Switching a frozen install to the new path
+while migration does not yet exist would hand an upgrading user a freshly seeded
+empty database while their real data sat untouched at the old one. Packet B2
+activates the switch atomically with that migration, and
+``tests/test_runtime_paths.py`` fails if the switch happens early.
+"""
+from __future__ import annotations
+
+import os
+import sys
+from pathlib import Path
+
+RUNTIME_ROOT_ENV = "HT_RUNTIME_DIR"
+
+# Windows and macOS convention is a display-cased directory; XDG is lowercase.
+APP_DIRECTORY_NAME = "HypertrophyToolbox"
+APP_DIRECTORY_NAME_XDG = "hypertrophy-toolbox"
+
+DATABASE_FILENAME = "database.db"
+DATA_DIRNAME = "data"
+LOGS_DIRNAME = "logs"
+
+
+def is_frozen() -> bool:
+    """Whether this process is a PyInstaller build rather than a checkout."""
+    return bool(getattr(sys, "frozen", False))
+
+
+def installation_root() -> Path:
+    """The directory holding immutable application assets.
+
+    Frozen builds resolve to the bundle (``_internal/``) because that is where
+    packaged data lands; checkouts resolve to the repository.
+    """
+    return Path(__file__).resolve().parents[1]
+
+
+def user_data_root() -> Path:
+    """The per-user writable application-data directory for this platform."""
+    if sys.platform == "win32":
+        base = os.environ.get("LOCALAPPDATA") or os.environ.get("APPDATA")
+        root = Path(base) if base else Path.home() / "AppData" / "Local"
+        return root / APP_DIRECTORY_NAME
+    if sys.platform == "darwin":
+        return Path.home() / "Library" / "Application Support" / APP_DIRECTORY_NAME
+    xdg = os.environ.get("XDG_DATA_HOME")
+    root = Path(xdg) if xdg else Path.home() / ".local" / "share"
+    return root / APP_DIRECTORY_NAME_XDG
+
+
+def runtime_root() -> Path:
+    """The directory under which all mutable state lives."""
+    override = os.environ.get(RUNTIME_ROOT_ENV)
+    if override:
+        return Path(override).expanduser().resolve()
+    if is_frozen():
+        return user_data_root()
+    return installation_root()
+
+
+def runtime_data_dir() -> Path:
+    """Where databases and backups belong. Not yet the database's home."""
+    return runtime_root() / DATA_DIRNAME
+
+
+def runtime_database_path() -> Path:
+    """Where the database belongs. Wired to ``DB_FILE`` by Packet B2, not B1."""
+    return runtime_data_dir() / DATABASE_FILENAME
+
+
+def legacy_data_dir() -> Path:
+    """The installation-relative data directory the database still uses."""
+    return installation_root() / DATA_DIRNAME
+
+
+def legacy_database_path() -> Path:
+    """The database path in use today, and B2's migration source."""
+    return legacy_data_dir() / DATABASE_FILENAME
+
+
+def logs_dir() -> Path:
+    """Where log files belong — never the installation directory.
+
+    Unlike the database this moves in B1: logs carry no user data worth
+    migrating, so relocating them cannot lose anything.
+    """
+    return runtime_root() / LOGS_DIRNAME
+
+
+def ensure_directory(path: Path) -> Path:
+    """Create *path* if absent and return it.
+
+    Directories are created where a path is first used, never as an import side
+    effect: importing ``utils.config`` used to create ``data/`` and ``logs/`` in
+    whatever directory a script happened to resolve, including during test
+    collection.
+    """
+    path.mkdir(parents=True, exist_ok=True)
+    return path


### PR DESCRIPTION
Packet B1 of `docs/rootdircleanup.md`. Base `origin/main` `e576cda`.

## Behavior / schema changes

- **Frozen builds write logs to the per-user data directory** instead of the installation directory.
- **`HT_RUNTIME_DIR` is new** — relocates the whole runtime tree (data + logs) in one move.
- **Importing `utils.config` no longer creates directories.**
- In a source checkout every resolved path is byte-for-byte what it was before.

No schema change, no API response change, no calculation change.

## Why a resolver

"Where does mutable state live" was answered independently by three modules — `utils/config.py` from its own `__file__`, `utils/database.py` from `DB_FILE`, `utils/auto_backup.py` from the database's parent. Three answers that happen to agree is not one policy, and a frozen build makes them disagree: an installation directory is not writable in general, yet all three pointed at it.

`utils/runtime_paths.py` implements the approved precedence: `DB_FILE` (database only) → `HT_RUNTIME_DIR` (whole tree) → frozen per-user OS data directory → the repository. Windows resolves to `LOCALAPPDATA` rather than roaming — a SQLite database should not be synchronized between machines by a roaming profile.

## Logs move, the database does not

`logs_dir()` is `runtime_root()/logs`, so a frozen install stops needing write access to its own installation directory just to log. Logs carry nothing worth migrating, which is exactly why they can move a packet ahead of the database.

**The sequencing constraint is enforced by tests, not by discipline.** `TestPacketB1DoesNotMoveTheDatabase` asserts that a *frozen* process still resolves `DB_FILE` to `legacy_database_path()`, and an AST scan asserts nothing under `utils/` or `routes/` references `runtime_database_path()` at all. Parsed rather than grepped — prose about the eventual switch is exactly what this packet is supposed to contain. Those tests fail the moment the switch lands early; **deleting them is part of B2's job, not a way to make B1 pass.**

## Import-time directory creation

Importing `utils.config` used to `os.makedirs` both `data/` and `logs/` in whatever directory happened to resolve, including during test collection. `get_db_connection()` now creates a missing database parent at connection time, which preserves that guarantee for every entry point — including a configured `DB_FILE` under a directory that does not exist yet — without a filesystem write at import.

Also removes `utils/database.py::DATA_DIR`, approved with the Packet B decisions: dead, recomputed from `DB_FILE` at import and imported by nothing.

## Tests rewritten rather than deleted

Two asserted implementation details that this packet changes on purpose:

- `test_config` asserted `DATA_DIR`/`LOGS_DIR` exist "created on import" → now asserts importing config creates nothing.
- `test_logger` asserted `os.makedirs` was called → now asserts, through the filesystem, that a relocated runtime root gets its logs directory. The point was never which call creates it.

## Verification

- pytest **1,812 passed / 1 skipped** — baseline **1,792 / 1** at `e576cda`, plus 20 resolver contracts.
- Real `app.py` startup with `HT_RUNTIME_DIR` pointed at a throwaway directory: `GET /` → 200, and **both** `data/database.db` and `logs/app.log` were written under that root, leaving the repository's own `logs/` untouched.
- Resolver contracts cover Windows/macOS/Linux conventions, the `LOCALAPPDATA`→`APPDATA`→home fallback chain, `~` expansion, and paths containing spaces and non-ASCII characters.

🤖 Generated with [Claude Code](https://claude.com/claude-code)