### PR TITLE
runtime: move the database out of the installation directory, safely, once

### DIFF
--- a/.claude/rules/database.md
+++ b/.claude/rules/database.md
@@ -77,11 +77,18 @@ data directory → the repository. Never derive a runtime path from `__file__`,
 and never create runtime directories at import time — `get_db_connection()`
 creates a missing database parent, and logging creates its own directory.
 
-Logs already follow the resolver (`runtime_root()/logs`). The **database does
-not yet**: `DB_FILE` still defaults to `legacy_database_path()`
-(`<installation>/data/database.db`) even when frozen. Packet B2 repoints it
-atomically with legacy migration; `tests/test_runtime_paths.py` fails if that
-switch lands early.
+Database, backups, and logs all follow the resolver. A frozen install writes to
+`%LOCALAPPDATA%\HypertrophyToolbox\` and adds nothing to its own installation
+directory; a source checkout still uses `<repo>/data` and `<repo>/logs`.
+
+`utils/runtime_migration.py::prepare_runtime_database()` runs in `app.py`
+**before** `bootstrap_runtime_database()` — seeding first would create an empty
+database that migration would then correctly decline to replace. It opens the
+legacy database `mode=ro`, refuses when `-wal`/`-journal` sidecars are
+outstanding, verifies the copy (`integrity_check`, `foreign_key_check`, row
+counts) before publishing it atomically, and never deletes or writes to the
+original. Any failure returns the legacy path and logs recovery steps; it never
+seeds a clean database after finding real data.
 
 ## Env vars that affect DB (`utils/config.py`)
 | Variable | Default | Effect |
@@ -94,6 +101,8 @@ switch lands early.
 ## Startup sequence (`app.py`)
 ```
 app.py startup:
+  prepare_runtime_database()      ← moves a legacy database to the runtime root, once
+  utils.config.DB_FILE = ...      ← whatever that decided (legacy path on failure)
   bootstrap_runtime_database()    ← copies catalog seed only when DB_FILE is missing
   run_all_initializers()          ← canonical schema registry sequence
   create_startup_backup()         ← skipped for the pristine first-run seed copy

--- a/app.py
+++ b/app.py
@@ -1,8 +1,10 @@
 
 from flask import Flask, jsonify, request, make_response, g
+import utils.config
 from utils.database import DatabaseHandler
 from utils.auto_backup import create_startup_backup, describe_snapshot
 from utils.catalog_seed import bootstrap_runtime_database
+from utils.runtime_migration import prepare_runtime_database
 from utils.schema_registry import drop_all_owned_tables, run_all_initializers
 from routes.workout_log import workout_log_bp
 from routes.weekly_summary import weekly_summary_bp
@@ -49,7 +51,15 @@ add_request_id_middleware(app)
 # Register standardized error handlers
 register_error_handlers(app)
 
-# Initialize the database
+# Initialize the database.
+# Order matters and is load-bearing: an existing database is moved out of the
+# installation directory BEFORE the seed bootstrap runs, so a user upgrading a
+# frozen install never boots onto a fresh empty catalog while their real data
+# sits at the old path. A migration that could not be proven correct returns the
+# legacy path, and the seed bootstrap then sees an existing database and does
+# nothing.
+migration = prepare_runtime_database()
+utils.config.DB_FILE = str(migration.database_path)
 database_seeded = bootstrap_runtime_database()
 run_all_initializers(force_base=False)
 

--- a/docs/rootdircleanup.md
+++ b/docs/rootdircleanup.md
@@ -1112,7 +1112,7 @@ Therefore:
   path. The resolver may compute the frozen runtime path; nothing may use it
   for `DB_FILE` yet. **Shipped** — see §7.6.
 - **B2** activates the frozen `DB_FILE` switch **atomically with** legacy
-  migration and backup copying — one PR, or not at all.
+  migration and backup copying — one PR, or not at all. **Shipped** — see §7.7.
 - **B3** adds catalog versioning and additive upgrade behavior.
 
 ### 7.3 Migration precedence
@@ -1129,25 +1129,25 @@ The migration must be idempotent and follow an explicit precedence:
 
 Checklist:
 
-- [ ] Use the SQLite backup API or an equivalent consistent copy for a live
+- [x] Use the SQLite backup API or an equivalent consistent copy for a live
       database.
-- [ ] Refuse migration while unresolved WAL/SHM state exists unless SQLite
+- [x] Refuse migration while unresolved WAL/SHM state exists unless SQLite
       performs the copy through a live connection.
-- [ ] Record migration completion without putting sensitive paths or row data in
+- [x] Record migration completion without putting sensitive paths or row data in
       logs.
-- [ ] Provide a clear recovery message if migration fails.
-- [ ] Verify old-schema migration after relocation.
-- [ ] Test paths containing spaces and non-ASCII characters.
-- [ ] Test read-only installation directories.
-- [ ] Test upgrade/reinstall over an existing user-data directory.
+- [x] Provide a clear recovery message if migration fails.
+- [x] Verify old-schema migration after relocation.
+- [x] Test paths containing spaces and non-ASCII characters.
+- [x] Test read-only installation directories.
+- [x] Test upgrade/reinstall over an existing user-data directory.
 
 Non-destructiveness is absolute (B-D3):
 
-- [ ] Never delete, move, truncate, or write to the legacy database.
-- [ ] Never replace an existing runtime database, whatever its schema or state.
-- [ ] Verify the migrated copy before it is published as the runtime database —
+- [x] Never delete, move, truncate, or write to the legacy database.
+- [x] Never replace an existing runtime database, whatever its schema or state.
+- [x] Verify the migrated copy before it is published as the runtime database —
       a copy that cannot be verified is not a migration.
-- [ ] On any failure, leave the legacy database authoritative and report
+- [x] On any failure, leave the legacy database authoritative and report
       recovery steps. Never seed a clean database after finding legacy data and
       never present that as success.
 
@@ -1158,17 +1158,17 @@ database is already the live one.
 
 ### 7.3.1 Logs and backups (B-D4)
 
-- [ ] Logs are written under the resolved runtime root, never the installation
+- [x] Logs are written under the resolved runtime root, never the installation
       directory.
-- [ ] `utils/logger.py` stops creating directories at import time; the resolver
+- [x] `utils/logger.py` stops creating directories at import time; the resolver
       owns creation.
-- [ ] Existing log files are not migrated. They are development history, not
+- [x] Existing log files are not migrated. They are development history, not
       user data.
