### PR TITLE
catalog: apply shipped catalog updates to existing installs, additively

### DIFF
--- a/.claude/rules/database.md
+++ b/.claude/rules/database.md
@@ -90,6 +90,26 @@ counts) before publishing it atomically, and never deletes or writes to the
 original. Any failure returns the legacy path and logs recovery steps; it never
 seeds a clean database after finding real data.
 
+## Catalog upgrades (`utils/catalog_upgrade.py`)
+The seed only initializes a new install. `upgrade_catalog_from_seed()` brings an
+existing runtime catalog up to the shipped one and runs from `app.py` startup
+only — never from `run_all_initializers()`, which the test suite uses to build
+deliberately empty schemas.
+
+Additive and update-only. It inserts exercises the runtime database lacks
+(with their isolated muscles), refreshes only `movement_pattern`,
+`movement_subpattern`, `youtube_video_id`, `media_path` on existing rows, and
+**never deletes or renames**. Everything else is user-owned: `save_exercise()`
+lets a user rewrite an exercise's muscle groups, equipment, mechanic, and
+difficulty — including on catalog exercises — and derives
+`exercise_isolated_muscles` from `advanced_isolated_muscles`. A `NULL` shipped
+value never overwrites a populated one.
+
+The trigger is a SHA-256 over the shipped catalog's rows, recorded in
+`catalog_version` (catalog metadata, deliberately not in
+`OWNED_TABLES_DROP_ORDER`). Adding a column to `save_exercise`'s editable list
+fails `tests/test_catalog_upgrade.py`.
+
 ## Env vars that affect DB (`utils/config.py`)
 | Variable | Default | Effect |
 |---|---|---|

--- a/app.py
+++ b/app.py
@@ -4,6 +4,7 @@ import utils.config
 from utils.database import DatabaseHandler
 from utils.auto_backup import create_startup_backup, describe_snapshot
 from utils.catalog_seed import bootstrap_runtime_database
+from utils.catalog_upgrade import upgrade_catalog_from_seed
 from utils.runtime_migration import prepare_runtime_database
 from utils.schema_registry import drop_all_owned_tables, run_all_initializers
 from routes.workout_log import workout_log_bp
@@ -62,6 +63,14 @@ migration = prepare_runtime_database()
 utils.config.DB_FILE = str(migration.database_path)
 database_seeded = bootstrap_runtime_database()
 run_all_initializers(force_base=False)
+
+# Bring an existing install's catalog up to the shipped one. Called from real
+# startup only, never from run_all_initializers(): the test suite initializes
+# empty schemas on purpose, and seeding 1,897 exercises into them would change
+# what most of the suite means. Additive and update-only — see
+# utils/catalog_upgrade.py for why deletion is not the symmetric case.
+if not database_seeded:
+    upgrade_catalog_from_seed()
 
 # The immutable seed is already a pristine recovery source. Avoid an immediate,
 # redundant first-run snapshot; normal subsequent startups retain the backup.

--- a/docs/rootdircleanup.md
+++ b/docs/rootdircleanup.md
@@ -1113,7 +1113,8 @@ Therefore:
   for `DB_FILE` yet. **Shipped** — see §7.6.
 - **B2** activates the frozen `DB_FILE` switch **atomically with** legacy
   migration and backup copying — one PR, or not at all. **Shipped** — see §7.7.
-- **B3** adds catalog versioning and additive upgrade behavior.
+- **B3** adds catalog versioning and additive upgrade behavior. **Shipped** —
+  see §7.8.
 
 ### 7.3 Migration precedence
 
@@ -1179,21 +1180,21 @@ silently diverge until this exists.
 
 The approved policy is **versioned, additive/update-only**:
 
-- [ ] Version catalog content independently from the mutable schema, and record
+- [x] Version catalog content independently from the mutable schema, and record
       the applied version in the runtime database.
-- [ ] Apply the upgrade idempotently: re-running it changes nothing.
-- [ ] Insert catalog exercises that the runtime database lacks.
-- [ ] Update catalog-owned columns of exercises it already has.
-- [ ] **Never delete or rename a catalog exercise automatically.** A row absent
+- [x] Apply the upgrade idempotently: re-running it changes nothing.
+- [x] Insert catalog exercises that the runtime database lacks.
+- [x] Update catalog-owned columns of exercises it already has.
+- [x] **Never delete or rename a catalog exercise automatically.** A row absent
       from a newer catalog is left alone. Renaming is deletion plus insertion
       against a text primary key, and the user's plans and logs reference that
       key.
-- [ ] Never cascade into user-owned tables. `exercise_isolated_muscles` is
+- [x] Never cascade into user-owned tables. `exercise_isolated_muscles` is
       catalog data and is reconciled with the catalog; `user_selection`,
       `workout_log`, and every other registered owned table are untouchable.
-- [ ] Preserve user-owned columns and user-created rows according to an
+- [x] Preserve user-owned columns and user-created rows according to an
       explicit, documented column split.
