### PR TITLE
docs: close root-cleanup follow-up gaps

### DIFF
--- a/.claude/commands/worktree.md
+++ b/.claude/commands/worktree.md
@@ -38,9 +38,6 @@ The script always checks the source exists before copying — missing source war
 > `run_all_initializers(force_base=True)` against a fresh `DB_FILE`, which is what
 > the pytest fixtures do — the seed bootstrap is deliberately never called from
 > `run_all_initializers()`. See `.claude/rules/database.md`.
->
-> The script's own console text still says "app.py will initialize on first run",
-> which is true but incomplete; it does not mention the seed copy.
 
 ## Per-worktree, never shared
 

--- a/docs/DECISIONS.md
+++ b/docs/DECISIONS.md
@@ -1,6 +1,16 @@
-# Exercise Import Decisions
+# Repository Decisions
 
-This document captures the non-negotiable rules for the Excel to SQLite merge utility.
+This document records durable, cross-cutting project decisions as lightweight
+architecture decision records (ADRs). Accepted decisions remain here as
+historical context even when the code or tool that prompted them is later
+retired; changed decisions are superseded by a new ADR rather than silently
+rewritten.
+
+## Historical exercise-import rules
+
+The Excel-to-SQLite merge utility that these rules governed is no longer present
+under `scripts/`. The rules are retained as historical context for ADR-001, not
+as instructions for a currently supported command.
 
 - **Normalization rules**: Trim leading/trailing whitespace, collapse internal whitespace to a single space, and normalize endash/emdash characters to the ASCII hyphen before any comparisons.
 - **Exact name matching**: Import logic only merges rows whose normalized `exercise_name` strings are identical. No fuzzy, partial, or substring matching is permitted.
@@ -9,7 +19,7 @@ This document captures the non-negotiable rules for the Excel to SQLite merge ut
 - **Update-only flag**: `--update-only` converts unmatched Excel rows into skipped entries instead of inserts.
 - **Default paths**: Unless overridden, the tool reads from `data/exercises.xlsx`, writes to `data/database.db`, and emits Markdown artifacts in `docs/`.
 
-## Data semantics
+### Data semantics
 
 - Equipment semantics: The equipment field intentionally includes both gear (Barbell, Dumbbells, …) and categories (Yoga, Recovery, Stretches, Cardio). These are first-class filter values.
 - Enumerations: Incoming `force`, `mechanic`, and `difficulty` values are canonicalized to `Push`/`Pull`/`Hold`, `Compound`/`Isolation`, and `Beginner`/`Intermediate`/`Advanced` respectively before merging.

--- a/docs/rootdircleanup.md
+++ b/docs/rootdircleanup.md
@@ -1467,13 +1467,12 @@ pass. `docs/CHANGELOG.md` gained the A0–B3 entry; the packets changed packagin
 runtime data location, migration, and catalog-update behavior, all user-visible,
 and none of it was recorded.
 
-**Deliberately not touched:** dated evidence documents
+**Deliberately not touched during C1:** dated evidence documents
 (`docs/CSS_PHASE4_*_EVIDENCE.md`, `docs/scan/**`, `docs/SCAN_FINDINGS.md`,
 `docs/archive/**`) — they were accurate when written, and rewriting history is a
-standing non-goal. Also untouched: `scripts/new-worktree.ps1`, to keep C1 free of
-executable changes. Its console text says "app.py will initialize on first run",
-which is true but does not mention the seed copy; `worktree.md` now records that
-gap explicitly.
+standing non-goal. C1 also left `scripts/new-worktree.ps1` untouched to keep that
+packet free of executable changes. A later documentation-only follow-up corrected
+its console text to mention both the catalog-seed copy and schema initialization.
 
 ### 8.2 Launcher and distribution modernization
 

--- a/scripts/new-worktree.ps1
+++ b/scripts/new-worktree.ps1
@@ -15,7 +15,8 @@
 .PARAMETER Seed
     DB seed mode:
       visual       (default) copy e2e/fixtures/database.visual.seed.db
-      empty        leave data/database.db absent; app.py will initialize on launch
+      empty        leave data/database.db absent; app.py will copy the catalog
+                   seed and initialize the schema on launch
       copy-current copy the current checkout's data/database.db if it exists
 
 .PARAMETER BranchPrefix
@@ -116,17 +117,17 @@ switch ($Seed) {
             Write-Host "Seeded $TargetDb from visual fixture."
         }
         else {
-            $Fallback = if ($DbIsTracked) { "leaving the tracked HEAD copy in place" } else { "no DB present; app.py will initialize on first run" }
+            $Fallback = if ($DbIsTracked) { "leaving the tracked HEAD copy in place" } else { "no DB present; app.py will copy the catalog seed and initialize the schema on first run" }
             Write-Warning "Visual fixture not found at $Fixture. $Fallback."
         }
     }
     "empty" {
         if (Test-Path $TargetDb) {
             Remove-Item -LiteralPath $TargetDb -Force
-            Write-Host "Empty seed mode: removed checked-out $TargetDb. app.py will initialize on first run."
+            Write-Host "Empty seed mode: removed checked-out $TargetDb. app.py will copy the catalog seed and initialize the schema on first run."
         }
         else {
-            Write-Host "Empty seed mode: $TargetDb absent. app.py will initialize on first run."
+            Write-Host "Empty seed mode: $TargetDb absent. app.py will copy the catalog seed and initialize the schema on first run."
         }
     }
     "copy-current" {
@@ -137,7 +138,7 @@ switch ($Seed) {
             Write-Warning "WAL/SHM sidecars were NOT copied. Stop the source app before relying on this seed."
         }
         else {
-            $Fallback = if ($DbIsTracked) { "leaving the tracked HEAD copy in place" } else { "no DB present; app.py will initialize on first run" }
+            $Fallback = if ($DbIsTracked) { "leaving the tracked HEAD copy in place" } else { "no DB present; app.py will copy the catalog seed and initialize the schema on first run" }
             Write-Warning "Source data/database.db not found at $Source. $Fallback."
         }
     }


### PR DESCRIPTION
## Summary

- reframe `docs/DECISIONS.md` as the repository-wide ADR collection while preserving the retired Excel-import rules as historical context
- make `scripts/new-worktree.ps1` help and console output describe catalog seeding plus schema initialization accurately
- remove the resolved worktree-command warning and update the root-cleanup record with the follow-up

## Why

Packet C intentionally left two small documentation gaps: the worktree helper described only schema initialization after an absent database, and the ADR collection still presented itself as documentation for a retired import utility. This closes those gaps without changing runtime behavior.

## Impact

Documentation and user-facing PowerShell messages only. Worktree seed behavior is unchanged.

## Validation

- PowerShell parser: pass
- `git diff --check`: pass
- stale-wording scan: pass