-- [ ] Legacy `data/auto_backup/` snapshots are copied once into the new runtime
+- [x] Legacy `data/auto_backup/` snapshots are copied once into the new runtime
       root, best-effort.
-- [ ] A backup-copy failure is logged and startup continues. The originals are
+- [x] A backup-copy failure is logged and startup continues. The originals are
       untouched, so a failure costs nothing; blocking startup over it would.
-- [ ] Backup rotation, `create_startup_backup()`, and erase-data recovery all
+- [x] Backup rotation, `create_startup_backup()`, and erase-data recovery all
       target the resolved runtime root.
 
 ### 7.4 Catalog updates after first install (B-D5)
@@ -1280,6 +1280,59 @@ assert behavior instead of implementation.
 Runtime check: `HT_RUNTIME_DIR` pointed at a throwaway directory, real `app.py`
 startup served `GET /` → 200 and wrote **both** `data/database.db` and
 `logs/app.log` under that root, leaving the repository's own `logs/` untouched.
+
+### 7.7 Recorded B2 results
+
+`utils/runtime_migration.py` owns the decision, and `app.py` calls it
+immediately **before** `bootstrap_runtime_database()`. That order is the whole
+safety property: seeding first would create an empty database at the new path,
+after which migration would correctly decline to overwrite it — and the user
+would be staring at an empty catalog with their data still on disk. A test
+parses `app.py` and asserts the call order rather than trusting it.
+
+Non-destructiveness, as implemented:
+
+- The legacy database is opened `mode=ro` through a URI connection. It is
+  physically never written, so a read-only installation directory migrates
+  fine — which a test asserts by chmod-ing the source directory to `0o500`.
+- Unresolved `-wal` / `-journal` sidecars **refuse** migration rather than
+  copying past them. Copying a database whose committed transactions still live
+  in a WAL would silently drop them, and resolving the WAL would mean writing to
+  the legacy file. Refusing costs one restart; the alternative costs data.
+- The copy goes to a temporary sibling, is verified there — `integrity_check`,
+  `foreign_key_check`, and per-table row counts equal to the source — and only
+  then is published with the same no-overwrite atomic rename the seed bootstrap
+  uses. That primitive moved to `runtime_paths.publish_without_overwrite()`; two
+  copies of an atomic-publication routine is one too many.
+- Every failure path returns the **legacy** path as the database to use, logs
+  what failed, and logs how to retry. A corrupt legacy database yields a refusal
+  and a recovery message, never a clean seed.
+
+Backups are copied best-effort, once, and a failure is logged and swallowed: the
+originals are untouched, so a failed copy costs nothing, while blocking startup
+over it would cost the user their session. Old logs are not migrated.
+
+**A defect the tests caught before merge.** `_verify_copy` originally used
+`with sqlite3.connect(...)`, which commits but does not close. On POSIX the
+rename succeeds anyway with the handle open; on Windows it fails with
+`WinError 32`. Every successful-migration test failed on Windows and would have
+passed in Linux CI — the copy verified and then could not be published. Fixed
+with `contextlib.closing`.
+
+Baseline at the packet's starting commit `a7883d4`: **1,812 passed / 1 skipped**.
+After: **1,837 passed / 1 skipped** — 25 migration contracts, including the B1
+guards inverted into their B2 counterparts.
+
+Real frozen validation, `--mode bootloader` against a fresh `build_exe.bat`
+build:
+
+- Fresh install: the runtime database is created **under the runtime root**, the
+  packaged seed is byte-identical, **the installation directory gains no runtime
+  files at all**, and `app.log` is written under the runtime root.
+- Upgrade: a legacy database carrying a plan row was planted in the
+  installation directory exactly where every earlier release put it. The app
+  served 1,897 exercises, the database moved to the runtime root, **the plan row
+  survived**, and **the original file is still there, byte-identical**.
 
 ---
 
@@ -1623,7 +1676,7 @@ schema changes, and merges only on green CI.
 2. [x] **A3** — staging SHA-256 hardening and the real frozen gate.
 3. [x] **B1** — resolver, config, and logging foundation, without switching the
        frozen database path.
-4. [ ] **B2** — frozen runtime database path, legacy migration, and backup
+4. [x] **B2** — frozen runtime database path, legacy migration, and backup
        copying, activated atomically.
 5. [ ] **B3** — catalog versioning and additive upgrade behavior.
 

--- a/scripts/smoke_packaged_app.py
+++ b/scripts/smoke_packaged_app.py
@@ -24,6 +24,7 @@ import argparse
 import json
 import os
 import shutil
+import sqlite3
 import subprocess
 import sys
 import tempfile
@@ -152,12 +153,20 @@ def _post_json(url: str, payload: dict, timeout: float = 30.0):
     return urllib.request.urlopen(request, timeout=timeout)
 
 
-def _launch(work_dir: Path, mode: str, payload_python: Path | None):
+def _launch(
+    work_dir: Path,
+    mode: str,
+    payload_python: Path | None,
+    runtime_root: Path,
+):
     child_environment = {
         **os.environ,
         "HT_NO_BROWSER": "1",
         "FLASK_USE_RELOADER": "0",
+        # Never let a smoke write into the real per-user data directory.
+        "HT_RUNTIME_DIR": str(runtime_root),
     }
+    child_environment.pop("DB_FILE", None)
 
     if mode == "bootloader":
         executable = work_dir / "Hypertrophy-Toolbox.exe"
@@ -206,16 +215,18 @@ def serve_and_check(
     mode: str,
     payload_python: Path | None,
     port: int,
+    runtime_root: Path,
 ) -> None:
     """Boot the distribution and assert it serves real catalog-backed pages."""
     base_url = f"http://127.0.0.1:{port}"
-    runtime_db = work_dir / "_internal" / "data" / "database.db"
-    seed = work_dir / "_internal" / "data" / "catalog.seed.db"
+    bundled_data = work_dir / "_internal" / "data"
+    runtime_db = runtime_root / "data" / "database.db"
+    seed = bundled_data / "catalog.seed.db"
     seed_digest = file_digest(seed)
 
     _check(not runtime_db.exists(), "no runtime database before first launch")
 
-    process = _launch(work_dir, mode, payload_python)
+    process = _launch(work_dir, mode, payload_python, runtime_root)
     try:
         _wait_for_server(base_url, process)
         for route in PAGES:
@@ -255,14 +266,107 @@ def serve_and_check(
         except subprocess.TimeoutExpired:
             process.kill()
 
-    _check(runtime_db.is_file(), "first launch created the runtime database")
+    _check(
+        runtime_db.is_file(),
+        f"first launch created the runtime database at {runtime_db}",
+    )
     _check(
         file_digest(seed) == seed_digest,
         "the packaged catalog seed is byte-identical after first run",
     )
+    # The Packet B property, asserted against the real installation directory:
+    # a running application must add nothing to the bundle it was installed
+    # from, or an update would overwrite user data.
     _check(
-        not (work_dir / "_internal" / "data" / "auto_backup").exists(),
+        sorted(path.name for path in bundled_data.iterdir())
+        == sorted(APPROVED_DATA_FILES),
+        "the installation directory gained no runtime files",
+    )
+    _check(
+        (runtime_root / "logs" / "app.log").is_file(),
+        "logs were written under the runtime root, not the installation",
+    )
+    _check(
+        not (bundled_data / "auto_backup").exists()
+        and not (runtime_root / "data" / "auto_backup").exists(),
         "no redundant first-run backup",
+    )
+
+
+LEGACY_ROUTINE = "SMOKE - Legacy Routine"
+
+
+def _plant_legacy_database(work_dir: Path) -> Path:
+    """Write a pre-Packet-B database into the installation directory.
+
+    This is what an existing user's install looks like: a real database sitting
+    beside the packaged assets, because that is where every earlier release put
+    it.
+    """
+    bundled_data = work_dir / "_internal" / "data"
+    legacy = bundled_data / "database.db"
+    shutil.copyfile(bundled_data / "catalog.seed.db", legacy)
+    connection = sqlite3.connect(str(legacy))
+    try:
+        exercise = connection.execute(
+            "SELECT exercise_name FROM exercises ORDER BY exercise_name LIMIT 1"
+        ).fetchone()[0]
+        connection.execute(
+            "INSERT INTO user_selection "
+            "(routine, exercise, sets, min_rep_range, max_rep_range, weight) "
+            "VALUES (?, ?, 3, 8, 12, 60.0)",
+            (LEGACY_ROUTINE, exercise),
+        )
+        connection.commit()
+    finally:
+        connection.close()
+    return legacy
+
+
+def check_upgrade_migration(
+    work_dir: Path,
+    mode: str,
+    payload_python: Path | None,
+    port: int,
+    runtime_root: Path,
+) -> None:
+    """Assert an existing install's data moves once and survives intact."""
+    legacy = _plant_legacy_database(work_dir)
+    legacy_digest = file_digest(legacy)
+    runtime_db = runtime_root / "data" / "database.db"
+    base_url = f"http://127.0.0.1:{port}"
+
+    process = _launch(work_dir, mode, payload_python, runtime_root)
+    try:
+        _wait_for_server(base_url, process)
+        with _get(f"{base_url}/get_all_exercises") as response:
+            exercises = json.loads(response.read())["data"]
+        _check(
+            len(exercises) == EXPECTED_EXERCISES,
+            f"upgraded install serves {len(exercises)} exercises",
+        )
+    finally:
+        process.terminate()
+        try:
+            process.wait(timeout=30)
+        except subprocess.TimeoutExpired:
+            process.kill()
+
+    _check(runtime_db.is_file(), "the database moved to the runtime root")
+
+    connection = sqlite3.connect(str(runtime_db))
+    try:
+        migrated = connection.execute(
+            "SELECT COUNT(*) FROM user_selection WHERE routine = ?",
+            (LEGACY_ROUTINE,),
+        ).fetchone()[0]
+    finally:
+        connection.close()
+    _check(migrated == 1, "the pre-existing plan row survived the move")
+
+    _check(
+        legacy.is_file() and file_digest(legacy) == legacy_digest,
+        "the original database is still there, byte-identical",
     )
 
 
@@ -296,6 +400,11 @@ def main() -> None:
         action="store_true",
         help="Inspect the built tree only.",
     )
+    parser.add_argument(
+        "--skip-upgrade",
+        action="store_true",
+        help="Skip the legacy-database migration run.",
+    )
     args = parser.parse_args()
 
     dist = args.dist.resolve()
@@ -317,8 +426,24 @@ def main() -> None:
             print(f"[SMOKE] copying distribution to {work_dir}")
             shutil.copytree(dist, work_dir)
             serve_and_check(
-                work_dir, args.mode, args.payload_python, args.port
+                work_dir,
+                args.mode,
+                args.payload_python,
+                args.port,
+                Path(temporary) / "runtime",
             )
+
+            if not args.skip_upgrade:
+                upgrade_dir = Path(temporary) / f"{dist.name}-upgrade"
+                print(f"[SMOKE] upgrade run from {upgrade_dir}")
+                shutil.copytree(dist, upgrade_dir)
+                check_upgrade_migration(
+                    upgrade_dir,
+                    args.mode,
+                    args.payload_python,
+                    args.port,
+                    Path(temporary) / "runtime-upgrade",
+                )
     except (SmokeError, OSError, ValueError) as exc:
         raise SystemExit(f"[SMOKE] FAIL: {exc}") from exc
 