-- [ ] Test upgrade from at least the previous shipped catalog version.
+- [x] Test upgrade from at least the previous shipped catalog version.
 
 The asymmetry is deliberate. Adding a wrong exercise is a cosmetic defect the
 user can ignore; deleting one silently invalidates their training history.
@@ -1223,16 +1224,16 @@ Stop and report before merging if any of these becomes true:
 
 Cross-packet:
 
-- [ ] Existing legacy user data survives migration exactly once.
-- [ ] Fresh install receives the full catalog and zero user rows.
-- [ ] Repeated startup does not recopy or reset the database.
-- [ ] Packaged upgrades do not overwrite runtime data.
-- [ ] Automatic backups and erase-data recovery target the new runtime
+- [x] Existing legacy user data survives migration exactly once.
+- [x] Fresh install receives the full catalog and zero user rows.
+- [x] Repeated startup does not recopy or reset the database.
+- [x] Packaged upgrades do not overwrite runtime data.
+- [x] Automatic backups and erase-data recovery target the new runtime
       directory.
-- [ ] Logs do not require write access to the installation directory.
-- [ ] Worktrees remain isolated.
-- [ ] `DB_FILE` overrides remain deterministic.
-- [ ] Full pytest, E2E, cold-start, old-schema migration, packaged smoke, and
+- [x] Logs do not require write access to the installation directory.
+- [x] Worktrees remain isolated.
+- [x] `DB_FILE` overrides remain deterministic.
+- [x] Full pytest, E2E, cold-start, old-schema migration, packaged smoke, and
       recovery tests pass.
 
 ### 7.6 Recorded B1 results
@@ -1333,6 +1334,75 @@ build:
   installation directory exactly where every earlier release put it. The app
   served 1,897 exercises, the database moved to the runtime root, **the plan row
   survived**, and **the original file is still there, byte-identical**.
+
+### 7.8 Recorded B3 results
+
+`utils/catalog_upgrade.py` applies the shipped catalog to an existing runtime
+database. `app.py` calls it after `run_all_initializers()` and only when the
+seed bootstrap did *not* just create the database — never from
+`run_all_initializers()` itself, for the same reason the seed bootstrap is not
+called there: the test suite initializes empty schemas deliberately, and
+injecting 1,897 exercises would change what most of the suite means.
+
+**Versioning is content-addressed.** The applied version is recorded in a
+`catalog_version` table, but the trigger is a SHA-256 over the shipped catalog's
+own rows rather than a hand-maintained number. A number can be forgotten during
+a catalog change; a content hash cannot go stale. `catalog_version` is catalog
+metadata and is deliberately absent from `OWNED_TABLES_DROP_ORDER`, so erasing
+user data does not force a needless full re-scan.
+
+#### The finding that shaped this packet
+
+§7.4 assumed a clean split between catalog columns and user columns, and that
+`exercise_isolated_muscles` could simply be "reconciled with the catalog". The
+code says otherwise. `ExerciseManager.save_exercise()` — reached from
+`POST /add_exercise` — lets a user rewrite an exercise's muscle groups,
+equipment, mechanic, difficulty, utility, grips, stabilizers, synergists, and
+force, **including on catalog exercises**. Those columns are user-owned the
+moment a row exists, and refreshing them from the seed would silently discard
+the user's edit. The same call derives `exercise_isolated_muscles` from the
+user-editable `advanced_isolated_muscles` column, so reconciling that table
+would overwrite user intent too.
+
+The implemented split is therefore narrower than §7.4 implied, and deliberately
+so:
+
+- **Refreshed on existing rows:** `movement_pattern`, `movement_subpattern`,
+  `youtube_video_id`, `media_path` — the four columns no application path lets a
+  user write.
+- **Never touched on existing rows:** every user-editable column, and
+  `exercise_isolated_muscles`.
+- **Inserted whole:** exercises absent from the runtime database, with their
+  isolated muscles.
+- **Never removed or renamed:** an exercise absent from a newer catalog is left
+  alone, whether it is a user's own or a retired one.
+
+A test parses `exercise_manager.py` and fails if any refreshed column appears in
+`save_exercise`'s editable column list — so a column that later becomes
+user-editable breaks the build instead of quietly starting to discard edits.
+
+**A missing shipped value never erases a populated one.** Verifying against the
+real catalog turned up the hazard: the shipped seed carries `media_path` for
+**0 of 1,897** rows and `youtube_video_id` for **56**, while `movement_pattern`
+is complete and `movement_subpattern` covers 1,282. Refreshing on plain
+inequality would blank populated columns the moment a catalog was regenerated
+without them — data loss dressed as an update. Only non-`NULL` shipped values
+are applied, and a test pins both halves: the empty value does not erase, and a
+real correction still lands.
+
+This stays inside the approved B-D5 policy (additive/update-only, never delete
+or rename); it is strictly more conservative than the policy's minimum.
+
+Baseline at the packet's starting commit `abfc048`: **1,837 passed / 1 skipped**.
+After: **1,856 passed / 1 skipped** — 19 catalog-upgrade contracts.
+
+Checked against the real 1,897-exercise catalog, not only synthetic fixtures.
+An "older install" was built by deleting three exercises, corrupting
+`movement_pattern` on five, editing one exercise's equipment, setting a
+`media_path` the seed does not carry, and adding a user-created exercise with a
+plan row referencing it. The upgrade inserted the three, corrected all five,
+preserved the equipment edit and the `media_path`, kept the user's exercise and
+plan, and the second run reported `already-current`.
 
 ---
 
