### PR TITLE
docs: close the root-cleanup track in the pointer docs

### DIFF
--- a/docs/ACTIVE_DEVELOPMENT.md
+++ b/docs/ACTIVE_DEVELOPMENT.md
@@ -4,14 +4,16 @@ This file is the execution source of truth for autonomous development sessions. 
 
 ## Current Objective
 
-**2026-07-26 — root cleanup Packet C.** The root-cleanup / data-packaging track
-(Packets A0, A, A2, A3, B1, B2, B3) is shipped; `main` == `origin/main` ==
-`43691f2`; pytest baseline **1,856 passed / 1 skipped**. Packet C1
-(generated-output paths + documentation synchronization) is the change in flight.
-C2 (launcher/environment + user-facing distribution docs) and C3 (IDE tracking +
-root-policy closeout) follow as separate packets, with owner decisions already
-recorded. Plan of record: [`rootdircleanup.md`](rootdircleanup.md); full state and
-the packet ladder: [`MASTER_HANDOVER.md`](MASTER_HANDOVER.md).
+**2026-07-26 — no workstream is in flight. The root-cleanup / data-packaging
+track is CLOSED.** Every packet shipped — A0, A, A2, A3, B1, B2, B3, C1, C2, C3,
+plus a documentation follow-up. The last code-bearing commit of the track is
+`2a30bda` (#179); this closeout entry is the only thing after it. pytest
+baseline **1,856 passed / 1 skipped**. All 225 checklist items in
+[`rootdircleanup.md`](rootdircleanup.md) are ticked and its §13 Definition of Done
+is met, so **that document is a closed record — do not execute its checklists.**
+Its durable outputs are the ADR-002 root-file policy in
+[`DECISIONS.md`](DECISIONS.md) and the invariants summarized in
+[`MASTER_HANDOVER.md`](MASTER_HANDOVER.md), which is where the packet ladder lives.
 
 The Phase-4 CSS track is **paused and owner-gated**, not abandoned. Its
 constraints — the ten deferred interaction-state declarations, the WP4.3i-c Page
@@ -25,8 +27,9 @@ intentional review of the exact golden diff before any behavior change.
 
 ## Next Action
 
-Finish Packet C1, then C2, then C3 — each as its own PR, merged on green CI.
-Do not begin CSS, fatigue, or feature work.
+Await owner direction. Nothing is in flight, and no packet is waiting to be
+picked up. Do not begin CSS, fatigue, or feature work — and do not reopen the
+root-cleanup track.
 
 ---
 

--- a/docs/MASTER_HANDOVER.md
+++ b/docs/MASTER_HANDOVER.md
@@ -4,12 +4,16 @@
 
 ## Current State
 
-> **2026-07-26 (LATEST) — the root-cleanup / data-packaging track shipped
-> Packets A0, A, A2, A3, B1, B2, and B3. Local `main` == `origin/main` ==
-> `43691f2`.** This supersedes the 2026-07-25 CSS note below **as to HEAD only**;
-> that note remains the authoritative record of the WP4.3i arc and its commit
-> ladder, and every CSS constraint it lists is still binding. Plan of record:
-> [`docs/rootdircleanup.md`](rootdircleanup.md). Exact ladder:
+> **2026-07-26 (LATEST) — the root-cleanup / data-packaging track is COMPLETE
+> and CLOSED. Every packet — A0, A, A2, A3, B1, B2, B3, C1, C2, C3 — is merged.
+> The track's last code-bearing commit is `2a30bda` (#179); only this closeout
+> entry follows it.** This supersedes the 2026-07-25
+> CSS note below **as to HEAD only**; that note remains the authoritative record
+> of the WP4.3i arc and its commit ladder, and every CSS constraint it lists is
+> still binding. Closed record:
+> [`docs/rootdircleanup.md`](rootdircleanup.md) — read it for the *reasoning*
+> behind the invariants below, but **do not execute its checklists**; all 225 are
+> ticked and its §13 Definition of Done is met. Exact ladder:
 >
 > | Packet | Commit | PR | What it did |
 > |---|---|---|---|
@@ -23,11 +27,18 @@
 > | B1 | `a7883d4` | #173 | `utils/runtime_paths.py` resolver; logs left the install directory; no import-time directory creation |
 > | B2 | `abfc048` | #174 | Frozen `DB_FILE` switch **atomically with** verified non-destructive legacy migration |
 > | B3 | `43691f2` | #175 | Content-addressed catalog versioning; additive/update-only catalog upgrade |
+> | C1 | `d620af8` | #176 | Generated output routed to the gitignored `artifacts/`; docs synced with A0–B3 |
+> | C2 | `3365627` | #177 | Corrected launcher environment, Python version, and distribution docs |
+> | C3 | `1e28b3b` | #178 | `.idea/` untracked (left on disk); `.vscode/launch.json` fixed; ADR-002 root policy |
+> | Follow-up | `2a30bda` | #179 | Closed doc gaps; `new-worktree.ps1` console text now mentions the seed copy |
 >
 > **pytest baseline: 1,856 passed / 1 skipped** (re-verified on `43691f2`,
-> 2026-07-26). The single skip is the POSIX-only executable-bit staging test that
+> 2026-07-26; unchanged through `2a30bda` — Packets C1–C3 altered no runtime
+> behavior). The single skip is the POSIX-only executable-bit staging test that
 > cannot assert on Windows. Baseline ladder across the track:
-> 1,753 → 1,772 (A) → 1,785 (A2) → 1,792 (A3) → 1,812 (B1) → 1,837 (B2) → 1,856 (B3).
+> 1,753 → 1,772 (A) → 1,785 (A2) → 1,792 (A3) → 1,812 (B1) → 1,837 (B2) → 1,856 (B3)
+> → 1,856 (C1–C3, docs only). PR #179 also ran the **full** Playwright suite green
+> — both functional shards, smoke, backup, fatigue context, and erase flow.
 >
 > **What changed that earlier docs may still contradict:**
 > - **The tracked database is gone.** `data/database.db` is untracked and ignored;
@@ -55,21 +66,28 @@
 > - **Packaging is allowlist-based and verified against the real build output**,
 >   with a `windows-latest` deep-gate job launching the actual bootloader.
 >
-> **Root cleanup Packet C is IN PROGRESS.** C1 (generated-output paths +
-> documentation synchronization) is this change. Owner-approved decisions for the
-> remaining packets, recorded 2026-07-26:
-> - **C2** — keep `venv/` (build + user launcher) and `.venv/` (dev) separate and
->   fix only the docs that misdescribe them; declare **"Python 3.11+, developed and
->   built on 3.14"**; keep `QUICK_START.md` but trim its duplication of `README.md`.
-> - **C3** — fix `.vscode/launch.json` and keep it tracked; untrack `.idea/`
->   with `git rm --cached` (**never delete from disk**); document the root-file
->   policy as an ADR in `docs/DECISIONS.md` with a pointer from `CLAUDE.md`
->   (which is at 189/200 lines and cannot absorb the table inline).
-> - **Not doing:** splitting `requirements.txt`. Test tooling never reaches the
->   distribution (verified by inspecting `dist/`), and 14 required-check CI steps
->   install it.
-> - **Nothing moves out of the repository root** — all 24 tracked root files map to
->   an approved category.
+> **Root cleanup Packet C SHIPPED, closing the track.** What it settled, all
+> owner-approved 2026-07-26 and now merged:
+> - **C1** — generated output (baselines, reports, screenshots, scratch DBs) goes
+>   under the gitignored `artifacts/`, never the repository root.
+> - **C2** — `venv/` (build + user launcher) and `.venv/` (dev) stay separate,
+>   because `venv/` carries pinned PyInstaller and no pandas/NumPy while `.venv/`
+>   carries undeclared pandas + NumPy; only the docs that misdescribed them were
+>   fixed. Declared **"Python 3.11+, developed and built on 3.14."**
+>   `QUICK_START.md` kept, its unpinned `pip install pyinstaller` corrected.
+> - **C3** — `.vscode/launch.json` fixed (its `flask run` config bypassed
+>   `app.py`'s `use_reloader=False` guard) and kept tracked; `.idea/` untracked
+>   with `git rm --cached`, left on disk; the root-file policy recorded as
+>   **ADR-002** in `docs/DECISIONS.md`, pointed to from `CLAUDE.md` §3.
+> - **Not done, deliberately:** splitting `requirements.txt`. Test tooling never
+>   reaches the distribution (verified by inspecting `dist/`), and 14
+>   required-check CI steps install it.
+> - **Nothing moved out of the repository root** — all 24 tracked root files map
+>   to an approved ADR-002 category. The audit that opened by assuming the root
+>   was clutter found **no root file that was clutter**; the real defects were the
+>   tracked user database, recursive packaging inputs, a frozen app writing into
+>   its own install directory, and installs that could never receive catalog
+>   updates. All four are fixed.
 >
 > **2026-07-25 — the WP4.3i Workout Plan dead-CSS arc is fully SHIPPED
 > and PUSHED. `origin/main` was `95f30c1` at the time of this entry** (superseded

--- a/docs/rootdircleanup.md
+++ b/docs/rootdircleanup.md
@@ -1,8 +1,17 @@
 # Root Directory Cleanup and Data Packaging Safety Plan
 
-**Status:** COMPLETE. Packets A0, A, A2, A3, B1, B2, B3, C1, C2, and C3 are all
-shipped and merged. Every checklist in this document is closed; §13 Definition of
-Done is met.
+**Status:** COMPLETE and CLOSED. Packets A0, A, A2, A3, B1, B2, B3, C1, C2, and
+C3 are all shipped and merged. Every checklist in this document is closed; §13
+Definition of Done is met.
+
+> **Do not execute anything in this document.** It is a closed record, kept for
+> the reasoning behind decisions that are still binding — not a work queue. All
+> 225 checklist items are ticked, and the preflight steps, worktree warnings, and
+> "stop and report before merging" gates below describe work that already
+> happened. Read it to understand *why* the seed, the packaging allowlist, the
+> path resolver, and the root-file policy are shaped as they are; the policy
+> itself lives in `docs/DECISIONS.md` ADR-002, and current state lives in
+> `docs/MASTER_HANDOVER.md`.
 
 **Last evidence pass:** 2026-07-26 — pytest baseline **1,856 passed / 1 skipped**,
 unchanged across all three Packet C packets, none of which altered runtime


### PR DESCRIPTION
## Why

`docs/rootdircleanup.md` was already marked COMPLETE, but the two files that route readers to it still described Packet C as in flight:

- [`docs/ACTIVE_DEVELOPMENT.md`](docs/ACTIVE_DEVELOPMENT.md) — header declares it "the execution source of truth for autonomous development sessions," and its **Next Action** read *"Finish Packet C1, then C2, then C3."* That work shipped in #176–#178. An autonomous session reading this would have set out to redo it.
- [`docs/MASTER_HANDOVER.md`](docs/MASTER_HANDOVER.md) — pinned at `43691f2`, ladder ending at B3, with a "Packet C is IN PROGRESS" block.

The long plan doc was correct; the short files pointing at it were wrong.

## What changed

- **ACTIVE_DEVELOPMENT.md** — current objective and Next Action now state that nothing is in flight and the track is closed.
- **MASTER_HANDOVER.md** — ladder extended with C1 (`d620af8`), C2 (`3365627`), C3 (`1e28b3b`), and the #179 follow-up (`2a30bda`); the IN PROGRESS block rewritten as what Packet C actually settled; baseline note records that C1–C3 altered no runtime behavior and that #179 ran the full Playwright suite green.
- **rootdircleanup.md** — banner marking it a closed record, so its preflight checklists, worktree warnings, and "stop and report before merging" gates are not mistaken for a work queue.

The plan doc stays where it is: ADR-002 in `docs/DECISIONS.md` cites it twice as the audit evidence behind the root-file policy, and it holds reasoning recorded nowhere else (seed-bootstrap invocation-site invariant, the allowlist exclusions, payload-vs-bootloader smoke semantics).

## Verification

No code, test, config, or workflow files touched — docs only, so the standard checks are the gate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)