### PR TITLE
docs: route generated output to artifacts/ and sync docs with Packets A0–B3 (Packet C1)

### DIFF
--- a/.claude/commands/worktree.md
+++ b/.claude/commands/worktree.md
@@ -24,11 +24,23 @@ If only one agent is active, stay in the main checkout — worktrees are overhea
 
 | Mode | What it does | Use when |
 |---|---|---|
-| `visual` (default) | Copies `e2e/fixtures/database.visual.seed.db` into `data/database.db`. If the fixture is missing, warns and leaves the DB absent so `app.py` initializes fresh on launch. | E2E or template work that expects the fixture dataset. |
-| `empty` | Leaves `data/database.db` absent. `app.py` will run `initialize_database()` on first launch. | Fresh dev / unit-test work. |
+| `visual` (default) | Copies `e2e/fixtures/database.visual.seed.db` into `data/database.db`. If the fixture is missing, warns and leaves the DB absent — see the seed note below for what launching then does. | E2E or template work that expects the fixture dataset. |
+| `empty` | Leaves `data/database.db` absent. **This no longer means an empty database** — see the seed note below. | Fresh dev / unit-test work. |
 | `copy-current` | Copies the main checkout's `data/database.db` if it exists. Warns about WAL/SHM sidecars; stop the source app first. | Reproducing a bug against your live local data. |
 
 The script always checks the source exists before copying — missing source warns and skips rather than failing the worktree creation.
+
+> **Seed note — "absent DB" is not "empty DB".** Since the packaging/privacy packet,
+> an absent `data/database.db` is populated on first `app.py` launch by
+> `bootstrap_runtime_database()`, which copies the tracked `data/catalog.seed.db`:
+> **1,897 exercises and zero user rows**. So `-Seed empty` gives you a clean
+> *catalog*, not a blank database. A genuinely empty schema comes only from
+> `run_all_initializers(force_base=True)` against a fresh `DB_FILE`, which is what
+> the pytest fixtures do — the seed bootstrap is deliberately never called from
+> `run_all_initializers()`. See `.claude/rules/database.md`.
+>
+> The script's own console text still says "app.py will initialize on first run",
+> which is true but incomplete; it does not mention the seed copy.
 
 ## Per-worktree, never shared
 

--- a/.claude/rules/database.md
+++ b/.claude/rules/database.md
@@ -125,6 +125,7 @@ app.py startup:
   utils.config.DB_FILE = ...      ← whatever that decided (legacy path on failure)
   bootstrap_runtime_database()    ← copies catalog seed only when DB_FILE is missing
   run_all_initializers()          ← canonical schema registry sequence