@@ -1678,7 +1748,7 @@ schema changes, and merges only on green CI.
        frozen database path.
 4. [x] **B2** — frozen runtime database path, legacy migration, and backup
        copying, activated atomically.
-5. [ ] **B3** — catalog versioning and additive upgrade behavior.
+5. [x] **B3** — catalog versioning and additive upgrade behavior.
 
 The verified starting point for this sequence is `origin/main` at
 `631f61a13036861841a00ce8360d40b6698f16f8`.

--- a/tests/test_catalog_upgrade.py
+++ b/tests/test_catalog_upgrade.py
@@ -1,0 +1,401 @@
+"""Contracts for versioned, additive catalog upgrades (Packet B3).
+
+The property under test throughout: an upgrade may add and it may refresh
+catalog-owned columns, but it may never remove an exercise, rename one, discard
+a user's edit, or touch a row outside the two catalog tables.
+"""
+from __future__ import annotations
+
+import sqlite3
+from pathlib import Path
+
+import pytest
+
+import utils.config
+from utils.catalog_upgrade import (
+    CATALOG_OWNED_COLUMNS,
+    CATALOG_VERSION,
+    CATALOG_VERSION_TABLE,
+    add_catalog_version_table,
+    upgrade_catalog_from_seed,
+)
+from utils.schema_registry import OWNED_TABLES_DROP_ORDER, run_all_initializers
+
+CATALOG_COLUMNS = (
+    "exercise_name",
+    "primary_muscle_group",
+    "secondary_muscle_group",
+    "tertiary_muscle_group",
+    "advanced_isolated_muscles",
+    "utility",
+    "grips",
+    "stabilizers",
+    "synergists",
+    "force",
+    "equipment",
+    "mechanic",
+    "difficulty",
+    "movement_pattern",
+    "movement_subpattern",
+    "youtube_video_id",
+    "media_path",
+)
+
+
+def _exercise(name: str, **overrides) -> dict:
+    row = {column: None for column in CATALOG_COLUMNS}
+    row["exercise_name"] = name
+    row["primary_muscle_group"] = "Chest"
+    row["equipment"] = "Barbell"
+    row["movement_pattern"] = "horizontal_push"
+    row.update(overrides)
+    return row
+
+
+def _write_seed(path: Path, exercises: list[dict], muscles: dict) -> Path:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    connection = sqlite3.connect(str(path))
+    try:
+        connection.execute(
+            "CREATE TABLE exercises ("
+            + ", ".join(f"{column} TEXT" for column in CATALOG_COLUMNS)
+            + ", PRIMARY KEY (exercise_name))"
+        )
+        connection.execute(
+            "CREATE TABLE exercise_isolated_muscles ("
+            "exercise_name TEXT, muscle TEXT, "
+            "PRIMARY KEY (exercise_name, muscle))"
+        )
+        for row in exercises:
+            connection.execute(
+                "INSERT INTO exercises VALUES ("
+                + ", ".join(f":{column}" for column in CATALOG_COLUMNS)
+                + ")",
+                row,
+            )
+        for name, entries in muscles.items():
+            for muscle in entries:
+                connection.execute(
+                    "INSERT INTO exercise_isolated_muscles VALUES (?, ?)",
+                    (name, muscle),
+                )
+        connection.commit()
+    finally:
+        connection.close()
+    return path
+
+
+@pytest.fixture
+def runtime(app, db_handler):
+    """A runtime database carrying one catalog exercise and one user plan."""
+    db_handler.execute_query(
+        "INSERT INTO exercises (exercise_name, primary_muscle_group, "
+        "equipment, movement_pattern) VALUES (?, ?, ?, ?)",
+        ("Bench Press", "Chest", "Barbell", "horizontal_push"),
+    )
+    db_handler.execute_query(
+        "INSERT INTO user_selection (routine, exercise, sets, min_rep_range, "
+        "max_rep_range, weight) VALUES (?, ?, 3, 8, 12, 60.0)",
+        ("Push Day", "Bench Press"),
+    )
+    return db_handler
+
+
+@pytest.fixture
+def seed(tmp_path) -> Path:
+    """A shipped catalog: the existing exercise plus a new one."""
+    return _write_seed(
+        tmp_path / "catalog.seed.db",
+        [
+            _exercise("Bench Press", media_path="media/bench.jpg"),
+            _exercise("Cable Fly", primary_muscle_group="Chest"),
+        ],
+        {"Cable Fly": ["pectoralis-major-sternal"]},
+    )
+
+
+def _names(db) -> set[str]:
+    return {row["exercise_name"] for row in db.fetch_all(
+        "SELECT exercise_name FROM exercises"
+    )}
+
+
+class TestAdditiveUpgrade:
+    def test_new_exercises_are_inserted_with_their_muscles(self, runtime, seed):
+        result = upgrade_catalog_from_seed(seed_path=seed)
+
+        assert result.applied
+        assert result.inserted == 1
+        assert _names(runtime) == {"Bench Press", "Cable Fly"}
+        muscles = runtime.fetch_all(
+            "SELECT muscle FROM exercise_isolated_muscles "
+            "WHERE exercise_name = ?",
+            ("Cable Fly",),
+        )
+        assert [row["muscle"] for row in muscles] == [
+            "pectoralis-major-sternal"
+        ]
+
+    def test_catalog_owned_columns_are_refreshed(self, runtime, seed):
+        upgrade_catalog_from_seed(seed_path=seed)
+
+        row = runtime.fetch_one(
+            "SELECT media_path FROM exercises WHERE exercise_name = ?",
+            ("Bench Press",),
+        )
+        assert row["media_path"] == "media/bench.jpg"
+
+    def test_running_twice_changes_nothing(self, runtime, seed):
+        upgrade_catalog_from_seed(seed_path=seed)
+
+        second = upgrade_catalog_from_seed(seed_path=seed)
+
+        assert not second.applied
+        assert second.reason == "already-current"
+        assert _names(runtime) == {"Bench Press", "Cable Fly"}
+
+    def test_a_changed_catalog_is_reapplied(self, runtime, seed, tmp_path):
+        upgrade_catalog_from_seed(seed_path=seed)
+        newer = _write_seed(
+            tmp_path / "newer.seed.db",
+            [
+                _exercise("Bench Press", media_path="media/bench.jpg"),
+                _exercise("Cable Fly"),
+                _exercise("Pec Deck"),
+            ],
+            {},
+        )
+
+        result = upgrade_catalog_from_seed(seed_path=newer)
+
+        assert result.applied
+        assert result.inserted == 1
+        assert "Pec Deck" in _names(runtime)
+
+    def test_the_applied_version_is_recorded(self, runtime, seed):
+        upgrade_catalog_from_seed(seed_path=seed)
+
+        row = runtime.fetch_one(
+            f"SELECT version, content_hash, applied_at "
+            f"FROM {CATALOG_VERSION_TABLE} WHERE id = 1"
+        )
+        assert row["version"] == CATALOG_VERSION
+        assert len(row["content_hash"]) == 64
+        assert row["applied_at"]
+
+
+class TestNeverDestructive:
+    def test_an_exercise_missing_from_a_newer_catalog_is_kept(
+        self, runtime, seed, tmp_path
+    ):
+        """Removing it would invalidate every plan and log row naming it."""
+        upgrade_catalog_from_seed(seed_path=seed)
+        shrunk = _write_seed(
+            tmp_path / "shrunk.seed.db", [_exercise("Cable Fly")], {}
+        )
+
+        result = upgrade_catalog_from_seed(seed_path=shrunk)
+
+        assert result.applied
+        assert "Bench Press" in _names(runtime)
+
+    def test_user_edits_to_catalog_exercises_survive(
+        self, runtime, seed, tmp_path
+    ):
+        """save_exercise() lets a user rewrite these columns; we must not."""
+        runtime.execute_query(
+            "UPDATE exercises SET equipment = ?, difficulty = ?, "
+            "primary_muscle_group = ? WHERE exercise_name = ?",
+            ("Dumbbell", "Advanced", "Shoulders", "Bench Press"),
+        )
+
+        upgrade_catalog_from_seed(seed_path=seed)
+
+        row = runtime.fetch_one(
+            "SELECT equipment, difficulty, primary_muscle_group "
+            "FROM exercises WHERE exercise_name = ?",
+            ("Bench Press",),
+        )
+        assert row["equipment"] == "Dumbbell"
+        assert row["difficulty"] == "Advanced"
+        assert row["primary_muscle_group"] == "Shoulders"
+
+    def test_a_missing_shipped_value_never_erases_a_populated_one(
+        self, runtime, tmp_path
+    ):
+        """The seed ships media_path empty for every row today.
+
+        Refreshing blindly would blank populated columns the moment a catalog
+        was regenerated without them, which is data loss dressed as an update.
+        """
+        runtime.execute_query(
+            "UPDATE exercises SET media_path = ?, youtube_video_id = ? "
+            "WHERE exercise_name = ?",
+            ("media/bench.jpg", "abc123", "Bench Press"),
+        )
+        sparse = _write_seed(
+            tmp_path / "sparse.seed.db",
+            [_exercise("Bench Press", media_path=None, youtube_video_id=None)],
+            {},
+        )
+
+        upgrade_catalog_from_seed(seed_path=sparse)
+
+        row = runtime.fetch_one(
+            "SELECT media_path, youtube_video_id FROM exercises "
+            "WHERE exercise_name = ?",
+            ("Bench Press",),
+        )
+        assert row["media_path"] == "media/bench.jpg"
+        assert row["youtube_video_id"] == "abc123"
+
+    def test_a_shipped_correction_still_lands(self, runtime, tmp_path):
+        """Not-erasing must not become not-updating."""
+        corrected = _write_seed(
+            tmp_path / "corrected.seed.db",
+            [_exercise("Bench Press", movement_pattern="vertical_push")],
+            {},
+        )
+
+        result = upgrade_catalog_from_seed(seed_path=corrected)
+
+        assert result.refreshed == 1
+        row = runtime.fetch_one(
+            "SELECT movement_pattern FROM exercises WHERE exercise_name = ?",
+            ("Bench Press",),
+        )
+        assert row["movement_pattern"] == "vertical_push"
+
+    def test_user_created_exercises_are_untouched(self, runtime, seed):
+        runtime.execute_query(
+            "INSERT INTO exercises (exercise_name, primary_muscle_group, "
+            "equipment) VALUES (?, ?, ?)",
+            ("My Custom Lift", "Back", "Machine"),
+        )
+
+        upgrade_catalog_from_seed(seed_path=seed)
+
+        row = runtime.fetch_one(
+            "SELECT primary_muscle_group FROM exercises WHERE exercise_name = ?",
+            ("My Custom Lift",),
+        )
+        assert row["primary_muscle_group"] == "Back"
+
+    def test_user_isolated_muscle_edits_survive(self, runtime, seed):
+        """Derived from the user-editable advanced_isolated_muscles column."""
+        runtime.execute_query(
+            "INSERT INTO exercise_isolated_muscles (exercise_name, muscle) "
+            "VALUES (?, ?)",
+            ("Bench Press", "a-muscle-the-user-chose"),
+        )
+
+        upgrade_catalog_from_seed(seed_path=seed)
+
+        rows = runtime.fetch_all(
+            "SELECT muscle FROM exercise_isolated_muscles "
+            "WHERE exercise_name = ?",
+            ("Bench Press",),
+        )
+        assert [row["muscle"] for row in rows] == ["a-muscle-the-user-chose"]
+
+    def test_no_user_owned_table_is_touched(self, runtime, seed, tmp_path):
+        before = {
+            table: runtime.fetch_one(f'SELECT COUNT(*) AS n FROM "{table}"')[
+                "n"
+            ]
+            for table in OWNED_TABLES_DROP_ORDER
+        }
+        shrunk = _write_seed(
+            tmp_path / "shrunk.seed.db", [_exercise("Cable Fly")], {}
+        )
+
+        upgrade_catalog_from_seed(seed_path=shrunk)
+
+        after = {
+            table: runtime.fetch_one(f'SELECT COUNT(*) AS n FROM "{table}"')[
+                "n"
+            ]
+            for table in OWNED_TABLES_DROP_ORDER
+        }
+        assert before == after
+        assert before["user_selection"] == 1
+
+    def test_a_plan_row_still_resolves_after_upgrade(self, runtime, seed):
+        upgrade_catalog_from_seed(seed_path=seed)
+
+        joined = runtime.fetch_one(
+            "SELECT s.routine FROM user_selection s "
+            "JOIN exercises e ON e.exercise_name = s.exercise"
+        )
+        assert joined["routine"] == "Push Day"
+
+
+class TestFailureIsHarmless:
+    def test_a_missing_catalog_is_not_an_error(self, runtime, tmp_path):
+        result = upgrade_catalog_from_seed(seed_path=tmp_path / "absent.db")
+
+        assert not result.applied
+        assert result.reason == "no-seed"
+        assert _names(runtime) == {"Bench Press"}
+
+    def test_an_unreadable_catalog_leaves_the_database_alone(
+        self, runtime, tmp_path
+    ):
+        broken = tmp_path / "broken.seed.db"
+        broken.write_bytes(b"not a database" * 50)
+
+        result = upgrade_catalog_from_seed(seed_path=broken)
+
+        assert not result.applied
+        assert result.reason == "unreadable-seed"
+        assert _names(runtime) == {"Bench Press"}
+
+
+class TestColumnSplitIsHonest:
+    def test_catalog_owned_columns_are_not_user_editable(self):
+        """The split is derived from what the application lets a user write.
+
+        If save_exercise() gains one of these columns, refreshing it would
+        start discarding user edits, and this fails rather than letting that
+        happen quietly.
+        """
+        source = (
+            Path(__file__).resolve().parents[1] / "utils" / "exercise_manager.py"
+        ).read_text(encoding="utf-8")
+        body = source.split("def save_exercise", 1)[1]
+        editable_block = body.split("columns = [", 1)[1].split("]", 1)[0]
+
+        for column in CATALOG_OWNED_COLUMNS:
+            assert f'"{column}"' not in editable_block
+
+
+class TestSchemaRegistration:
+    def test_the_version_table_is_created_by_the_initializers(
+        self, test_db_path, monkeypatch
+    ):
+        monkeypatch.setattr(utils.config, "DB_FILE", test_db_path)
+        run_all_initializers(force_base=True)
+
+        connection = sqlite3.connect(test_db_path)
+        try:
+            tables = {
+                row[0]
+                for row in connection.execute(
+                    "SELECT name FROM sqlite_master WHERE type='table'"
+                )
+            }
+        finally:
+            connection.close()
+        assert CATALOG_VERSION_TABLE in tables
+
+    def test_the_version_table_is_catalog_metadata_not_user_data(self):
+        """Erasing user data must not force a needless full catalog re-scan."""
+        assert CATALOG_VERSION_TABLE not in OWNED_TABLES_DROP_ORDER
+
+    def test_creating_the_table_is_idempotent(self, db_handler):
+        add_catalog_version_table()
+        add_catalog_version_table()
+
+        assert db_handler.fetch_one(
+            f"SELECT COUNT(*) AS n FROM {CATALOG_VERSION_TABLE}"
+        )["n"] == 0