--- a/tests/test_runtime_migration.py
+++ b/tests/test_runtime_migration.py
@@ -1,0 +1,343 @@
+"""Contracts for the legacy-database migration (Packet B2).
+
+The property under test throughout is that the legacy database survives every
+path — success, refusal, corruption, concurrency — byte for byte.
+"""
+from __future__ import annotations
+
+import shutil
+import sqlite3
+from pathlib import Path
+
+import pytest
+
+from utils.runtime_migration import (
+    MigrationError,
+    _verify_copy,
+    copy_legacy_backups,
+    prepare_runtime_database,
+)
+
+
+def _write_database(path: Path, exercises: int = 3, plans: int = 2) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    connection = sqlite3.connect(str(path))
+    try:
+        connection.execute(
+            "CREATE TABLE exercises (exercise_name TEXT PRIMARY KEY)"
+        )
+        connection.execute(
+            "CREATE TABLE user_selection ("
+            "id INTEGER PRIMARY KEY, exercise TEXT, "
+            "FOREIGN KEY (exercise) REFERENCES exercises(exercise_name))"
+        )
+        for index in range(exercises):
+            connection.execute(
+                "INSERT INTO exercises VALUES (?)", (f"Exercise {index}",)
+            )
+        for index in range(plans):
+            connection.execute(
+                "INSERT INTO user_selection (exercise) VALUES (?)",
+                (f"Exercise {index}",),
+            )
+        connection.commit()
+    finally:
+        connection.close()
+
+
+def _row_count(path: Path, table: str) -> int:
+    connection = sqlite3.connect(str(path))
+    try:
+        return connection.execute(f"SELECT COUNT(*) FROM {table}").fetchone()[0]
+    finally:
+        connection.close()
+
+
+@pytest.fixture
+def legacy(tmp_path: Path) -> Path:
+    path = tmp_path / "install" / "data" / "database.db"
+    _write_database(path)
+    return path
+
+
+@pytest.fixture
+def target(tmp_path: Path) -> Path:
+    return tmp_path / "userdata" / "data" / "database.db"
+
+
+@pytest.fixture(autouse=True)
+def no_ambient_override(monkeypatch):
+    monkeypatch.delenv("DB_FILE", raising=False)
+
+
+class TestSuccessfulMigration:
+    def test_copies_rows_and_leaves_the_original_untouched(self, legacy, target):
+        original = legacy.read_bytes()
+
+        outcome = prepare_runtime_database(target=target, legacy=legacy)
+
+        assert outcome.action == "migrated"
+        assert outcome.database_path == target
+        assert target.is_file()
+        assert _row_count(target, "exercises") == 3
+        assert _row_count(target, "user_selection") == 2
+        assert legacy.is_file()
+        assert legacy.read_bytes() == original
+
+    def test_runs_exactly_once(self, legacy, target):
+        prepare_runtime_database(target=target, legacy=legacy)
+        _write_database(legacy.with_name("other.db"), exercises=99)
+        # Simulate the user continuing to work in the migrated database.
+        connection = sqlite3.connect(str(target))
+        connection.execute("INSERT INTO exercises VALUES ('Added Later')")
+        connection.commit()
+        connection.close()
+
+        outcome = prepare_runtime_database(target=target, legacy=legacy)
+
+        assert outcome.action == "already-present"
+        assert _row_count(target, "exercises") == 4
+
+    def test_leaves_no_temporary_files_behind(self, legacy, target):
+        prepare_runtime_database(target=target, legacy=legacy)
+
+        assert sorted(p.name for p in target.parent.iterdir()) == [
+            "database.db"
+        ]
+
+
+class TestNeverDestructive:
+    def test_an_existing_runtime_database_is_never_replaced(
+        self, legacy, target
+    ):
+        _write_database(target, exercises=7)
+        existing = target.read_bytes()
+
+        outcome = prepare_runtime_database(target=target, legacy=legacy)
+
+        assert outcome.action == "already-present"
+        assert target.read_bytes() == existing
+
+    def test_an_empty_existing_runtime_database_is_still_not_replaced(
+        self, legacy, target
+    ):
+        """"Looks empty" is not a licence to overwrite; it may be mid-repair."""
+        target.parent.mkdir(parents=True)
+        target.touch()
+
+        outcome = prepare_runtime_database(target=target, legacy=legacy)
+
+        assert outcome.action == "already-present"
+        assert target.stat().st_size == 0
+
+    def test_a_concurrent_winner_is_preserved(
+        self, legacy, target, monkeypatch
+    ):
+        """Two simultaneous first launches must not clobber each other."""
+        import utils.runtime_migration as migration_module
+
+        real_verify = migration_module._verify_copy
+
+        def verify_then_race(source: Path, copy: Path) -> None:
+            real_verify(source, copy)
+            if not target.exists():
+                _write_database(target, exercises=42)
+
+        monkeypatch.setattr(
+            migration_module, "_verify_copy", verify_then_race
+        )
+
+        outcome = prepare_runtime_database(target=target, legacy=legacy)
+
+        assert outcome.action == "migrated"
+        assert _row_count(target, "exercises") == 42
+        assert legacy.is_file()
+
+
+class TestRefusesRatherThanGuesses:
+    @pytest.mark.parametrize("suffix", ["-wal", "-journal"])
+    def test_unresolved_journal_state_refuses_migration(
+        self, legacy, target, suffix
+    ):
+        """Copying past a live WAL would silently drop committed rows."""
+        legacy.with_name(legacy.name + suffix).write_bytes(b"pending")
+        original = legacy.read_bytes()
+
+        outcome = prepare_runtime_database(target=target, legacy=legacy)
+
+        assert outcome.action == "failed"
+        assert "unresolved journal state" in (outcome.reason or "")
+        assert not target.exists()
+        assert legacy.read_bytes() == original
+
+    def test_a_failed_migration_keeps_using_the_legacy_database(
+        self, legacy, target
+    ):
+        legacy.with_name(legacy.name + "-wal").write_bytes(b"pending")
+
+        outcome = prepare_runtime_database(target=target, legacy=legacy)
+
+        assert outcome.database_path == legacy
+
+    def test_a_corrupt_legacy_database_never_becomes_a_clean_seed(
+        self, legacy, target
+    ):
+        """The failure mode that would read to a user as data loss."""
+        legacy.write_bytes(b"this is not a database" * 100)
+
+        outcome = prepare_runtime_database(target=target, legacy=legacy)
+
+        assert outcome.action == "failed"
+        assert outcome.database_path == legacy
+        assert not target.exists()
+
+    def test_an_unverifiable_copy_is_discarded(
+        self, legacy, target, monkeypatch
+    ):
+        import utils.runtime_migration as migration_module
+
+        def reject(source: Path, copy: Path) -> None:
+            raise MigrationError("row counts differ")
+
+        monkeypatch.setattr(migration_module, "_verify_copy", reject)
+
+        outcome = prepare_runtime_database(target=target, legacy=legacy)
+
+        assert outcome.action == "failed"
+        assert not target.exists()
+        assert not list(target.parent.glob("*.tmp"))
+        assert legacy.is_file()
+
+    def test_verification_rejects_a_copy_missing_rows(self, legacy, tmp_path):
+        truncated = tmp_path / "truncated.db"
+        shutil.copyfile(legacy, truncated)
+        connection = sqlite3.connect(str(truncated))
+        connection.execute("DELETE FROM user_selection")
+        connection.commit()
+        connection.close()
+
+        with pytest.raises(MigrationError, match="user_selection"):
+            _verify_copy(legacy, truncated)
+
+    def test_verification_accepts_a_faithful_copy(self, legacy, tmp_path):
+        faithful = tmp_path / "faithful.db"
+        shutil.copyfile(legacy, faithful)
+
+        _verify_copy(legacy, faithful)
+
+
+class TestPrecedence:
+    def test_an_explicit_db_file_is_never_migrated_into(
+        self, legacy, target, monkeypatch, tmp_path
+    ):
+        chosen = tmp_path / "chosen.db"
+        monkeypatch.setenv("DB_FILE", str(chosen))
+
+        outcome = prepare_runtime_database(target=target, legacy=legacy)
+
+        assert outcome.action == "explicit-override"
+        assert outcome.database_path == chosen
+        assert not target.exists()
+
+    def test_identical_paths_are_a_no_op(self, legacy):
+        outcome = prepare_runtime_database(target=legacy, legacy=legacy)
+
+        assert outcome.action == "same-path"
+        assert outcome.database_path == legacy
+
+    def test_a_fresh_install_defers_to_seed_bootstrap(self, tmp_path, target):
+        absent = tmp_path / "install" / "data" / "database.db"
+
+        outcome = prepare_runtime_database(target=target, legacy=absent)
+
+        assert outcome.action == "no-legacy"
+        assert outcome.database_path == target
+        assert not target.exists()
+
+
+class TestAwkwardEnvironments:
+    @pytest.mark.parametrize(
+        "name", ["with spaces", "ünïcodé", "spaces and ünïcodé"]
+    )
+    def test_paths_with_spaces_and_non_ascii_migrate(self, tmp_path, name):
+        legacy = tmp_path / f"install {name}" / "data" / "database.db"
+        _write_database(legacy)
+        target = tmp_path / f"userdata {name}" / "data" / "database.db"
+
+        outcome = prepare_runtime_database(target=target, legacy=legacy)
+
+        assert outcome.action == "migrated"
+        assert _row_count(target, "exercises") == 3
+
+    def test_a_read_only_installation_directory_still_migrates(
+        self, legacy, target
+    ):
+        """The whole point: the source is only ever read.
+
+        Genuinely restrictive on POSIX (where CI runs pytest); on Windows
+        chmod does not restrict directories, so there it asserts only that the
+        happy path is unaffected.
+        """
+        install_directory = legacy.parent
+        original_mode = install_directory.stat().st_mode
+        install_directory.chmod(0o500)
+        try:
+            outcome = prepare_runtime_database(target=target, legacy=legacy)
+        finally:
+            install_directory.chmod(original_mode)
+
+        assert outcome.action == "migrated"
+        assert _row_count(target, "exercises") == 3
+
+
+class TestBackupCopying:
+    def test_copies_snapshots_once(self, tmp_path):
+        source = tmp_path / "install" / "data" / "auto_backup"
+        source.mkdir(parents=True)
+        for stamp in ("20260101_010101", "20260102_010101"):
+            _write_database(source / f"database_{stamp}.db")
+        target = tmp_path / "userdata" / "data" / "auto_backup"
+
+        assert copy_legacy_backups(source, target) == 2
+        assert copy_legacy_backups(source, target) == 0
+        assert sorted(p.name for p in target.iterdir()) == [
+            "database_20260101_010101.db",
+            "database_20260102_010101.db",
+        ]
+        assert len(list(source.iterdir())) == 2
+
+    def test_missing_legacy_backups_are_not_an_error(self, tmp_path):
+        assert copy_legacy_backups(
+            tmp_path / "absent", tmp_path / "target"
+        ) == 0
+
+    def test_a_copy_failure_never_blocks_startup(self, tmp_path, monkeypatch):
+        source = tmp_path / "auto_backup"
+        source.mkdir()
+        _write_database(source / "database_20260101_010101.db")
+
+        def explode(*args, **kwargs):
+            raise OSError("disk full")
+
+        monkeypatch.setattr("utils.runtime_migration.shutil.copy2", explode)
+
+        assert copy_legacy_backups(source, tmp_path / "target") == 0
+
+    def test_migration_carries_backups_across(self, tmp_path, monkeypatch):
+        legacy = tmp_path / "install" / "data" / "database.db"
+        _write_database(legacy)
+        backups = legacy.parent / "auto_backup"
+        backups.mkdir()
+        _write_database(backups / "database_20260101_010101.db")
+        target = tmp_path / "userdata" / "data" / "database.db"
+        monkeypatch.setattr(
+            "utils.runtime_migration.legacy_data_dir", lambda: legacy.parent
+        )
+        monkeypatch.setattr(
+            "utils.runtime_migration.runtime_data_dir", lambda: target.parent
+        )
+
+        outcome = prepare_runtime_database(target=target, legacy=legacy)
+
+        assert outcome.backups_copied == 1
+        assert (target.parent / "auto_backup").is_dir()