+  upgrade_catalog_from_seed()     ← additive catalog refresh; skipped when the seed just ran
   create_startup_backup()         ← skipped for the pristine first-run seed copy
 ```
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -43,14 +43,22 @@ Any change to core workflow behavior (plan/log/analyze/progress/distribute/backu
 ## 2. Architecture
 
 ### Startup sequence (`app.py`)
-`app.py` initializes the schema through a single call to `run_all_initializers(force_base=False)` (defined in `utils/schema_registry.py`, WP2.6) — the per-table `initialize_*` / `add_*_table` functions are registered there, not called individually from `app.py`. It then snapshots the live DB via `create_startup_backup()`, registers 13 blueprints (`register_blueprint` calls in `app.py`), plus one direct route: `POST /erase-data` (`erase_data()` in `app.py`) — the erase route is **not** a blueprint.
+The order is load-bearing — `.claude/rules/database.md` has the reasoning:
+```
+prepare_runtime_database()              ← moves a legacy DB out of the install dir, once
+bootstrap_runtime_database()            ← copies data/catalog.seed.db only when DB_FILE is missing
+run_all_initializers(force_base=False)  ← canonical schema registry (utils/schema_registry.py, WP2.6)
+upgrade_catalog_from_seed()             ← additive catalog refresh; skipped on a fresh seed
+create_startup_backup()                 ← also skipped on a fresh seed
+```
+The per-table `initialize_*` / `add_*_table` functions are registered in `utils/schema_registry.py`, not called individually from `app.py`. Seeding and catalog upgrade are called **only** from real `app.py` startup, never from `run_all_initializers()` — the test suite creates empty schemas on purpose. `app.py` then registers 13 blueprints (`register_blueprint` calls in `app.py`), plus one direct route: `POST /erase-data` (`erase_data()` in `app.py`) — the erase route is **not** a blueprint.
 
 ### Module boundaries
 ```
 app.py                 ← startup + middleware only; no business logic
   routes/*.py          ← HTTP: validate input → call utils → return response
     utils/*.py         ← all business logic + DB queries
-      utils/database.py → DatabaseHandler → data/database.db (SQLite)
+      utils/database.py → DatabaseHandler → SQLite (path resolved by utils/runtime_paths.py)
 ```
 
 - Routes import from utils; utils never import from routes.
@@ -92,7 +100,7 @@ app.py                 ← startup + middleware only; no business logic
 from utils.logger import get_logger
 logger = get_logger()
 ```
-Returns the `'hypertrophy_toolbox'` named logger (`utils/logger.py`). Logs to `logs/app.log` (rotating 10MB × 5) and console (INFO+).
+Returns the `'hypertrophy_toolbox'` named logger (`utils/logger.py`). Logs to `<runtime root>/logs/app.log` (rotating 10MB × 5) and console (INFO+). The runtime root is the repository in a source checkout and `%LOCALAPPDATA%\HypertrophyToolbox` in a frozen build — never assume repository-local paths (`utils/runtime_paths.py`).
 
 ### DatabaseHandler pattern
 ```python
@@ -109,7 +117,8 @@ with DatabaseHandler() as db:
 ### Env vars (`utils/config.py`)
 | Variable | Default | Effect |
 |---|---|---|
-| `DB_FILE` | `data/database.db` | SQLite path. Tests patch `utils.config.DB_FILE` directly. |
+| `DB_FILE` | `<runtime root>/data/database.db` | SQLite path; wins over every resolved path. Tests patch `utils.config.DB_FILE` directly. |
+| `HT_RUNTIME_DIR` | unset | Relocates the whole runtime tree (database, backups, logs) in one move. The supported portable-install mechanism. |
 | `FLASK_DEBUG` | `'0'` in `app.py`; `'1'` in `utils/database.py` | Controls Flask debug AND journal mode |
 | `FLASK_USE_RELOADER` | `'0'` | Auto-reload (off by default — avoids WAL corruption) |
 | `TESTING` | unset | Set to `'1'` by `tests/conftest.py` |
@@ -146,9 +155,10 @@ npx playwright test --project=chromium --reporter=line
 - [ ] Write tests in `tests/test_myfeature.py`.
 
 ### B. Refactor safely
-1. **Before**: run full test suite, record baseline.
+1. **Before**: run full test suite, record baseline. Generated output goes under the gitignored `artifacts/`, never the repository root.
    ```bash
-   .venv/Scripts/python.exe -m pytest tests/ -q > baseline.txt 2>&1
+   mkdir -p artifacts
+   .venv/Scripts/python.exe -m pytest tests/ -q > artifacts/baseline_pytest.txt 2>&1
    ```
 2. **Scope**: Grep for function/class name across `routes/`, `utils/`, `templates/`, `tests/`.
 3. **Change**: one module at a time, keeping old interface as a thin wrapper if callers span multiple files.

--- a/docs/ACTIVE_DEVELOPMENT.md
+++ b/docs/ACTIVE_DEVELOPMENT.md
@@ -4,6 +4,34 @@ This file is the execution source of truth for autonomous development sessions. 
 
 ## Current Objective
 
+**2026-07-26 — root cleanup Packet C.** The root-cleanup / data-packaging track
+(Packets A0, A, A2, A3, B1, B2, B3) is shipped; `main` == `origin/main` ==
+`43691f2`; pytest baseline **1,856 passed / 1 skipped**. Packet C1
+(generated-output paths + documentation synchronization) is the change in flight.
+C2 (launcher/environment + user-facing distribution docs) and C3 (IDE tracking +
+root-policy closeout) follow as separate packets, with owner decisions already
+recorded. Plan of record: [`rootdircleanup.md`](rootdircleanup.md); full state and
+the packet ladder: [`MASTER_HANDOVER.md`](MASTER_HANDOVER.md).
+
+The Phase-4 CSS track is **paused and owner-gated**, not abandoned. Its
+constraints — the ten deferred interaction-state declarations, the WP4.3i-c Page
+Header contract, WP4.3j (Workout Log) and WP4.4 (shared bundles) both unstarted —
+are recorded in `MASTER_HANDOVER.md` and still bind. Do not resume any CSS packet
+without explicit direction.
+
+WPB.4 also remains unimplemented and owner-gated: it requires retaining one
+synthetic `Unassigned` session, an explicit unresolved-denominator decision, and
+intentional review of the exact golden diff before any behavior change.
+
+## Next Action
+
+Finish Packet C1, then C2, then C3 — each as its own PR, merged on green CI.
+Do not begin CSS, fatigue, or feature work.
+
+---
+
+## Superseded — prior objective (historical)
+
 **2026-07-19 — Phase-4 WP4.3d Volume Splitter dark/token cleanup is integrated
 into local `main` as history-preserving merge `40bc09f`.** Exact repeated
 status, accent, heading, and dark-surface values now use page-local semantic
@@ -22,11 +50,8 @@ DBs are unchanged. The narrow post-merge git-diff, contract, PostCSS, Flake8,
 tsc, Node-syntax, and Vitest gates passed; all protected identities remained
 unchanged. Nothing was pushed. Evidence:
 `docs/CSS_PHASE4_WP4_3D_EVIDENCE.md`.
-WPB.4 remains unimplemented and gated on retaining one synthetic `Unassigned` session,
-an explicit unresolved denominator decision, and intentional review of the exact golden
-diff before any behavior change.
 
-## Next Action
+### Next Action (as of 2026-07-19 — superseded)
 
 WP4.3d is integrated locally. Leave the branch/worktree intact; do not push or
 begin Welcome, another WP4.3 page, or WP4.4 until explicit direction.

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -2,6 +2,35 @@
 
 All notable changes to Hypertrophy Toolbox v3.
 
+## Unreleased - July 26, 2026
+
+### Packaging, runtime data location, and catalog updates (root-cleanup Packets A0–B3)
+
+Shipped via PRs #166–#175. No calculation, API response shape, or exercise
+catalog content changed.
+
+**Fresh installs**
+
+- The distribution now ships an immutable exercise catalog, `data/catalog.seed.db`. The first launch copies it to the runtime database and never overwrites an existing one. Previously a build from a clean checkout shipped **zero** exercises, because the only catalog source was the builder's own working copy.
+- Packaging is allowlist-based: exactly `catalog.seed.db` and `free_exercise_db_mapping.csv` from `data/`, and `static/`+`templates/` staged from a `git ls-files` manifest rather than a filesystem walk. Ignored and untracked working-copy content — local backups, personal exports, scratch body-map trees and their nested `.git` — can no longer enter a build. The built tree is verified against a `manifest.sha256` record, and a `windows-latest` gate launches the real executable.
+
+**Existing installs — migration**
+
+- Frozen builds no longer keep mutable data inside their installation directory. The database, automatic backups, and logs now live under a per-user application-data directory (`%LOCALAPPDATA%\HypertrophyToolbox` on Windows), resolved centrally by `utils/runtime_paths.py`.
+- **Your existing database migrates automatically, once, on first launch after upgrading.** It is copied read-only, verified, and only then published. The original file is never deleted, moved, or written to, and remains exactly where it was. If migration cannot be verified, the app keeps using the original database and reports recovery steps — it never silently starts from an empty catalog.
+- Migration refuses to run while unresolved WAL/journal sidecars exist; close the app cleanly and relaunch. Old log files are not migrated. Existing automatic backups are copied best-effort; a failure there is logged and does not block startup.
+- Set `HT_RUNTIME_DIR` to relocate the whole runtime tree in one move — the supported mechanism for portable/USB installs. `DB_FILE` still overrides the database path and wins over everything else.
+- Source checkouts and worktrees are unaffected and stay repository-local, deliberately: pointing parallel worktrees at one OS-level SQLite file is the WAL corruption `scripts/new-worktree.ps1` exists to prevent.
+
+**Existing installs — catalog updates**
+
+- A newer shipped catalog is now applied to existing databases instead of only new ones. The upgrade is additive and update-only: it inserts exercises you don't have and refreshes only the four columns no application path lets you edit (`movement_pattern`, `movement_subpattern`, `youtube_video_id`, `media_path`).
+- It **never** deletes or renames a catalog exercise, and never touches user-owned tables. Your edits to an exercise's muscles, equipment, mechanic, difficulty, grips, or force are preserved, as are user-created exercises and every plan or log row referencing them. A value absent from a newer catalog never erases a populated one.
+
+**Repository hygiene**
+
+- `data/database.db` is no longer tracked. The build environment is pinned (`requirements-build.txt`, `pyinstaller==6.21.0`) and `build_exe.bat` now invokes the committed spec instead of reconstructing a second configuration.
+
 ## Unreleased - May 23, 2026
 
 ### HTTP endpoint removals (Track B WPB.6)

--- a/docs/MASTER_HANDOVER.md
+++ b/docs/MASTER_HANDOVER.md
@@ -4,8 +4,77 @@
 
 ## Current State
 
-> **2026-07-25 (LATEST) — the WP4.3i Workout Plan dead-CSS arc is fully SHIPPED
-> and PUSHED. Local `main` == `origin/main` == `95f30c1`.** WP4.3i-dead and
+> **2026-07-26 (LATEST) — the root-cleanup / data-packaging track shipped
+> Packets A0, A, A2, A3, B1, B2, and B3. Local `main` == `origin/main` ==
+> `43691f2`.** This supersedes the 2026-07-25 CSS note below **as to HEAD only**;
+> that note remains the authoritative record of the WP4.3i arc and its commit
+> ladder, and every CSS constraint it lists is still binding. Plan of record:
+> [`docs/rootdircleanup.md`](rootdircleanup.md). Exact ladder:
+>
+> | Packet | Commit | PR | What it did |
+> |---|---|---|---|
+> | Plan approval | `a559222` / `8583224` | #166 | Committed the approved plan so a main-based worktree could read it |
+> | A0 | `b715a02` | #167 | Pinned the build environment (`requirements-build.txt`, `pyinstaller==6.21.0`); dropped stale pandas/NumPy hidden imports |
+> | A0 docs | `8dba5b2` | #168 | Synced Packet A prerequisites with shipped state |
+> | A | `a3121bf` / `22350ec` | #169 | Immutable `data/catalog.seed.db`; untracked `data/database.db`; first-run bootstrap; `data/` packaging allowlist |
+> | A2 | `3b3fb2b`, `7a3787c` / `631f61a` | #170 | `static/`+`templates/` staged from a `git ls-files` manifest instead of a filesystem walk |
+> | B decisions | `906b2fe` | #171 | Recorded the five owner-approved Packet B policies |
+> | A3 | `e576cda` | #172 | SHA-256 staging verification, `manifest.sha256`, real `windows-latest` bootloader gate |
+> | B1 | `a7883d4` | #173 | `utils/runtime_paths.py` resolver; logs left the install directory; no import-time directory creation |
+> | B2 | `abfc048` | #174 | Frozen `DB_FILE` switch **atomically with** verified non-destructive legacy migration |
+> | B3 | `43691f2` | #175 | Content-addressed catalog versioning; additive/update-only catalog upgrade |
+>
+> **pytest baseline: 1,856 passed / 1 skipped** (re-verified on `43691f2`,
+> 2026-07-26). The single skip is the POSIX-only executable-bit staging test that
+> cannot assert on Windows. Baseline ladder across the track:
+> 1,753 → 1,772 (A) → 1,785 (A2) → 1,792 (A3) → 1,812 (B1) → 1,837 (B2) → 1,856 (B3).
+>
+> **What changed that earlier docs may still contradict:**
+> - **The tracked database is gone.** `data/database.db` is untracked and ignored;
+>   the tracked catalog is the immutable `data/catalog.seed.db` (negated in
+>   `.gitignore` after the broad `*.db` rule). No `skip-worktree` flag remains.
+> - **An absent database is no longer an empty one.** First launch copies the seed
+>   — 1,897 exercises, zero user rows. Seeding is called only from real `app.py`
+>   startup, never from `run_all_initializers()`, so pytest fixtures stay empty.
+> - **Frozen builds no longer write to their installation directory.** Database,
+>   backups, and logs resolve through `utils/runtime_paths.py`
+>   (`%LOCALAPPDATA%\HypertrophyToolbox` when frozen); `HT_RUNTIME_DIR` relocates
+>   the whole tree and is the supported portable-install mechanism. Source
+>   checkouts and worktrees remain repository-local, deliberately — one OS-level
+>   SQLite file shared across worktrees is the WAL corruption
+>   `scripts/new-worktree.ps1` exists to prevent.
+> - **Legacy data migrates once, non-destructively.** The old database is opened
+>   read-only, copied to a temporary sibling, verified there, then published
+>   atomically. It is never deleted, moved, or written to. Every failure path
+>   returns the legacy path and reports recovery steps — never a clean seed.
+> - **Existing installs get catalog updates.** Additive/update-only: inserts
+>   missing exercises, refreshes only the four columns no user can edit
+>   (`movement_pattern`, `movement_subpattern`, `youtube_video_id`, `media_path`),
+>   and never deletes or renames a catalog exercise. A missing shipped value never
+>   erases a populated one.
+> - **Packaging is allowlist-based and verified against the real build output**,
+>   with a `windows-latest` deep-gate job launching the actual bootloader.
+>
+> **Root cleanup Packet C is IN PROGRESS.** C1 (generated-output paths +
+> documentation synchronization) is this change. Owner-approved decisions for the
+> remaining packets, recorded 2026-07-26:
+> - **C2** — keep `venv/` (build + user launcher) and `.venv/` (dev) separate and
+>   fix only the docs that misdescribe them; declare **"Python 3.11+, developed and
+>   built on 3.14"**; keep `QUICK_START.md` but trim its duplication of `README.md`.
+> - **C3** — fix `.vscode/launch.json` and keep it tracked; untrack `.idea/`
+>   with `git rm --cached` (**never delete from disk**); document the root-file
+>   policy as an ADR in `docs/DECISIONS.md` with a pointer from `CLAUDE.md`
+>   (which is at 189/200 lines and cannot absorb the table inline).
+> - **Not doing:** splitting `requirements.txt`. Test tooling never reaches the
+>   distribution (verified by inspecting `dist/`), and 14 required-check CI steps
+>   install it.
+> - **Nothing moves out of the repository root** — all 24 tracked root files map to
+>   an approved category.
+>
+> **2026-07-25 — the WP4.3i Workout Plan dead-CSS arc is fully SHIPPED
+> and PUSHED. `origin/main` was `95f30c1` at the time of this entry** (superseded
+> as to HEAD by the 2026-07-26 note above; the CSS constraints below still bind).
+> WP4.3i-dead and
 > WP4.3i-filter-btn reached `origin/main` via **PR #165**, merged 2026-07-25 as
 > **merge commit `95f30c1`** — a true merge commit, not a squash, so `db23801`,
 > `cb5ff6e`, and the docs commit `0cd44eb` all remain individually reachable and

--- a/docs/REFACTOR_PLAN.md
+++ b/docs/REFACTOR_PLAN.md
@@ -543,7 +543,9 @@ erase-flow 2. The full Playwright inventory is 505 tests across 30 specs.
 - Archive the v2 candidates plus `seed_visual_baseline.py` only after updating its docs
   and static-analysis disposition; do not confuse it with
   `e2e/scripts/build_visual_seed.py` or `prepare_visual_db.py`.
-- Remove root `baseline_e2e.txt`/`baseline_pytest.txt` and ignore future copies.
+- ~~Remove root `baseline_e2e.txt`/`baseline_pytest.txt` and ignore future copies.~~
+  **Done** — the files were removed and `/baseline*.txt` is ignored (`.gitignore`);
+  the generating command now writes to `artifacts/` (root-cleanup Packet C1).
 - Gate: full pytest, pyright baseline diff, visual seed smoke, CI.
 
 ### WP0.4 JavaScript dead-code sweep

--- a/docs/ai_workflow/INDEX.md
+++ b/docs/ai_workflow/INDEX.md
@@ -53,4 +53,7 @@
   the agent workflow plan; default-manager activation remains Phase 6-gated).
 
 ## Baselines (gitignored, generated locally)
-- `baseline_pytest.txt`, `baseline_e2e.txt` — last full-suite outputs; not in git
+- `artifacts/baseline_pytest.txt`, `artifacts/baseline_e2e.txt` — last full-suite outputs; not in git
+- Generated output belongs under `artifacts/`, never the repository root. `/artifacts/`
+  is gitignored, and Playwright (`playwright.config.ts`), pytest's cache (`pytest.ini`),
+  and both CI workflows already write there.

--- a/docs/rootdircleanup.md
+++ b/docs/rootdircleanup.md
@@ -1,9 +1,12 @@
 # Root Directory Cleanup and Data Packaging Safety Plan
 
-**Status:** Packets A0, A, and A2 shipped. Packet A3 and Packet B are
-owner-approved and next; Packet C is unstarted.
+**Status:** Packets A0, A, A2, A3, B1, B2, and B3 are shipped and merged
+(`origin/main` at `43691f2`). Packet C is owner-approved and in progress: **C1
+shipped** (generated-output paths + documentation synchronization); **C2**
+(launcher/environment + user-facing distribution docs) and **C3** (IDE tracking +
+root-policy closeout) are next, as separate packets.
 
-**Last evidence pass:** 2026-07-26
+**Last evidence pass:** 2026-07-26 — pytest baseline **1,856 passed / 1 skipped**
 
 **Scope:** Repository-root hygiene, shipped database privacy, PyInstaller data
 allowlisting, first-run database bootstrap, and the later runtime-data location
@@ -1413,13 +1416,64 @@ boundary is safe.
 
 ### 8.1 Root generated-output policy
 
-- [ ] Redirect baseline output to `artifacts/` instead of the root.
-- [ ] Update the baseline command in `CLAUDE.md`.
-- [ ] Update `docs/ai_workflow/INDEX.md`, which currently documents root
+- [x] Redirect baseline output to `artifacts/` instead of the root.
+- [x] Update the baseline command in `CLAUDE.md`.
+- [x] Update `docs/ai_workflow/INDEX.md`, which currently documents root
       `baseline_*.txt` files.
-- [ ] Keep root screenshot patterns ignored as defense in depth.
-- [ ] Prefer tools that write screenshots and reports directly under
-      `artifacts/`.
+- [x] Keep root screenshot patterns ignored as defense in depth. *(Already true
+      before Packet C: `.gitignore` carries `/baseline*.txt` and the four root
+      screenshot patterns, and the root is physically clean of both.)*
+- [x] Prefer tools that write screenshots and reports directly under
+      `artifacts/`. *(Already true before Packet C: `playwright.config.ts` routes
+      report, test-results, and the throwaway E2E database under `artifacts/`;
+      `pytest.ini` sets `cache_dir = artifacts/pytest/cache`; both CI workflows
+      write only there. No script writes a root PNG.)*
+
+A fourth reference the original checklist missed was also updated:
+`docs/REFACTOR_PLAN.md`'s WP0.x line calling for root `baseline_*.txt` removal.
+
+#### Recorded C1 results
+
+Shipped from `origin/main` at `43691f2`, pytest baseline **1,856 passed /
+1 skipped** unchanged — the packet touches no executable code.
+
+Beyond §8.1, C1 reconciled the documentation drift the completed packets left
+behind. `docs/MASTER_HANDOVER.md` still described `95f30c1` and the WP4.3i CSS
+arc, with **zero** mentions of Packets A0–B3, `catalog.seed.db`,
+`runtime_paths`, or PRs #166–#175 — the file new sessions are told to read first
+was seven packets stale. Its WP4.3i commit ladder and CSS constraints were
+preserved intact and the new state prepended above them.
+
+`CLAUDE.md` was the more dangerous case: it is always loaded, whereas the fully
+current `.claude/rules/database.md` loads only when editing `utils/database*.py`.
+Its §2 startup sequence omitted migration, seed bootstrap, and catalog upgrade
+entirely and described `create_startup_backup()` as unconditional; its env table
+had no `HT_RUNTIME_DIR`; and it presented database and log paths as universally
+repository-local. All corrected, landing at **189/200 lines** against its own cap
+— which is why §8.4's root policy belongs in an ADR rather than inline.
+
+Two further corrections, one of them a behavior contradiction rather than a
+staleness: `.claude/commands/worktree.md` documented `-Seed empty` as producing a
+database that `app.py` fills via `initialize_database()`. Both halves were wrong
+— that function is not what startup calls, and since Packet A an absent database
+is seeded with **1,897 exercises**. Anyone relying on `empty` was getting the
+opposite of the documented behavior. `.claude/rules/database.md`'s startup
+diagram was missing `upgrade_catalog_from_seed()` (B3 documented it in prose but
+not in the diagram).
+
+`docs/ACTIVE_DEVELOPMENT.md`, which calls itself the execution source of truth,
+was frozen further back still (2026-07-19, WP4.3d) and was refreshed in the same
+pass. `docs/CHANGELOG.md` gained the A0–B3 entry; the packets changed packaging,
+runtime data location, migration, and catalog-update behavior, all user-visible,
+and none of it was recorded.
+
+**Deliberately not touched:** dated evidence documents
+(`docs/CSS_PHASE4_*_EVIDENCE.md`, `docs/scan/**`, `docs/SCAN_FINDINGS.md`,
+`docs/archive/**`) — they were accurate when written, and rewriting history is a
+standing non-goal. Also untouched: `scripts/new-worktree.ps1`, to keep C1 free of
+executable changes. Its console text says "app.py will initialize on first run",
+which is true but does not mention the seed copy; `worktree.md` now records that
+gap explicitly.
 
 ### 8.2 Launcher and distribution modernization
 
@@ -1753,13 +1807,54 @@ schema changes, and merges only on green CI.
 The verified starting point for this sequence is `origin/main` at
 `631f61a13036861841a00ce8360d40b6698f16f8`.
 
+### Packet C authorization checklist
+
+Owner approval recorded on 2026-07-26, after an audit that verified the starting
+state rather than trusting the checklist boxes. All four recommended options were
+accepted.
+
+- [x] **C-D1. `venv/` and `.venv/` stay separate; fix only the docs.** Measured:
+      `venv/` carries PyInstaller 6.21.0 and **no** pandas/NumPy; `.venv/` carries
+      pandas + NumPy (undeclared) and no PyInstaller. Building from `.venv` would
+      reintroduce exactly the defect A0 fixed. Newly found and to be corrected in
+      C2: `venv/` is **co-owned** by `START.bat`, so `build_exe.bat`'s comment
+      claiming a dedicated environment overstates the isolation, and `README.md`'s
+      developer setup points at `venv/` while every tool config assumes `.venv`.
+- [x] **C-D2. Declare "Python 3.11+, developed and built on 3.14."** Five sources
+      disagreed: CI and pyright say 3.11, `QUICK_START.md` says 3.10+ (untested by
+      anything), `README.md` says 3.14, `.idea/` says 3.12, both venvs run 3.14.4.
+- [x] **C-D3. Keep `QUICK_START.md`, trim its duplication of `README.md`.** It
+      holds genuinely unique content, but line 92 instructs an **unpinned**
+      `pip install pyinstaller` — a live regression against A0's reproducible
+      build contract, and the one policy regression this audit found.
+- [x] **C-D4. Fix `.vscode/launch.json` and keep it tracked.** Its Flask config
+      uses `flask run` with `FLASK_DEBUG=1`, bypassing `app.py`'s
+      `use_reloader=False` guard — the exact double-process condition that
+      comment says causes database corruption, now also re-running Packet B
+      migration and seed bootstrap.
+- [x] **Not splitting `requirements.txt`.** A0 observed it mixes runtime and test
+      dependencies. Inspecting the built `dist/` shows pytest, playwright, and
+      vulture **never reach the distribution** (the spec excludes `pytest`;
+      PyInstaller bundles only reachable imports), while 14 required-check CI
+      steps install from it. The split buys nothing measurable and risks every PR.
+- [x] **Nothing moves out of the repository root.** All 24 tracked root files map
+      to an approved §8.4 category; §8.4 is a documentation task, not a
+      relocation task.
+
 ### Packet C completion checklist
 
-- [ ] Baselines write to `artifacts/`.
-- [ ] Launcher environment naming is consistent.
-- [ ] Packaging dependencies are reproducible.
-- [ ] IDE tracking decision completed.
-- [ ] Root-file policy documented in the main contributor guidance.
+- [x] Baselines write to `artifacts/`. (C1.)
+- [ ] Launcher environment naming is consistent. (C2.)
+- [x] Packaging dependencies are reproducible. **Already satisfied by Packet A0**
+      — pinned `pyinstaller==6.21.0`, both requirements files installed
+      unconditionally, the committed spec as the single definition, and
+      `test_batch_file_uses_only_the_committed_spec` locking it. Bookkeeping only;
+      see the authorization checklist above for why the requirements split was
+      declined.
+- [ ] IDE tracking decision completed. (C3 — decision made, removal pending.)
+- [ ] Root-file policy documented in the main contributor guidance. (C3 — as an
+      ADR in `docs/DECISIONS.md` with a pointer from `CLAUDE.md`, which is at
+      189/200 lines and cannot absorb the table inline.)
 
 ---
 


### PR DESCRIPTION
Root-cleanup **Packet C1** — generated-output paths and documentation synchronization. Plan of record: [`docs/rootdircleanup.md`](docs/rootdircleanup.md) §8.1.

**Documentation only. No executable file is touched, no schema or API change, no calculation surface affected.**

## Generated-output policy (§8.1)

- The baseline command in `CLAUDE.md` now writes to `artifacts/` instead of the repository root.
- `docs/ai_workflow/INDEX.md` documents `artifacts/baseline_*.txt` and states the general rule.
- The other two §8.1 items were **already true before Packet C** and are ticked with evidence rather than re-done: `.gitignore` already carries `/baseline*.txt` and the root screenshot patterns, and `playwright.config.ts`, `pytest.ini`, and both CI workflows already write only under `artifacts/`.
- Updated a fourth reference the original checklist missed, in `docs/REFACTOR_PLAN.md`.

## Documentation drift left by the completed packets

| File | Was | Now |
|---|---|---|
| `docs/MASTER_HANDOVER.md` | Described `95f30c1` and the WP4.3i CSS arc. **Zero** mentions of Packets A0–B3, `catalog.seed.db`, `runtime_paths`, or PRs #166–#175 — the file new sessions read first was seven packets stale | New state prepended; WP4.3i commit ladder and all CSS constraints preserved intact |
| `CLAUDE.md` | Startup sequence omitted migration, seed bootstrap, and catalog upgrade, and called `create_startup_backup()` unconditional; no `HT_RUNTIME_DIR`; paths presented as universally repository-local | Corrected. 189/200 lines, within its own cap |
| `.claude/commands/worktree.md` | `-Seed empty` "leaves the DB absent; `app.py` will run `initialize_database()`" | **Both halves were wrong.** That is not what startup calls, and since Packet A an absent DB is seeded with 1,897 exercises |
| `.claude/rules/database.md` | Startup diagram missing `upgrade_catalog_from_seed()` | Added |
| `docs/ACTIVE_DEVELOPMENT.md` | Frozen at 2026-07-19 / WP4.3d | Refreshed; CSS constraints and the WPB.4 gate kept |
| `docs/CHANGELOG.md` | No entry for packaging, runtime-path, migration, or catalog-upgrade changes | Added — all user-visible |

`CLAUDE.md` mattered most because it is *always* loaded, whereas the fully current `.claude/rules/database.md` loads only when editing `utils/database*.py`.

## Also recorded

The owner-approved Packet C decisions, and the closure of **"packaging dependencies are reproducible"** as already satisfied by Packet A0 — inspecting the built `dist/` confirms pytest, playwright, and vulture never reach the distribution, so splitting `requirements.txt` (which 14 required-check CI steps install from) was declined.

## Deliberately not touched

Dated evidence documents (`docs/CSS_PHASE4_*_EVIDENCE.md`, `docs/scan/**`, `docs/archive/**`) — accurate when written; rewriting history is a standing non-goal. `scripts/new-worktree.ps1` is untouched to keep this packet free of executable changes; `worktree.md` records the gap in its console text instead.

## Verification

- Full pytest **1,856 passed / 1 skipped** — identical to the pre-change baseline at `43691f2`.
- Diff confined to **9 markdown files**; no non-`.md` file in the diff; no untracked noise.
- `CLAUDE.md` **189/200** lines.
- Every introduced markdown link and cited code path resolves.
- Numeric claims verified directly rather than quoted from the plan: seed holds **1,897 exercises / 0 user rows**; root inventory is **24 tracked files**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)