--- a/tests/test_catalog_upgrade.py
+++ b/tests/test_catalog_upgrade.py
@@ -42,8 +42,8 @@ CATALOG_COLUMNS = (
 )
 
 
-def _exercise(name: str, **overrides) -> dict:
-    row = {column: None for column in CATALOG_COLUMNS}
+def _exercise(name: str, **overrides) -> dict[str, str | None]:
+    row: dict[str, str | None] = {column: None for column in CATALOG_COLUMNS}
     row["exercise_name"] = name
     row["primary_muscle_group"] = "Chest"
     row["equipment"] = "Barbell"

--- a/utils/catalog_upgrade.py
+++ b/utils/catalog_upgrade.py
@@ -1,0 +1,246 @@
+"""Bring an existing runtime catalog up to the shipped one, additively.
+
+The seed only initializes a *new* install. Without this, a user who installed
+once would never receive a corrected movement pattern or a newly mapped
+exercise image, and fresh installs would silently diverge from upgraded ones.
+
+The policy is additive and update-only:
+
+- Exercises in the shipped catalog but not in the runtime database are inserted.
+- Exercises already present have only their **catalog-owned** columns refreshed.
+- Nothing is ever deleted or renamed, and nothing outside the two catalog tables
+  is touched.
+
+Deletion is not a symmetric risk to insertion. A wrong extra exercise is
+cosmetic and ignorable; removing one silently invalidates every plan and log row
+that references it, because `exercises.exercise_name` is the key those rows
+carry. Renaming is deletion plus insertion against that same key, so it is not
+automatic either. An exercise that disappears from a future catalog is left
+alone.
+
+**The column split is derived, not invented.** `ExerciseManager.save_exercise`
+lets a user edit an exercise's muscle groups, equipment, mechanic, difficulty,
+and the rest of its descriptive columns — including catalog exercises. Those
+columns are therefore user-owned once a row exists, and refreshing them would
+silently discard the user's edit. Only the columns no application path lets a
+user write are refreshed. For the same reason `exercise_isolated_muscles` is
+populated only for exercises this upgrade inserts: for existing rows it is
+derived from the user-editable `advanced_isolated_muscles` column, so
+reconciling it would overwrite user intent.
+"""
+from __future__ import annotations
+
+import hashlib
+import sqlite3
+from contextlib import closing
+from dataclasses import dataclass
+from datetime import datetime
+from pathlib import Path
+
+from utils.catalog_seed import resolve_catalog_seed_path
+from utils.database import DatabaseHandler
+from utils.logger import get_logger
+
+logger = get_logger()
+
+CATALOG_VERSION = 1
+CATALOG_VERSION_TABLE = "catalog_version"
+
+EXERCISES_TABLE = "exercises"
+ISOLATED_MUSCLES_TABLE = "exercise_isolated_muscles"
+
+# Columns no application path lets a user write, so refreshing them cannot
+# discard an edit. Keep this in step with ExerciseManager.save_exercise: a
+# column that becomes user-editable must move out of here.
+CATALOG_OWNED_COLUMNS = (
+    "movement_pattern",
+    "movement_subpattern",
+    "youtube_video_id",
+    "media_path",
+)
+
+
+@dataclass(frozen=True)
+class CatalogUpgradeResult:
+    """What the upgrade did, for logging and for tests."""
+
+    applied: bool
+    inserted: int = 0
+    refreshed: int = 0
+    reason: str | None = None
+
+
+def add_catalog_version_table() -> None:
+    """Create the applied-catalog-version record.
+
+    Catalog metadata, not user data: it is deliberately absent from
+    ``OWNED_TABLES_DROP_ORDER`` so erasing user data does not force a needless
+    full catalog re-scan on the next start.
+    """
+    with DatabaseHandler() as db:
+        db.execute_query(
+            f"""CREATE TABLE IF NOT EXISTS {CATALOG_VERSION_TABLE} (
+                id INTEGER PRIMARY KEY CHECK (id = 1),
+                version INTEGER NOT NULL,
+                content_hash TEXT NOT NULL,
+                applied_at TEXT NOT NULL
+            )"""
+        )
+
+
+def _catalog_content_hash(connection: sqlite3.Connection) -> str:
+    """A content-addressed catalog version.
+
+    Derived from the rows themselves rather than a hand-maintained number,
+    which cannot be forgotten during a catalog change and cannot go stale.
+    """
+    digest = hashlib.sha256()
+    for statement in (
+        f"SELECT * FROM {EXERCISES_TABLE} ORDER BY exercise_name",
+        f"SELECT * FROM {ISOLATED_MUSCLES_TABLE} ORDER BY exercise_name, muscle",
+    ):
+        for row in connection.execute(statement):
+            digest.update(repr(row).encode("utf-8"))
+            digest.update(b"\x1e")
+        digest.update(b"\x1d")
+    return digest.hexdigest()
+
+
+def _read_seed_catalog(seed: Path) -> tuple[dict, dict, str]:
+    """Return the shipped exercises, their isolated muscles, and the hash."""
+    with closing(
+        sqlite3.connect(f"file:{seed.as_posix()}?mode=ro", uri=True)
+    ) as connection:
+        content_hash = _catalog_content_hash(connection)
+        connection.row_factory = sqlite3.Row
+        exercises = {
+            row["exercise_name"]: dict(row)
+            for row in connection.execute(f"SELECT * FROM {EXERCISES_TABLE}")
+        }
+        muscles: dict[str, list[str]] = {}
+        for row in connection.execute(
+            f"SELECT exercise_name, muscle FROM {ISOLATED_MUSCLES_TABLE}"
+        ):
+            muscles.setdefault(row["exercise_name"], []).append(row["muscle"])
+    return exercises, muscles, content_hash
+
+
+def _recorded_content_hash(db: DatabaseHandler) -> str | None:
+    row = db.fetch_one(
+        f"SELECT content_hash FROM {CATALOG_VERSION_TABLE} WHERE id = 1"
+    )
+    return row["content_hash"] if row else None
+
+
+def _record_applied(db: DatabaseHandler, content_hash: str) -> None:
+    db.execute_query(
+        f"""INSERT INTO {CATALOG_VERSION_TABLE}
+                (id, version, content_hash, applied_at)
+            VALUES (1, ?, ?, ?)
+            ON CONFLICT(id) DO UPDATE SET
+                version = excluded.version,
+                content_hash = excluded.content_hash,
+                applied_at = excluded.applied_at""",
+        (CATALOG_VERSION, content_hash, datetime.now().isoformat(" ")),
+    )
+
+
+def _insert_exercise(db: DatabaseHandler, row: dict, muscles: list[str]) -> None:
+    columns = list(row)
+    db.execute_query(
+        f"INSERT INTO {EXERCISES_TABLE} ({', '.join(columns)}) "
+        f"VALUES ({', '.join(':' + column for column in columns)})",
+        row,
+    )
+    for muscle in muscles:
+        db.execute_query(
+            f"INSERT OR IGNORE INTO {ISOLATED_MUSCLES_TABLE} "
+            "(exercise_name, muscle) VALUES (?, ?)",
+            (row["exercise_name"], muscle),
+        )
+
+
+def upgrade_catalog_from_seed(
+    *,
+    seed_path: Path | str | None = None,
+    force: bool = False,
+) -> CatalogUpgradeResult:
+    """Apply the shipped catalog to the runtime database, additively.
+
+    Idempotent: a second run against an unchanged catalog does nothing. Never
+    raises — a catalog that cannot be read leaves the runtime database exactly
+    as it was, which is a working application with a slightly older catalog.
+    """
+    seed = Path(
+        seed_path if seed_path is not None else resolve_catalog_seed_path()
+    )
+    if not seed.is_file():
+        return CatalogUpgradeResult(False, reason="no-seed")
+
+    try:
+        shipped, shipped_muscles, content_hash = _read_seed_catalog(seed)
+    except sqlite3.Error as exc:
+        logger.warning("Could not read the shipped catalog at %s: %s", seed, exc)
+        return CatalogUpgradeResult(False, reason="unreadable-seed")
+
+    try:
+        with DatabaseHandler() as db:
+            if not force and _recorded_content_hash(db) == content_hash:
+                return CatalogUpgradeResult(False, reason="already-current")
+
+            existing = {
+                row["exercise_name"]: row
+                for row in db.fetch_all(
+                    f"SELECT exercise_name, "
+                    f"{', '.join(CATALOG_OWNED_COLUMNS)} FROM {EXERCISES_TABLE}"
+                )
+            }
+
+            inserted = 0
+            for name, row in shipped.items():
+                if name in existing:
+                    continue
+                _insert_exercise(db, row, shipped_muscles.get(name, []))
+                inserted += 1
+
+            refreshed = 0
+            for name, current in existing.items():
+                shipped_row = shipped.get(name)
+                if shipped_row is None:
+                    # Absent from a newer catalog: a user's own exercise, or one
+                    # that was retired. Either way it is not ours to remove.
+                    continue
+                # A value the shipped catalog does not carry never erases one
+                # the runtime database has. The seed currently ships
+                # media_path empty for all 1,897 rows and youtube_video_id for
+                # all but 56, so refreshing blindly would blank populated
+                # columns the moment a catalog was regenerated without them.
+                changes = {
+                    column: shipped_row[column]
+                    for column in CATALOG_OWNED_COLUMNS
+                    if shipped_row[column] is not None
+                    and current[column] != shipped_row[column]
+                }
+                if not changes:
+                    continue
+                assignments = ", ".join(f"{c} = :{c}" for c in changes)
+                db.execute_query(
+                    f"UPDATE {EXERCISES_TABLE} SET {assignments} "
+                    "WHERE exercise_name = :exercise_name",
+                    {**changes, "exercise_name": name},
+                )
+                refreshed += 1
+
+            _record_applied(db, content_hash)
+    except sqlite3.Error as exc:
+        logger.warning("Catalog upgrade did not complete: %s", exc)
+        return CatalogUpgradeResult(False, reason="failed")
+
+    if inserted or refreshed:
+        logger.info(
+            "Catalog upgrade: %s exercise(s) added, %s refreshed (version %s)",
+            inserted,
+            refreshed,
+            CATALOG_VERSION,
+        )
+    return CatalogUpgradeResult(True, inserted=inserted, refreshed=refreshed)