--- a/tests/test_runtime_paths.py
+++ b/tests/test_runtime_paths.py
@@ -140,26 +140,26 @@ class TestUserDataRoot:
         )
 
 
-class TestPacketB1DoesNotMoveTheDatabase:
-    """The sequencing constraint, as an executable contract.
+class TestPacketB2MovesTheDatabase:
+    """The switch B1 deliberately withheld, now active.
 
-    Packet B2 activates the frozen database switch atomically with legacy
-    migration. If that switch lands first, an upgrading user boots onto a
-    freshly seeded empty database while their real one sits at the old path.
-    These tests fail the moment the switch happens early — deleting them is
-    part of B2's job, not a way to make B1 pass.
+    B1 asserted the opposite of these: that a frozen process still resolved
+    ``DB_FILE`` to the legacy path, and that nothing referenced
+    ``runtime_database_path`` at all. Those guards existed so the switch could
+    not land before migration, and B2 is the packet entitled to replace them.
     """
 
     def test_legacy_database_path_is_installation_relative(
         self, clean_environment
     ):
+        """Still resolvable — it is the migration source and recovery path."""
         _freeze(clean_environment)
 
         assert runtime_paths.legacy_database_path() == (
             runtime_paths.installation_root() / "data" / "database.db"
         )
 
-    def test_configured_db_file_is_still_the_legacy_path_when_frozen(
+    def test_configured_db_file_leaves_the_installation_when_frozen(
         self, clean_environment
     ):
         _freeze(clean_environment)
@@ -168,44 +168,58 @@ class TestPacketB1DoesNotMoveTheDatabase:
 
         try:
             importlib.reload(utils.config)
+            configured = Path(utils.config.DB_FILE)
 
-            assert (
-                Path(utils.config.DB_FILE)
-                == runtime_paths.legacy_database_path()
-            )
-            assert (
-                Path(utils.config.DB_FILE)
-                != runtime_paths.runtime_database_path()
+            assert configured == runtime_paths.runtime_database_path()
+            assert configured != runtime_paths.legacy_database_path()
+            assert not configured.is_relative_to(
+                runtime_paths.installation_root()
             )
         finally:
             clean_environment.undo()
             importlib.reload(utils.config)
 
-    def test_nothing_in_the_application_reads_the_new_database_path(self):
-        """B1 computes runtime_database_path(); B2 is what wires it up.
+    def test_source_checkouts_keep_the_repository_database(
+        self, clean_environment
+    ):
+        """The switch must be invisible to a checkout and to every worktree."""
+        import utils.config
 
