### PR TITLE
docs: correct launcher environment, Python version, and distribution docs (Packet C2)

### DIFF
--- a/QUICK_START.md
+++ b/QUICK_START.md
@@ -22,7 +22,7 @@ Generate evidence-based workout plans with one click:
 1. Go to **Workout Plan** page
 2. Click the green **Generate Plan** button
 3. Configure your preferences:
-   - **Training Days**: 1-3 days per week
+   - **Training Days**: 1-5 days per week
    - **Environment**: Gym (full equipment) or Home (bodyweight/minimal)
    - **Experience Level**: Novice, Intermediate, or Advanced
    - **Goal**: Hypertrophy, Strength, or General fitness
@@ -45,31 +45,18 @@ Monitor your program balance on the **Weekly Summary** page:
 
 ---
 
-## 🔧 For Developers (Building the Executable)
+## 🔧 For Developers
 
-### Prerequisites
-- Python 3.10+ installed
-- All dependencies installed (`pip install -r requirements.txt`)
+**Python 3.11+** (CI runs 3.11; developed and built on 3.14).
 
-### Building the Standalone Executable
+Build and distribution steps live in one place — see
+[Building the Standalone Executable](README.md#-building-the-standalone-executable-for-developers)
+in `README.md`. In short: run `build_exe.bat`, then zip `dist/Hypertrophy-Toolbox/`.
 
-1. **Run the build script:**
-   ```
-   build_exe.bat
-   ```
-
-2. **Wait for build to complete** (3-5 minutes)
-
-3. **Find your executable in:**
-   ```
-   dist/Hypertrophy-Toolbox/
-   ```
-
-### Distributing to Users
-
-1. Zip the entire `dist/Hypertrophy-Toolbox/` folder
-2. Share the zip file
-3. Users extract and run `Hypertrophy-Toolbox.exe`
+The build installs its own pinned toolchain into `venv/` from `requirements.txt`
+and `requirements-build.txt`. Don't install PyInstaller by hand — an unpinned
+version makes "the build succeeded" a claim about whatever release happened to be
+current that day.
 
 ---
 
@@ -87,17 +74,16 @@ Monitor your program balance on the **Weekly Summary** page:
 - Manually open: http://localhost:5000
 
 ### Executable Build Fails
-- Make sure all dependencies are installed
-- Run: `pip install -r requirements.txt`
-- Run: `pip install pyinstaller`
+- Re-run `build_exe.bat`. It installs everything it needs into `venv/` on every
+  run, from `requirements.txt` and `requirements-build.txt`.
+- Do **not** `pip install pyinstaller` manually. The version is pinned in
+  `requirements-build.txt` on purpose; installing an unpinned one is how builds
+  stop being reproducible.
+- If it still fails, delete the `venv/`, `build/`, and `dist/` folders and run the
+  script again.
 
 ---
 
 ## 📁 File Overview
 
-| File | Purpose |
-|------|---------|
-| `START.bat` | Quick launcher for users with Python |
-| `build_exe.bat` | Creates standalone .exe (for developers) |
-| `app_launcher.py` | Wrapper for executable build |
-| `RUN_APP.bat` | Helper script included in executable |
+See [Launcher Files](README.md#-launcher-files) in `README.md`.

--- a/README.md
+++ b/README.md
@@ -39,12 +39,20 @@ This will automatically:
 
 1. **Create and activate virtual environment:**
    ```bash
-   python -m venv venv
+   python -m venv .venv
    # Windows
-   venv\Scripts\activate
+   .venv\Scripts\activate
    # Linux/Mac
-   source venv/bin/activate
+   source .venv/bin/activate
    ```
+
+   > **Why `.venv` and not `venv`?** They are two environments with different
+   > jobs, and the split is deliberate. `.venv` is the development environment —
+   > the one `playwright.config.ts`, `pyrightconfig.json`, and the test commands
+   > all expect. `venv` belongs to `START.bat` and `build_exe.bat`; the build
+   > installs the pinned toolchain there from the committed requirements files, so
+   > a release never depends on packages that happen to be in a developer's
+   > environment. Don't build from `.venv`, and don't point the tools at `venv`.
 
 2. **Install dependencies:**
    ```bash
@@ -69,7 +77,7 @@ This will automatically:
 | `START.bat` | 1-click launcher (requires Python installed) |
 | `build_exe.bat` | Builds standalone .exe for distribution |
 | `app_launcher.py` | Wrapper script for executable build |
-| `QUICK_START.md` | Detailed setup instructions |
+| `QUICK_START.md` | Feature walkthrough (starter generator, progression, pattern coverage) and troubleshooting |
 
 ## 📦 Building the Standalone Executable (For Developers)
 
@@ -79,7 +87,8 @@ To create the standalone `.exe` package for distribution to end users:
    ```bash
    build_exe.bat
    ```
-   (the pinned build toolchain is installed into the dedicated `venv/`)
+   (the pinned build toolchain is installed into `venv/`, from
+   `requirements.txt` + `requirements-build.txt` — not from your `.venv`)
 
 2. **Find the output in the `dist` folder (NOT `build`):**
    ```
@@ -117,7 +126,8 @@ To create the standalone `.exe` package for distribution to end users:
 
 See the [`docs/`](docs/) folder:
 
-- [scope.md](docs/scope.md) - Architecture and tech stack
+- [README.md](docs/README.md) - Documentation index
+- [CLAUDE.md](CLAUDE.md) - Architecture, module boundaries, and conventions
 - [CHANGELOG.md](docs/CHANGELOG.md) - Version history
 - [CSS_OWNERSHIP_MAP.md](docs/CSS_OWNERSHIP_MAP.md) - CSS file organization
 - [muscle_selector.md](docs/muscle_selector.md) - Muscle selector component
@@ -125,10 +135,11 @@ See the [`docs/`](docs/) folder:
 
 ## 🛠️ Tech Stack
 
-- **Backend**: Flask 3.1+, Python 3.14, SQLite
+- **Backend**: Flask 3.1+, SQLite
+- **Python**: 3.11+ (CI runs 3.11; developed and built on 3.14)
 - **Frontend**: Vanilla JavaScript (ES6+), HTML5, CSS3
 - **Styling**: Custom Bootstrap 5.1.3 build + custom CSS
-- **Testing**: pytest (321 tests)
+- **Testing**: pytest, Playwright (Chromium), Vitest
 
 ## 🧪 Running Tests
 

--- a/START.bat
+++ b/START.bat
@@ -103,4 +103,3 @@ venv\Scripts\python.exe app.py
 echo.
 echo [INFO] Server stopped.
 pause
-pause

--- a/build_exe.bat
+++ b/build_exe.bat
@@ -26,12 +26,17 @@ for /f "tokens=*" %%i in ('python --version 2^>^&1') do set PYVER=%%i
 echo [OK] %PYVER% found
 echo.
 
-:: The build deliberately uses its own "venv", not the developer ".venv".
+:: The build deliberately uses "venv", not the developer ".venv".
 :: .venv has accumulated packages that requirements.txt never declares (pandas,
 :: numpy), so building from it makes the artifact depend on incidental developer
 :: state -- that is how the stale pandas/numpy hidden imports appeared to work.
-:: A dedicated environment built only from the committed requirements files is
-:: reproducible.
+:: An environment built only from the committed requirements files is reproducible.
+::
+:: Note that "venv" is shared with START.bat, which creates it for end users and
+:: installs only requirements.txt. So this environment is not isolated from the
+:: user launcher, only from ".venv" -- what keeps the build reproducible is the
+:: unconditional install of both requirements files below, which repairs a venv
+:: that START.bat created with the runtime set alone.
 
 :: Check if virtual environment exists, create if not
 if not exist "venv" (


### PR DESCRIPTION
Root-cleanup **Packet C2**, applying owner-approved decisions **C-D1**, **C-D2**, **C-D3**. Plan of record: [`docs/rootdircleanup.md`](docs/rootdircleanup.md) §8.2.

Documentation plus one duplicate line. **No behavior change.**

## C-D1 — `venv/` and `.venv/` stay separate; only the misleading docs change

Measured before deciding, rather than assumed:

| | `venv/` (build + user launcher) | `.venv/` (dev) |
|---|---|---|
| PyInstaller | **6.21.0** | absent |
| pandas / numpy | **absent** | **present** (neither declared in `requirements.txt`) |

Building from `.venv` would reintroduce the undeclared-dependency defect Packet A0 fixed.

- **`build_exe.bat`** claimed a *"dedicated"* environment. It is dedicated relative to `.venv`, but **shared with `START.bat`**, which creates the same `venv/` for end users with only `requirements.txt` installed. What actually keeps the build reproducible is the unconditional install of *both* requirements files, which repairs such a venv. The comment now says that.
- **`README.md`** told developers to create `venv/`, while `playwright.config.ts`, `pyrightconfig.json`, and every test command expect `.venv`. Corrected, with a short note on why both exist.

## C-D2 — declare "Python 3.11+, developed and built on 3.14"

Five sources disagreed: CI and pyright say **3.11**, `QUICK_START.md` said **3.10+** (untested by anything), `README.md` said **3.14**, `.idea/` says **3.12**, both venvs run **3.14.4**.

## C-D3 — keep `QUICK_START.md`, trim the duplication

- **Removed the unpinned `pip install pyinstaller` instruction.** This was a live regression against A0's reproducible-build contract — the only policy regression the Packet C audit found. The troubleshooting entry now explains why installing it by hand is wrong.
- **"Training Days: 1-3" → 1-5**, verified against the validator in [`utils/plan_generator.py:262-263`](utils/plan_generator.py#L262-L263) and the five options in `templates/workout_plan.html`.
- The duplicated build/distribute steps and file-overview table now point at README's sections. Two files independently describing the build is exactly how the unpinned-PyInstaller line survived A0.

## Also in scope

- Removed the duplicate `pause` at the end of `START.bat`.
- Replaced README's link to `docs/scope.md` — **which does not exist** — with the docs index and `CLAUDE.md`.
- Dropped README's "pytest (321 tests)" claim rather than updating the number. The real count is 1,856, and a hardcoded count only goes stale again.

## Verification

- Full pytest **1,856 passed / 1 skipped** — unchanged.
- `tests/test_packaging_contract.py` **5 passed** — the gate on `build_exe.bat`.
- Diff limited to `README.md`, `QUICK_START.md`, `START.bat`, `build_exe.bat`.
- Every link and every README anchor referenced from `QUICK_START.md` resolves.
- `START.bat` is a single-line deletion with no line-ending churn (repo blob and staged content both LF).
- **`START.bat` was not launched.** Deleting a duplicate trailing `pause` cannot alter control flow, so a full launch test would be disproportionate — flagging it rather than implying coverage I didn't run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)