--- a/utils/schema_registry.py
+++ b/utils/schema_registry.py
@@ -10,6 +10,7 @@ from utils.database import (
     add_user_profile_tables,
     add_volume_tracking_tables,
 )
+from utils.catalog_upgrade import add_catalog_version_table
 from utils.db_initializer import initialize_database
 from utils.logger import get_logger
 from utils.program_backup import initialize_backup_tables
@@ -131,6 +132,8 @@ def run_all_initializers(*, force_base: bool = False) -> None:
     initialize_exercise_order()
     logger.info("Initializing backup tables...")
     initialize_backup_tables()
+    logger.info("Adding catalog version table...")
+    add_catalog_version_table()
     logger.info("Database initialization complete")
 
 


### PR DESCRIPTION
Packet B3 of `docs/rootdircleanup.md`, the last of the approved sequence. Base `origin/main` `abfc048`.

## Behavior / schema changes

- **New `catalog_version` table** — catalog metadata, one row, deliberately *not* in `OWNED_TABLES_DROP_ORDER`.
- **Existing installs receive new catalog exercises and corrections** to four catalog-owned columns on startup.

No API response change, no calculation change, no user-owned table is read or written.

## Why

The seed only initializes a *new* install. Without this a user who installed once would never receive a corrected movement pattern or a newly mapped exercise, and fresh installs would silently diverge from upgraded ones.