-        Parsed rather than grepped: prose about the eventual switch is exactly
-        what this packet is supposed to contain.
+        clean_environment.delenv("DB_FILE", raising=False)
+        try:
+            importlib.reload(utils.config)
+
+            assert (
+                Path(utils.config.DB_FILE)
+                == runtime_paths.legacy_database_path()
+            )
+        finally:
+            clean_environment.undo()
+            importlib.reload(utils.config)
+
+    def test_startup_migrates_before_it_seeds(self):
+        """Ordering is the whole safety property, so it is asserted directly.
+
+        Seeding first would create an empty database at the new path, after
+        which migration would correctly decline to overwrite it — and the user
+        would be looking at an empty catalog with their data still on disk.
         """
-        repository = Path(__file__).resolve().parents[1]
-        readers = []
-        for directory in ("utils", "routes"):
-            for path in (repository / directory).rglob("*.py"):
-                if path.name == "runtime_paths.py":
-                    continue
-                tree = ast.parse(path.read_text(encoding="utf-8"))
-                referenced = any(
-                    (isinstance(node, ast.Name) and node.id == NEW_PATH_HELPER)
-                    or (
-                        isinstance(node, ast.Attribute)
-                        and node.attr == NEW_PATH_HELPER
-                    )
-                    for node in ast.walk(tree)
-                )
-                if referenced:
-                    readers.append(path.relative_to(repository).as_posix())
+        source = (
+            Path(__file__).resolve().parents[1] / "app.py"
+        ).read_text(encoding="utf-8")
+        tree = ast.parse(source)
+        called_at = {}
+        for node in ast.walk(tree):
+            if isinstance(node, ast.Call) and isinstance(node.func, ast.Name):
+                called_at.setdefault(node.func.id, node.lineno)
 
-        assert readers == []
+        assert "prepare_runtime_database" in called_at
+        assert "bootstrap_runtime_database" in called_at
+        assert (
+            called_at["prepare_runtime_database"]
+            < called_at["bootstrap_runtime_database"]
+            < called_at["run_all_initializers"]
+        )
 
 
 class TestEnvironmentOverride:
@@ -272,7 +286,7 @@ def test_config_paths_delegate_to_the_resolver():
     """One policy, not three modules that happen to agree."""
     import utils.config
 
-    assert Path(utils.config.DATA_DIR) == runtime_paths.legacy_data_dir()
+    assert Path(utils.config.DATA_DIR) == runtime_paths.runtime_data_dir()
     assert Path(utils.config.LOGS_DIR) == runtime_paths.logs_dir()
     assert Path(utils.config.BASE_DIR) == runtime_paths.installation_root()
 

--- a/utils/catalog_seed.py
+++ b/utils/catalog_seed.py
@@ -9,6 +9,7 @@ from pathlib import Path
 
 import utils.config
 from utils.logger import get_logger
+from utils.runtime_paths import publish_without_overwrite
 
 
 logger = get_logger()
@@ -25,19 +26,6 @@ def resolve_catalog_seed_path() -> Path:
     else:
         bundle_root = Path(__file__).resolve().parents[1]
     return bundle_root / "data" / CATALOG_SEED_FILENAME
