### PR TITLE
docs(css): close WP4.3j-b responsive audit

### DIFF
--- a/docs/ACTIVE_DEVELOPMENT.md
+++ b/docs/ACTIVE_DEVELOPMENT.md
@@ -4,22 +4,31 @@ This file is the execution source of truth for autonomous development sessions. 
 
 ## Current Objective
 
-**2026-07-26 — no workstream is in flight. The root-cleanup / data-packaging
-track is CLOSED.** Every packet shipped — A0, A, A2, A3, B1, B2, B3, C1, C2, C3,
-plus a documentation follow-up. The last code-bearing commit of the track is
-`2a30bda` (#179); this closeout entry is the only thing after it. pytest
-baseline **1,856 passed / 1 skipped**. All 225 checklist items in
-[`rootdircleanup.md`](rootdircleanup.md) are ticked and its §13 Definition of Done
-is met, so **that document is a closed record — do not execute its checklists.**
-Its durable outputs are the ADR-002 root-file policy in
-[`DECISIONS.md`](DECISIONS.md) and the invariants summarized in
-[`MASTER_HANDOVER.md`](MASTER_HANDOVER.md), which is where the packet ladder lives.
+**2026-07-26 — no workstream is in flight. WP4.3j-a is merged at `99dfee1`
+(PR #181), and WP4.3j-b is complete as an audit-only, no-op investigation.**
+WP4.3j-a removed five overpainted dark-mode Workout Log table-cell declarations:
+`!important` **292 → 287**, visuals **6/6** update-free, contracts **30/30**,
+focused functional Chromium **33/33**, and full pytest **1,856 passed /
+1 skipped**.
 
-The Phase-4 CSS track is **paused and owner-gated**, not abandoned. Its
-constraints — the ten deferred interaction-state declarations, the WP4.3i-c Page
-Header contract, WP4.3j (Workout Log) and WP4.4 (shared bundles) both unstarted —
-are recorded in `MASTER_HANDOVER.md` and still bind. Do not resume any CSS packet
-without explicit direction.
+WP4.3j-b changed no production file. Its supposed duplicate `@media` ladders
+proved to be different selector/property families, and browser ownership tracing
+showed that the measured table padding/type declarations never beat the shared
+important `components.css` table-cell rule. The measured frame-padding family
+never beats `html body .workout-log-frame { padding: 0 !important; }`. The
+`992px` table overflow, first-ladder page/button/routine families, and separate
+legend query were not measured and remain unclassified. Exact evidence:
+[`CSS_PHASE4_WP4_3J_B_EVIDENCE.md`](CSS_PHASE4_WP4_3J_B_EVIDENCE.md).
+
+The root-cleanup / data-packaging track also remains CLOSED. All packets shipped,
+all 225 checklist items in [`rootdircleanup.md`](rootdircleanup.md) are ticked,
+and that closed record must not be re-executed.
+
+The Phase-4 CSS track is paused and owner-gated. A separate Workout Log dead-CSS
+packet may target only the property families proven inert by j-b; WP4.4 may
+review the shared `:is()` specificity trap. Neither is authorized or started.
+The ten WP4.3i deferred interaction-state declarations and WP4.3i-c Page Header
+contract remain untouched.
 
 WPB.4 also remains unimplemented and owner-gated: it requires retaining one
 synthetic `Unassigned` session, an explicit unresolved-denominator decision, and
@@ -28,8 +37,8 @@ intentional review of the exact golden diff before any behavior change.
 ## Next Action
 
 Await owner direction. Nothing is in flight, and no packet is waiting to be
-picked up. Do not begin CSS, fatigue, or feature work — and do not reopen the
-root-cleanup track.
+picked up. Do not begin the Workout Log deletion candidate, WP4.4, fatigue, or
+feature work — and do not reopen the root-cleanup track.
 
 ---
 

--- a/docs/CSS_PHASE4_WP4_3J_B_EVIDENCE.md
+++ b/docs/CSS_PHASE4_WP4_3J_B_EVIDENCE.md
@@ -1,0 +1,189 @@
+# WP4.3j-b — Workout Log responsive-ladder audit
+
+**Branch:** `wt/wp4-3j-b-media-ladders` · **Base:** `origin/main` @ `99dfee1`
+**Production diff:** none · **Outcome:** audit-only, no-op packet
+
+---
+
+## Original hypothesis
+
+WP4.3j-a recorded 17 media queries in two late regions of
+`static/css/pages-workout-log.css` as a possible duplicated responsive ladder:
+
+- the first region begins with the `max-width: 992px` table overflow rule and
+  continues through the table's 1280 / 1366 / 1536 / 1600 / 1920 / 2560
+  breakpoints;
+- the second region contains the `RESPONSIVE FRAME ADJUSTMENTS` block over the
+  1200 / 1280 / 1366 / 1536 / 1600 / 1920 / 2560 breakpoints, followed by a
+  separate `max-width: 1200px` legend rule.
+
+The candidate packet was to consolidate the two regions without changing
+responsive behavior. The audit rejected that premise before any CSS changed:
+the regions are not duplicate owners, and the overlapping table/frame
+declarations do not render.
+
+## Why the regions are not duplicates
+
+The table rules in the first region use:
+
+```css
+.workout-log-table thead th { ... }
+.workout-log-table td { ... }
+```
+
+The table rules in the frame-adjustment region use:
+
+```css
+.workout-log-frame .workout-log-table thead th { ... }
+```
+
+The second region additionally assigns `.workout-log-frame` padding. The first
+region additionally owns table overflow, page padding, delete-button sizing,
+routine-cell widths, and routine typography at selected breakpoints. Combining
+the media-query shells merely because their boundaries coincide would obscure
+these different selector and property families.
+
+## Actual table-cell owner
+
+The rendered Workout Log table has both `table` and `table-calm` classes inside
+`.workout-log-page`, so this shared `components.css` rule matches every header
+and body cell:
+
+```css
+:is(
+  #workout[data-page="workout-plan"],
+  .workout-log-page,
+  .summary-frame.frame-calm-glass,
+  .progression-plan-container
+) .table.table-calm > :not(caption) > * > * {
+  font-size: var(--wp-table-fs, 0.88rem) !important;
+  letter-spacing: 0 !important;
+  padding: var(--wp-table-cell-padding, 0.75rem 1rem) !important;
+}
+```
+
+This is an `:is()` specificity trap. The specificity of `:is()` is that of its
+most specific argument, even when a less-specific argument is the branch that
+matches the current element. Here:
+
+| Selector part | Specificity |
+|---|---:|
+| `#workout[data-page="workout-plan"]` (most specific `:is()` argument) | `(1,1,0)` |
+| `.table.table-calm` | `(0,2,0)` |
+| `:not(caption)` | `(0,0,1)` |
+| **Full shared selector** | **`(1,3,1)`** |
+
+The first ladder's `.workout-log-table thead th` is `(0,1,2)` and its
+`.workout-log-table td` is `(0,1,1)`. The second ladder's
+`.workout-log-frame .workout-log-table thead th` is `(0,2,2)`. None of those
+responsive declarations carries `!important`; the shared declarations do.
+The shared rule therefore wins on both importance and specificity.
+
+The same shared rule also beats the earlier page-local header and cell groups,
+which do carry `!important`: their most specific live selector arms still have
+no ID component. This explains why adding progressively more specific
+page-local responsive selectors did not change the rendered padding or type
+scale.
+
+## Actual frame-padding owner
+
+The base frame block and the responsive frame-adjustment block propose nine
+`.workout-log-frame` padding values in total: one base value and eight
+responsive values. They all lose to the file's opening rule:
+
+```css
+html body .workout-log-frame {
+  padding: 0 !important;
+}
+```
+
+The winner is `(0,1,2)` and important. The base and responsive proposals use
+the lone `.workout-log-frame` class, `(0,1,0)`, without `!important`. Computed
+frame padding is therefore `0px` throughout the measured width range.
+
+## Browser ownership matrix
+
+The browser walk inspected the winning declaration for each measured property
+across every loaded stylesheet, rather than considering source order inside
+`pages-workout-log.css` alone.
+
+| Region | Selector/property family | Audit result | Winning owner |
+|---|---|---|---|
+| First ladder | `thead th` padding, font size, letter spacing | **Proven dead** | Shared `components.css` cell rule |
+| First ladder | `td` padding, font size | **Proven dead** | Shared `components.css` cell rule |
+| First ladder | `max-width: 992px` table display/overflow | **Not measured** | No claim |
+| First ladder | page padding, delete-button sizing, icon sizing, routine-cell width/type | **Not measured** | No claim |
+| Frame-adjustment block | eight responsive frame-padding declarations | **Proven dead** | `html body .workout-log-frame` in the same page bundle |
+| Frame-adjustment block | seven header padding/font-size pairs | **Proven dead** | Shared `components.css` cell rule |
+| Base frame block | base frame-padding declaration | **Proven dead** | `html body .workout-log-frame` in the same page bundle |
+| Late legend query | `.legend-item` minimum width | **Not measured** | No claim |
+
+The conclusion is deliberately narrower than "both ladders are dead." Every
+declaration in the eight-query `RESPONSIVE FRAME ADJUSTMENTS` block was measured
+and found inert. Only the table-cell property families in the first ladder were
+measured; its other responsive families remain unclassified. The separate
+legend query also remains unclassified.
+
+## Fourteen breakpoint probes
+
+The audit sampled both sides of every transition shared by the measured
+1200–2561px property families:
+
+| Transition | Probe widths |
+|---|---|
+| 1200 / 1201 | `1200`, `1201` |
+| 1280 / 1281 | `1280`, `1281` |
+| 1366 / 1367 | `1366`, `1367` |
+| 1536 / 1537 | `1536`, `1537` |
+| 1600 / 1601 | `1600`, `1601` |
+| 1920 / 1921 | `1920`, `1921` |
+| 2560 / 2561 | `2560`, `2561` |
+
+At all 14 widths, representative header and body cells computed to:
+
+| Property | Computed value | Source expression |
+|---|---:|---|
+| `padding` | `12px 16px` | `var(--wp-table-cell-padding, 0.75rem 1rem)` |
+| `font-size` | `14.08px` | `var(--wp-table-fs, 0.88rem)` |
+
+The frame computed to `padding: 0px` at every probe. None of the measured media
+padding or font-size values became a winning computed value; source ownership
+also assigns the first ladder's header letter spacing to the shared important
+`letter-spacing: 0` declaration. The `992px` overflow rule was outside this
+14-probe property audit and is not classified.
+
+## Packet decision
+
+Consolidation was rejected because it would not preserve two live responsive
+systems; it would disguise dead-CSS deletion as structural deduplication.
+WP4.3j-b therefore closes as an audit-only packet:
+
+- no production CSS changed;
+- no test, snapshot, generated Bootstrap, SCSS, JavaScript, template, or
+  database file changed;
+- no commit or branch may claim a responsive behavior change.
+
+## Owner-gated follow-ups
+
+### Separate Workout Log dead-CSS packet
+
+A later, explicitly authorized deletion packet may remove only the families
+proven dead above: the eight-query `RESPONSIVE FRAME ADJUSTMENTS` block and the
+dead header/body-cell rule blocks from the first ladder. The base frame-padding
+declaration is also proven dead but should be named explicitly if included.
+The `992px` table overflow rule, page/button/routine responsive families, and
+legend query must remain unless separately audited.
+
+Such a packet needs its own before/after pixel oracle, same-CSS control, cascade
+contracts, functional checks, and owner approval. This audit does not authorize
+the deletion.
+
+### WP4.4 shared-selector review
+
+The shared `components.css` selector is intentionally left unchanged here. Its
+ID-bearing `:is()` arm exports ID-level specificity to the Workout Log, Workout
+Plan, summary-frame, and Progression branches, making page-local table-cell
+padding and type-scale overrides unexpectedly difficult or impossible.
+Ownership repair belongs to WP4.4 shared-bundle work and requires a cross-page
+cascade and visual review; this audit records the finding without proposing the
+replacement selector or desired responsive behavior.

--- a/docs/MASTER_HANDOVER.md
+++ b/docs/MASTER_HANDOVER.md
@@ -4,10 +4,38 @@
 
 ## Current State
 
-> **2026-07-26 (LATEST) — the root-cleanup / data-packaging track is COMPLETE
+> **2026-07-26 (LATEST) — WP4.3j-a is merged; WP4.3j-b closed as an audit-only
+> no-op.** WP4.3j-a reached `main` through PR #181 at **`99dfee1`**, removing
+> five overpainted dark-mode table-cell `background-color` declarations.
+> Production delta: five deletions; `!important` **292 → 287**; focused and
+> total Stylelint **−10**; Workout Log visuals **6/6** update-free; contracts
+> **30/30**; focused functional Chromium **33/33**; full pytest **1,856 passed /
+> 1 skipped**. Evidence:
+> [`CSS_PHASE4_WP4_3J_A_EVIDENCE.md`](CSS_PHASE4_WP4_3J_A_EVIDENCE.md).
+>
+> WP4.3j-b investigated the apparent duplicate responsive `@media` ladders and
+> made **zero CSS changes**. The premise collapsed: the regions target different
+> selector/property families, while the measured table padding/type declarations
+> are suppressed by the important shared `components.css` table-cell rule and
+> the measured frame-padding declarations are suppressed by
+> `html body .workout-log-frame { padding: 0 !important; }`. Fourteen browser
+> probes across both sides of the 1200–2561px transitions found invariant table
+> padding `12px 16px`, font size `14.08px`, and frame padding `0px`. The
+> `992px` table-overflow rule, the first ladder's page/button/routine families,
+> and the separate legend query were **not measured and are not classified as
+> dead**. Evidence:
+> [`CSS_PHASE4_WP4_3J_B_EVIDENCE.md`](CSS_PHASE4_WP4_3J_B_EVIDENCE.md).
+>
+> Two follow-ups are recorded but owner-gated and **not started**: a separate
+> Workout Log dead-CSS packet limited to the proven-inert property families,
+> and WP4.4 review of the shared `:is()` selector whose ID-bearing argument
+> exports ID-level specificity to every branch. Do not begin either without
+> explicit owner direction.
+>
+> **2026-07-26 — the root-cleanup / data-packaging track is COMPLETE
 > and CLOSED. Every packet — A0, A, A2, A3, B1, B2, B3, C1, C2, C3 — is merged.
-> The track's last code-bearing commit is `2a30bda` (#179); only this closeout
-> entry follows it.** This supersedes the 2026-07-25
+> The track's last code-bearing commit is `2a30bda` (#179); later commits belong
+> to documentation closeout or the resumed CSS track.** This supersedes the 2026-07-25
 > CSS note below **as to HEAD only**; that note remains the authoritative record
 > of the WP4.3i arc and its commit ladder, and every CSS constraint it lists is
 > still binding. Closed record:

--- a/docs/REFACTOR_PLAN.md
+++ b/docs/REFACTOR_PLAN.md
@@ -1,8 +1,9 @@
 # Deep Refactor Plan — v3 (2026-07-04, full-scan grounded)
 
-**Status (2026-07-25): Track A, Phases -1 through 3, and Phase-4 packets
+**Status (2026-07-26): Track A, Phases -1 through 3, and Phase-4 packets
 WP4.-1, WP4.0a, WP4.0, WP4.1, WP4.2, and WP4.3a–WP4.3h are complete, as is the
-WP4.3i Workout Plan dead-CSS arc through WP4.3i-filter-btn.** WP2.2 is committed
+WP4.3i Workout Plan dead-CSS arc through WP4.3i-filter-btn. WP4.3j-a is merged,
+and WP4.3j-b is complete as an audit-only no-op.** WP2.2 is committed
 as `c461840`; optional WP3.6 is committed as `0cbedac`. WP4.0 measurement
 provenance remains unchanged head `e46b67e`, with its ledger committed as
 `ca725c2`. Local integration verification through WP4.3d is complete
@@ -62,15 +63,27 @@ dead-CSS packet on this page must pair the sweep with a rest-state differential
 4. The remaining Workout Plan **raw-literal → token extraction and `!important`
    weighting review** is redesign-sized, multi-packet, and **has not started**.
 5. **WP4.3j (Workout Log) is IN PROGRESS as a sub-arc**; **WP4.4 (shared bundles
-   / navbar / `theme-dark.css`)** has **not started**. WP4.3j-a removed the five
-   overpainted dark-mode `background-color` declarations on columns 1–4 and
-   15–17 — evidence:
+   / navbar / `theme-dark.css`)** has **not started**. WP4.3j-a merged through
+   PR #181 at `99dfee1`; it removed the five overpainted dark-mode
+   `background-color` declarations on columns 1–4 and 15–17 — evidence:
    [`CSS_PHASE4_WP4_3J_A_EVIDENCE.md`](CSS_PHASE4_WP4_3J_A_EVIDENCE.md).
    **Method addition from that packet: for declarations suppressed by overpaint
    rather than by the cascade, the differential must be taken in pixel space.** A
    computed-declaration-owner audit certifies them live — correctly, by its own
-   question — while zero pixels change. Later j packets (j-b `@media` ladder
-   duplication, j-c header/cell glass) are **not started** and stay owner-gated.
+   question — while zero pixels change. WP4.3j-b then audited the apparent
+   duplicate `@media` ladders and closed as a **zero-CSS-change no-op**: they
+   target different selector/property families, while the measured table
+   padding/type declarations lose to the shared important `components.css`
+   table-cell owner and the measured frame-padding declarations lose to
+   `html body .workout-log-frame { padding: 0 !important; }`. Fourteen
+   breakpoint probes were invariant. The `992px` overflow rule, the first
+   ladder's page/button/routine families, and the separate legend query were not
+   measured and are not classified as dead. Evidence:
+   [`CSS_PHASE4_WP4_3J_B_EVIDENCE.md`](CSS_PHASE4_WP4_3J_B_EVIDENCE.md).
+   A separate deletion packet limited to the proven-inert families and j-c
+   header/cell glass are **not started** and stay owner-gated. The shared
+   ID-bearing `:is()` specificity finding belongs to WP4.4 and is recorded, not
+   acted on.
 6. Deferred and unacted: the superset dark-tint gap (`--superset-bg-1..4` has no
    live dark override) and the dead `body.dark-mode` in
    `static/css/layout.css:1120` (→ WP4.4).


### PR DESCRIPTION
## What changed

- adds the WP4.3j-b responsive-ladder audit evidence
- records why the apparent duplicate ladders are different selector/property families
- documents the shared `components.css` `:is()` specificity owner and the page-local frame-padding owner
- records all 14 breakpoint probes and distinguishes proven-dead declarations from unmeasured families
- synchronizes `MASTER_HANDOVER.md`, `ACTIVE_DEVELOPMENT.md`, and `REFACTOR_PLAN.md`

## Why

The authorized consolidation premise collapsed during browser ownership tracing. The measured responsive values never render: shared important table-cell declarations own padding/type, while `html body .workout-log-frame { padding: 0 !important; }` owns frame padding. Converting that finding into a CSS deletion would be a different packet, so WP4.3j-b closes as an audit-only no-op.

## Impact

Documentation only. No CSS, tests, snapshots, generated Bootstrap, SCSS, JavaScript, templates, or databases changed. The separate dead-CSS candidate and WP4.4 shared-selector review remain owner-gated.

## Validation

- `git diff --check`
- changed-file allowlist: exactly four files under `docs/`
- local link-target and synchronized-status checks
- branch based on `origin/main` at `99dfee1`