`upgrade_catalog_from_seed()` runs from `app.py` startup only — never from `run_all_initializers()`, which the test suite uses to build deliberately empty schemas. Injecting 1,897 exercises there would change what most of the suite means. It is also skipped when the seed bootstrap just created the database, which is the shipped catalog by definition.

Versioning is **content-addressed**: a SHA-256 over the shipped catalog's own rows, not a hand-maintained number that can be forgotten during a catalog change.

## The finding that shaped this packet

§7.4 assumed a clean catalog/user column split and that `exercise_isolated_muscles` could simply be "reconciled". **The code says otherwise.** `ExerciseManager.save_exercise()`, reached from `POST /add_exercise`, lets a user rewrite an exercise's muscle groups, equipment, mechanic, difficulty, utility, grips, stabilizers, synergists and force — **including on catalog exercises**. Those columns are user-owned the moment a row exists. The same call derives `exercise_isolated_muscles` from the user-editable `advanced_isolated_muscles` column.

So the implemented split is narrower than the plan implied, and deliberately so:

| | |
|---|---|
| **Refreshed on existing rows** | `movement_pattern`, `movement_subpattern`, `youtube_video_id`, `media_path` — the four columns no application path lets a user write |
| **Never touched on existing rows** | every user-editable column, and `exercise_isolated_muscles` |
| **Inserted whole** | exercises absent from the runtime database, with their isolated muscles |
| **Never removed or renamed** | an exercise absent from a newer catalog is left alone |