-
-
-def _publish_without_overwrite(temporary: Path, target: Path) -> None:
-    """Atomically publish *temporary* while preserving a concurrent winner."""
-    if os.name == "nt":
-        # Windows rename is atomic and fails when the destination exists.
-        os.rename(temporary, target)
-        return
-
-    # POSIX rename replaces an existing destination, so use an atomic hard-link
-    # publication instead. Both paths are siblings and therefore on one device.
-    os.link(temporary, target)
-    temporary.unlink()
 
 
 def bootstrap_runtime_database(
@@ -86,7 +74,7 @@ def bootstrap_runtime_database(
             os.fsync(copied.fileno())
 
         try:
-            _publish_without_overwrite(temporary, target)
+            publish_without_overwrite(temporary, target)
         except FileExistsError:
             logger.info(
                 "Runtime database was created concurrently at %s; "

--- a/utils/config.py
+++ b/utils/config.py
@@ -1,23 +1,25 @@
 import os
 
 from utils.runtime_paths import (
-    legacy_data_dir,
-    legacy_database_path,
+    installation_root,
     logs_dir,
+    runtime_data_dir,
+    runtime_database_path,
 )
 
 # Paths
 # BASE_DIR is the installation root: the repository in a checkout, the bundle in
 # a frozen build. utils/runtime_paths.py owns every path derived from it.
-BASE_DIR = str(legacy_data_dir().parent)
-DATA_DIR = str(legacy_data_dir())  # Database and backups (Packet B2 moves these)
+BASE_DIR = str(installation_root())
+DATA_DIR = str(runtime_data_dir())  # Database and backups; per-user when frozen
 LOGS_DIR = str(logs_dir())  # Per-user writable when frozen, repository-local otherwise
 
 # Database File
-# Still installation-relative on purpose. Packet B2 repoints this to
-# runtime_paths.runtime_database_path() atomically with legacy migration; doing
-# it earlier would seed an empty database over an upgrading user's real data.
-DB_FILE = os.getenv("DB_FILE", str(legacy_database_path()))  # Allow override via environment variable
+# Resolved, not installation-relative: a frozen install writes to the per-user
+# data directory, so an application update cannot overwrite user data and a
+# read-only installation directory still works. utils/runtime_migration.py moves
+# an existing database here on the first startup that needs it.
+DB_FILE = os.getenv("DB_FILE", str(runtime_database_path()))  # Allow override via environment variable
 
 # Application Constants
 APP_TITLE = "Workout Tracker"

--- a/utils/runtime_migration.py
+++ b/utils/runtime_migration.py
@@ -1,0 +1,276 @@
+"""Move an existing database out of the installation directory, once, safely.
+
+Packet B1 built the resolver but deliberately left the database where it was.
+This module is the other half: it decides which database a frozen install
+actually opens, and migrates a legacy one when the new location is empty.
+
+The legacy database is **never** deleted, moved, or written to. It is copied
+through SQLite's backup API, the copy is verified before it is published, and
+the original stays exactly where it was as the recovery path. If anything about
+the migration cannot be proven, this run keeps using the legacy database and
+says so — it never seeds a clean database after finding real user data, which
+would present as data loss whether or not the data was recoverable.
+"""
+from __future__ import annotations
+
+import os
+import shutil
+import sqlite3
+import tempfile
+from contextlib import closing
+from dataclasses import dataclass
+from pathlib import Path
+
+from utils.logger import get_logger
+from utils.runtime_paths import (
+    ensure_directory,
+    legacy_data_dir,
+    legacy_database_path,
+    publish_without_overwrite,
+    runtime_data_dir,
+    runtime_database_path,
+)
+
+logger = get_logger()
+
+DB_FILE_ENV = "DB_FILE"
+AUTO_BACKUP_DIRNAME = "auto_backup"
+
+# A journal or WAL sidecar means the legacy database has state that only a
+# writer can resolve, and writing to it is forbidden. Copying anyway would
+# silently drop committed transactions still living in the WAL.
+_UNRESOLVED_SIDECARS = ("-wal", "-journal")
+
+RECOVERY_MESSAGE = (
+    "The existing database was left untouched at %s and is still in use. "
+    "Close any other running copy of the application and restart to retry "
+    "the move to %s."
+)
+
+
+@dataclass(frozen=True)
+class MigrationOutcome:
+    """What startup decided, and which database it should open."""
+
+    action: str
+    database_path: Path
+    legacy_path: Path | None = None
+    backups_copied: int = 0
+    reason: str | None = None
+
+    @property
+    def migrated(self) -> bool:
+        return self.action == "migrated"
+
+
+class MigrationError(RuntimeError):
+    """Raised internally when a migration cannot be proven correct."""
+
+
+def _table_names(connection: sqlite3.Connection) -> set[str]:
+    rows = connection.execute(
+        "SELECT name FROM sqlite_master WHERE type='table' "
+        "AND name NOT LIKE 'sqlite_%'"
+    ).fetchall()
+    return {row[0] for row in rows}
+
+
+def _row_counts(connection: sqlite3.Connection) -> dict[str, int]:
+    return {
+        table: connection.execute(
+            f'SELECT COUNT(*) FROM "{table}"'
+        ).fetchone()[0]
+        for table in _table_names(connection)
+    }
+
+
+def _read_only_connection(path: Path) -> sqlite3.Connection:
+    """Open *path* in a mode that cannot modify it."""
+    return sqlite3.connect(f"file:{path.as_posix()}?mode=ro", uri=True)
+
+
+def _assert_no_unresolved_sidecars(legacy: Path) -> None:
+    outstanding = [
+        legacy.with_name(legacy.name + suffix)
+        for suffix in _UNRESOLVED_SIDECARS
+        if legacy.with_name(legacy.name + suffix).exists()
+    ]
+    if outstanding:
+        raise MigrationError(
+            "the database has unresolved journal state "
+            f"({', '.join(path.name for path in outstanding)}); it must be "
+            "closed cleanly before it can be copied without writing to it"
+        )
+
+
+def _verify_copy(legacy: Path, copy: Path) -> None:
+    """Fail unless *copy* is a sound database holding the same rows.
+
+    ``closing`` rather than ``with connection``: the latter commits but leaves
+    the handle open, and Windows refuses to rename a file that is still open —
+    so the copy would verify and then fail to publish.
+    """
+    with closing(_read_only_connection(legacy)) as source, closing(
+        _read_only_connection(copy)
+    ) as destination:
+        integrity = destination.execute("PRAGMA integrity_check").fetchone()
+        if not integrity or integrity[0] != "ok":
+            raise MigrationError(
+                f"the copy failed its integrity check: {integrity}"
+            )
+        violations = destination.execute("PRAGMA foreign_key_check").fetchall()
+        if violations:
+            raise MigrationError(
+                f"the copy has {len(violations)} foreign-key violations"
+            )
+
+        expected = _row_counts(source)
+        actual = _row_counts(destination)
+        if expected != actual:
+            differing = sorted(
+                table
+                for table in set(expected) | set(actual)
+                if expected.get(table) != actual.get(table)
+            )
+            raise MigrationError(
+                "the copy does not hold the same rows; differing tables: "
+                + ", ".join(differing)
+            )
+
+
+def _copy_and_publish(legacy: Path, target: Path) -> None:
+    """Copy *legacy* to *target* via a verified temporary sibling.
+
+    Verification happens before publication, never after: checking a database
+    that is already the live one leaves a window in which a half-copied file is
+    what the application opens.
+    """
+    ensure_directory(target.parent)
+    descriptor, temporary_name = tempfile.mkstemp(
+        prefix=f".{target.name}.migrating.", suffix=".tmp", dir=target.parent
+    )
+    os.close(descriptor)
+    temporary = Path(temporary_name)
+    try:
+        with closing(_read_only_connection(legacy)) as source, closing(
+            sqlite3.connect(str(temporary))
+        ) as destination:
+            source.backup(destination)
+
+        _verify_copy(legacy, temporary)
+
+        try:
+            publish_without_overwrite(temporary, target)
+        except FileExistsError:
+            logger.info(
+                "Runtime database appeared at %s while migrating; "
+                "preserving it and leaving the original untouched",
+                target,
+            )
+    finally:
+        temporary.unlink(missing_ok=True)
+
+
+def copy_legacy_backups(
+    source_directory: Path | None = None,
+    target_directory: Path | None = None,
+) -> int:
+    """Copy legacy auto-backup snapshots to the new runtime root, best-effort.
+
+    Failure is logged and swallowed on purpose. The originals are untouched, so
+    a failed copy costs nothing; blocking startup over it would cost the user
+    their session.
+    """
+    source = (
+        source_directory
+        if source_directory is not None
+        else legacy_data_dir() / AUTO_BACKUP_DIRNAME
+    )
+    target = (
+        target_directory
+        if target_directory is not None
+        else runtime_data_dir() / AUTO_BACKUP_DIRNAME
+    )
+    if not source.is_dir() or source.resolve() == target.resolve():
+        return 0
+
+    copied = 0
+    try:
+        ensure_directory(target)
+        for snapshot in sorted(source.glob("database_*.db")):
+            destination = target / snapshot.name
+            if destination.exists():
+                continue
+            shutil.copy2(snapshot, destination)
+            copied += 1
+    except OSError:
+        logger.warning(
+            "Could not copy every legacy backup from %s; the originals are "
+            "unchanged and still readable there",
+            source,
+            exc_info=True,
+        )
+    if copied:
+        logger.info("Copied %s legacy backup snapshot(s) to %s", copied, target)
+    return copied
+
+
+def prepare_runtime_database(
+    *,
+    target: Path | None = None,
+    legacy: Path | None = None,
+    explicit_override: str | None = None,
+) -> MigrationOutcome:
+    """Decide which database to open, migrating a legacy one exactly once.
+
+    Precedence, and every branch is a no-op on the legacy file:
+
+    1. An explicit ``DB_FILE`` wins outright and is never migrated into.
+    2. A runtime database that already exists is used unchanged.
+    3. A legacy database is copied once, verified, and published.
+    4. Neither present — the caller's seed bootstrap handles a fresh install.
+
+    Never raises. A migration that cannot be proven correct leaves the legacy
+    database authoritative for this run and reports how to retry.
+    """
+    override = (
+        explicit_override
+        if explicit_override is not None
+        else os.environ.get(DB_FILE_ENV)
+    )
+    if override:
+        return MigrationOutcome("explicit-override", Path(override))
+
+    destination = target if target is not None else runtime_database_path()
+    origin = legacy if legacy is not None else legacy_database_path()
+
+    if destination == origin:
+        # A source checkout resolves both to the repository; nothing to move.
+        return MigrationOutcome("same-path", destination, origin)
+    if destination.exists():
+        return MigrationOutcome("already-present", destination, origin)
+    if not origin.is_file():
+        return MigrationOutcome("no-legacy", destination, origin)
+
+    try:
+        _assert_no_unresolved_sidecars(origin)
+        _copy_and_publish(origin, destination)
+    except (MigrationError, sqlite3.Error, OSError) as exc:
+        logger.error(
+            "Could not move the existing database to %s: %s", destination, exc
+        )
+        logger.error(RECOVERY_MESSAGE, origin, destination)
+        return MigrationOutcome(
+            "failed", origin, origin, reason=str(exc)
+        )
+
+    backups_copied = copy_legacy_backups()
+    logger.info(
+        "Moved the existing database from %s to %s; the original was left in "
+        "place",
+        origin,
+        destination,
+    )
+    return MigrationOutcome(
+        "migrated", destination, origin, backups_copied=backups_copied
+    )

--- a/utils/runtime_paths.py
+++ b/utils/runtime_paths.py
@@ -110,6 +110,25 @@ def logs_dir() -> Path:
     return runtime_root() / LOGS_DIRNAME
 
 
+def publish_without_overwrite(temporary: Path, target: Path) -> None:
+    """Atomically publish *temporary* as *target*, preserving any winner.
+
+    Raises ``FileExistsError`` when *target* already exists, which is what makes
+    two simultaneous first launches safe: the loser finds the winner's file
+    rather than replacing it. Both paths must be siblings, and therefore on one
+    device.
+    """
+    if os.name == "nt":
+        # Windows rename is atomic and fails when the destination exists.
+        os.rename(temporary, target)
+        return
+
+    # POSIX rename replaces an existing destination, so use an atomic hard-link
+    # publication instead.
+    os.link(temporary, target)
+    temporary.unlink()
+
+
 def ensure_directory(path: Path) -> Path:
     """Create *path* if absent and return it.
 


### PR DESCRIPTION
Packet B2 of `docs/rootdircleanup.md`. Base `origin/main` `a7883d4`.

## Behavior / schema changes

- **Frozen builds store database, backups, and logs under the per-user data directory** (`%LOCALAPPDATA%\HypertrophyToolbox\` on Windows), and **migrate an existing installation-directory database there once**.
- **Source checkouts are unchanged** — same repository path, so worktree isolation is untouched.

No schema change, no API response change, no calculation change.

## Why this is one PR

B1 built the resolver and deliberately left the database alone. The two halves are only safe together: a frozen install resolving to the new path while migration does not yet exist hands an upgrading user a freshly seeded empty database while their real data sits untouched at the old one. Recoverable, but indistinguishable from data loss in the moment.

## Ordering is the safety property

`prepare_runtime_database()` runs in `app.py` immediately **before** `bootstrap_runtime_database()`. Seeding first would create an empty database at the new path, after which migration would *correctly* decline to overwrite it — and the user would be staring at an empty catalog with their data still on disk. A test parses `app.py` and asserts the call order rather than trusting it.

## Never destructive

- The legacy database is opened `mode=ro` through a URI connection — physically never written. A test chmods the source directory to `0o500` to prove a read-only installation still migrates.
- **Unresolved `-wal`/`-journal` sidecars refuse migration** rather than copying past them. A database whose committed transactions still live in a WAL would silently lose them, and resolving the WAL would mean writing to the file we promised not to touch. Refusing costs one restart.
- The copy goes to a temporary sibling and is **verified there** (`integrity_check`, `foreign_key_check`, per-table row counts equal to source) before atomic no-overwrite publication. Verifying after publication leaves a window where a half-copied database is already live.
- Every failure path returns the **legacy** path, logs what failed, and logs how to retry. A corrupt legacy database yields a refusal and a recovery message — never a clean seed presented as success.
- An existing runtime database is never replaced, including a zero-byte one: "looks empty" is not a licence to overwrite something that may be mid-repair.

Backups are copied once, best-effort; failure is logged and swallowed, because the originals are untouched while blocking startup would cost the user their session. Old logs are not migrated.

`publish_without_overwrite()` moved to `runtime_paths` — two copies of an atomic-publication routine is one too many.

## A defect the tests caught before merge

`_verify_copy` used `with sqlite3.connect(...)`, which commits but does **not** close. POSIX renames happily with the handle open; Windows fails with `WinError 32`. Every successful-migration test failed locally and **would have passed in Linux CI** — the copy verified and then could not be published. Fixed with `contextlib.closing`.

## Verification

- pytest **1,837 passed / 1 skipped** — baseline **1,812 / 1** at `a7883d4`, plus 25 migration contracts. B1's guard tests are inverted into their B2 counterparts; this is the packet entitled to replace them.
- Real `build_exe.bat` build, `--mode bootloader` on the real executable:
  - **Fresh install** — database created under the runtime root, packaged seed byte-identical, **the installation directory gained no runtime files at all**, `app.log` under the runtime root.
  - **Upgrade** — a legacy database carrying a plan row was planted in the installation directory exactly where every earlier release put it. The app served 1,897 exercises, the database moved to the runtime root, **the plan row survived**, and **the original is still there, byte-identical**.
- Migration contracts also cover paths with spaces and non-ASCII characters, repeat startup, concurrent first launches, and explicit `DB_FILE` precedence.

The `frozen-windows` deep-gate job is triggered on this branch before merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)