A test parses `exercise_manager.py` and fails if a refreshed column ever appears in `save_exercise`'s editable list — so a column that later becomes user-editable breaks the build instead of quietly starting to discard edits.

This stays inside approved policy B-D5 and is strictly more conservative than its minimum.

## A second hazard, found by checking against the real catalog

The shipped seed carries `media_path` for **0 of 1,897** rows and `youtube_video_id` for **56**, while `movement_pattern` is complete. Refreshing on plain inequality would **blank populated columns** the moment a catalog was regenerated without them — data loss dressed as an update. Only non-`NULL` shipped values are applied, and a test pins both halves: the empty value does not erase, and a real correction still lands.

## Why deletion is not the symmetric case

A wrong extra exercise is cosmetic and ignorable. Removing one invalidates every plan and log row that names it, because `exercises.exercise_name` is the key those rows carry. Renaming is deletion plus insertion against that same key.

## Verification

- pytest **1,856 passed / 1 skipped** — baseline **1,837 / 1** at `abfc048`, plus 19 catalog-upgrade contracts.
- **Checked against the real 1,897-exercise catalog**, not only synthetic fixtures. An "older install" was built by deleting three exercises, corrupting `movement_pattern` on five, editing one exercise's equipment, setting a `media_path` the seed does not carry, and adding a user-created exercise with a plan row referencing it. The upgrade inserted the three, corrected all five, preserved the equipment edit and the `media_path`, kept the user's exercise and plan, and the second run reported `already-current`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)