### PR TITLE
css(workout-log): delete three inert responsive families (WP4.3j-b-dead)

### DIFF
--- a/docs/ACTIVE_DEVELOPMENT.md
+++ b/docs/ACTIVE_DEVELOPMENT.md
@@ -4,8 +4,36 @@ This file is the execution source of truth for autonomous development sessions. 
 
 ## Current Objective
 
-**2026-07-26 — no workstream is in flight. WP4.3j-a is merged at `99dfee1`
-(PR #181), and WP4.3j-b is complete as an audit-only, no-op investigation.**
+**2026-07-26 — no workstream is in flight. WP4.3j-b-dead is the latest shipped
+packet; WP4.3j-a is merged at `99dfee1` (PR #181), and WP4.3j-b was an
+audit-only, no-op investigation.**
+
+WP4.3j-b-dead is the deletion packet the j-b audit nominated but explicitly did
+not authorize. It removed three inert responsive families from
+`static/css/pages-workout-log.css` — the eight-query `RESPONSIVE FRAME
+ADJUSTMENTS` block, the first ladder's `thead th` / `td` padding and type blocks,
+and the base `.workout-log-frame` `padding: var(--frame-padding, 1.25rem)`
+declaration. Lines **2,180 → 2,025**; `@media` **17 → 9**. Every j-b claim was
+re-proven on a fresh branch cut from merged `main`: **385 declaration-instances
+examined across 14 widths, 0 ever a winning owner**; before vs after **0
+differing records / 504** and **14/14 zero-diff** frame pixels; invariants
+measured identical at every probe (cell padding `12px 16px`, font size
+`14.08px`, frame padding `0px`). Stylelint moved by **zero** (focused 717,
+total 5,784, `!important` 285, no category increased) — the deleted declarations
+triggered no rule, so the win is 155 non-rendering lines rather than a lint
+score. Gates: visuals **6/6** update-free, contracts **31/31**, focused
+functional Chromium **33/33**, full pytest **1,857 passed / 1 skipped**.
+Evidence: [`CSS_PHASE4_WP4_3J_B_DEAD_EVIDENCE.md`](CSS_PHASE4_WP4_3J_B_DEAD_EVIDENCE.md).
+
+Two oracle constraints carried forward: the **full-page pixel oracle is unusable
+on this route** (a same-CSS control drifts at 10 of 14 widths inside the animated
+navbar strip `y ∈ [18,40]` — scope pixel claims to the element under test), and a
+specificity model that mishandles `:is()` or splits selectors on a naive comma
+will **report an owner contradicting the computed value**. Retained on purpose
+and contract-asserted: the `992px` overflow rule, page padding, delete-button and
+icon sizing, routine-cell widths and typography, the late legend query, and the
+five now-empty first-ladder media shells.
+
 WP4.3j-a removed five overpainted dark-mode Workout Log table-cell declarations:
 `!important` **292 → 287**, visuals **6/6** update-free, contracts **30/30**,
 focused functional Chromium **33/33**, and full pytest **1,856 passed /
@@ -24,11 +52,11 @@ The root-cleanup / data-packaging track also remains CLOSED. All packets shipped
 all 225 checklist items in [`rootdircleanup.md`](rootdircleanup.md) are ticked,
 and that closed record must not be re-executed.
 
-The Phase-4 CSS track is paused and owner-gated. A separate Workout Log dead-CSS
-packet may target only the property families proven inert by j-b; WP4.4 may
-review the shared `:is()` specificity trap. Neither is authorized or started.
-The ten WP4.3i deferred interaction-state declarations and WP4.3i-c Page Header
-contract remain untouched.
+The Phase-4 CSS track is paused and owner-gated. The Workout Log dead-CSS packet
+that j-b nominated **has now shipped as WP4.3j-b-dead** and is closed. WP4.4 may
+review the shared `:is()` specificity trap; it is not authorized or started, and
+neither is j-c header/cell-glass work. The ten WP4.3i deferred interaction-state
+declarations and WP4.3i-c Page Header contract remain untouched.
 
 WPB.4 also remains unimplemented and owner-gated: it requires retaining one
 synthetic `Unassigned` session, an explicit unresolved-denominator decision, and
@@ -37,8 +65,9 @@ intentional review of the exact golden diff before any behavior change.
 ## Next Action
 
 Await owner direction. Nothing is in flight, and no packet is waiting to be
-picked up. Do not begin the Workout Log deletion candidate, WP4.4, fatigue, or
-feature work — and do not reopen the root-cleanup track.
+picked up. The Workout Log deletion candidate is **done** (WP4.3j-b-dead). Do not
+begin WP4.3j-c, WP4.4, fatigue, or feature work — and do not reopen the
+root-cleanup track.
 
 ---
 

--- a/docs/CSS_PHASE4_WP4_3J_B_DEAD_EVIDENCE.md
+++ b/docs/CSS_PHASE4_WP4_3J_B_DEAD_EVIDENCE.md
@@ -1,0 +1,244 @@
+# WP4.3j-b-dead — Workout Log inert responsive-family deletion
+
+**Branch:** `wt/wp4-3j-b-dead` · **Base:** `origin/main` @ `ff9fe4b`
+**File:** `static/css/pages-workout-log.css` (+ one cascade contract)
+**Diff:** 11 insertions / 166 deletions in the bundle
+
+---
+
+## What this packet is, and how it differs from WP4.3j-b
+
+WP4.3j-b was an **audit-only, zero-CSS-change** packet. It examined the apparent
+duplicate responsive `@media` ladders, rejected the consolidation premise, and
+classified three property families as inert. It explicitly did **not** authorize
+their deletion:
+
+> "Such a packet needs its own before/after pixel oracle, same-CSS control,
+> cascade contracts, functional checks, and owner approval. This audit does not
+> authorize the deletion."
+> — [`CSS_PHASE4_WP4_3J_B_EVIDENCE.md`](CSS_PHASE4_WP4_3J_B_EVIDENCE.md)
+
+**WP4.3j-b-dead is that separate deletion packet.** The j-b findings were treated
+as a *nomination*, not as proof. Every liveness claim was re-established from
+scratch in a fresh browser walk on this branch before a line was removed. No
+responsive behavior was redesigned, and no j-b conclusion was taken on trust.
+
+Branching note: this packet was cut fresh from merged `main` at `ff9fe4b`, not
+continued from the pre-squash `wt/wp4-3j-b-media-ladders` history.
+
+---
+
+## Authorized scope, and what was deliberately left alone
+
+**Deleted — three families, all independently re-proven inert:**
+
+1. the complete eight-query `RESPONSIVE FRAME ADJUSTMENTS` block;
+2. the `thead th` (padding / font-size / letter-spacing) and `td`
+   (padding / font-size) rule blocks in the first responsive ladder;
+3. the base `.workout-log-frame` `padding: var(--frame-padding, 1.25rem)`
+   declaration.
+
+**Retained — explicitly out of scope, and asserted present by the contract:**
+the `max-width: 992px` table display/overflow rule; page-padding rules;
+delete-button and icon sizing; routine-cell widths and routine typography; the
+late `.legend-item` query; j-c header/cell-glass work; `components.css` and its
+shared `:is()` selector; WP4.4; modal styling, `nth-child` restructuring,
+tokenization, templates, JavaScript, SCSS, and generated Bootstrap.
+
+The five first-ladder media **shells** that became empty were **kept**, each with
+a one-line comment recording why. Removing them would have gone beyond deleting
+proven-dead declarations into restructuring the ladder, and Stylelint carries no
+`block-no-empty` rule, so the retained shells cost nothing. This is the only
+reason the diff is not pure deletion.
+
+---
+
+## Oracles
+
+Two oracles were used, because neither alone answers the question. The WP4.3i-dead
+rule (a sentinel sweep over-reports; pair it with a differential **and** a
+same-CSS control) and the WP4.3j-a rule (take the differential in the space the
+claim lives) both applied.
+
+### 1. Computed value + declaration ownership, 14 widths
+
+A browser walk at **1200, 1201, 1280, 1281, 1366, 1367, 1536, 1537, 1600, 1601,
+1920, 1921, 2560, 2561** captured, for a representative `thead th`, `tbody td`,
+and the `.workout-log-frame`: the computed value of every padding longhand,
+`font-size` and `letter-spacing`, **plus the full list of candidate declarations**
+from every same-origin stylesheet whose rule matched the element under
+currently-matching media conditions, ranked by importance, specificity and source
+order. That is **504 computed/winner records per run**.
+
+> **Method correction worth recording.** The first implementation ranked owners
+> with a regex specificity model and a naive `,` split. Both are wrong on this
+> page: the split shreds the `components.css` `:is(...)` selector into invalid
+> fragments, and the regex model does not give `:is()` the specificity of its most
+> specific argument. The result was a reported "winner" that **contradicted the
+> measured computed value**. The model was rewritten with a nesting-aware splitter
+> and correct `:is()`/`:not()`/`:has()`/`:where()` handling; only then did the
+> reported owner reproduce the computed value exactly. **A reported owner that
+> disagrees with the computed value is a broken oracle, not a finding.**
+
+### 2. Pixel differential, frame-scoped
+
+The **full-page** pixel oracle is unusable here, and this was proven rather than
+assumed. A same-CSS control produced non-zero diffs at **10 of 14** widths,
+localized to `y ∈ [18, 40]` — the animated navbar strip, the known WP4.0
+animated-logo drift:
+
+| width | control diff (full page) | bounding box |
+|---|---:|---|
+| 1200 / 1201 / 1280 / 1281 | 0 | — |
+| 1366 | 76 | `[35,18,44,32]` |
+| 1920 | 456 | `[35,18,1146,40]` |
+| 2561 | 348 | `[35,20,1146,40]` |
+
+The oracle was therefore scoped to the `.workout-log-frame` element, which is
+where every authorized deletion's claim lives and which excludes animated navbar
+chrome entirely.
+
+---
+
+## Same-CSS control
+
+| Comparison | Computed/winner records | Frame pixels |
+|---|---|---|
+| `before-A` vs `before-B` | **0 differing / 504** | **14/14 zero-diff** |
+| `after-A` vs `after-C` | 0 differing / 504 | 14/14 zero-diff |
+| `after-C` vs `after-D` | 0 differing / 504 | 14/14 zero-diff |
+| `final-1` vs `final-2` | **0 differing / 504** | **14/14 zero-diff** |
+
+**One characterized flake, disclosed.** Of six after-state runs, `after-B` alone
+differed, at two widths (`w1920` 25,350 px over the whole frame; `w2560` 231 px).
+Its **computed values were identical** to every other run, and side-by-side
+inspection shows a ~1px text-baseline shift, i.e. layout rounding jitter, not a
+cascade change. Five runs — `before-A`, `before-B`, `after-A`, `after-C`,
+`after-D` — plus both `final` runs are mutually byte-identical in the frame. An
+earlier round also showed a one-off thumbnail-decode drift, which was eliminated
+by adding an explicit image-decode and font-ready barrier to the harness.
+
+---
+
+## Result: before vs after
+
+| Comparison | Computed/winner records | Frame pixels |
+|---|---|---|
+| `before-A` vs `after-A` | **0 differing / 504** | **14/14 zero-diff** |
+| `before-A` vs `after-C` | 0 differing / 504 | 14/14 zero-diff |
+| `before-A` vs `final-1` | **0 differing / 504** | **14/14 zero-diff** |
+| `before-B` vs `final-2` | 0 differing / 504 | 14/14 zero-diff |
+
+**Not one computed value, and not one declaration owner, changed at any of the
+14 widths.**
+
+### Deadness proof
+
+Across the 14 widths, the before-state walk examined **385 declaration-instances**
+belonging to the deletion scope (every media-gated candidate plus the base frame
+padding). **Zero of them were ever the winning owner.**
+
+| Family | Instances | Times winner |
+|---|---:|---:|
+| Frame-adjustment block — 8 responsive `.workout-log-frame` paddings | 56 | **0** |
+| Frame-adjustment block — 7 `.workout-log-frame … thead th` pairs | 65 | **0** |
+| First ladder — `.workout-log-table thead th` | 82 | **0** |
+| First ladder — `.workout-log-table td` | 70 | **0** |
+| Base `.workout-log-frame` padding | 112 | **0** |
+| **Total** | **385** | **0** |
+
+(Counts differ per family because each is sampled only at the widths its media
+condition matches, and because `thead th` carries `letter-spacing` while `td`
+does not.)
+
+### Measured invariants
+
+Measured, not assumed — identical before and after at **all 14 widths**:
+
+| Property | Computed value | Winning owner |
+|---|---|---|
+| `th`/`td` padding | `12px 16px` | `components.css` `:is()` cell rule, spec `(1,3,1)`, important |
+| `th`/`td` `font-size` | `14.08px` | same |
+| `th`/`td` `letter-spacing` | `normal` (from `0px`) | same |
+| `.workout-log-frame` padding | `0px` | `html body .workout-log-frame`, spec `(0,1,2)`, important |
+
+This independently reproduces the WP4.3j-b conclusion, including the ID-bearing
+`:is()` specificity trap: the shared selector's most specific argument
+(`#workout[data-page="workout-plan"]`) exports ID-level specificity to the
+`.workout-log-page` branch that actually matches.
+
+---
+
+## Deltas
+
+| Metric | Before | After | Δ |
+|---|---:|---:|---:|
+| Lines (`pages-workout-log.css`) | 2,180 | 2,025 | **−155** |
+| `@media` queries | 17 | 9 | **−8** |
+| `!important` declarations | 285 | 285 | **0** |
+| Stylelint — focused | 717 | 717 | **0** |
+| Stylelint — total (`static/css/*.css` + `scss/**/*.scss`) | 5,784 | 5,784 | **0** |
+| Stylelint categories increased | — | — | **NONE** |
+
+**The Stylelint delta is honestly zero.** None of the deleted declarations was an
+`!important`, a colour literal, an ID selector, or a duplicate, so none of them
+triggered a rule in this configuration. The win here is 155 lines of CSS that
+could never render, not a lint score.
+
+> Counting note: `grep -c '!important'` reports *lines*, not occurrences, and the
+> file contains prose mentions of the keyword. The 285 figure is occurrences in
+> the comment-stripped body, and is what the contract asserts.
+
+---
+
+## Gates
+
+| Gate | Result |
+|---|---|
+| Focused Workout Log visuals (6 win32 variants, `PW_VISUAL_SEED=1`) | **6 passed**, update-free |
+| CSS cascade + visual selector contracts | **31 passed** (30 + 1 new) |
+| Focused functional Chromium (`workout-log`, `smoke-navigation`) | **33 passed** |
+| Full pytest | **1,857 passed / 1 skipped** |
+| Stylelint before/after | no category increased |
+
+Baseline at branch point `ff9fe4b` was **1,856 passed / 1 skipped**; the +1 is the
+new contract test. `git status -- e2e/__screenshots__` is empty — **no visual
+baseline was updated**. No generated file, database, snapshot, SCSS, template, or
+JavaScript appears in the diff.
+
+### Contract
+
+`test_workout_log_drops_inert_responsive_table_and_frame_families` in
+`tests/test_css_cascade_contracts.py` pins both halves, which is the point:
+
+1. the three deleted families are absent;
+2. the shared `components.css` owner that beat them is unchanged;
+3. **every explicitly out-of-scope family is still present** — the 992px overflow
+   rule, page padding, delete-button and icon sizing, routine-cell width and
+   typography, and the late legend query;
+4. the five retained shells are still there;
+5. the `!important` count did not move.
+
+Its red path was proven: run against the pre-deletion bundle, it fails.
+
+Two assertions needed anchoring rather than substring matching, because the
+deleted selectors also appear as **live comma arms** of base grouped rules
+(`.workout-log-frame .workout-log-table thead th,` and
+`table.workout-log-table thead th {`). The contract matches on the `{` terminator
+and the media-query indent so it can never pass by deleting a live grouped arm.
+
+---
+
+## Findings recorded, not acted on
+
+1. **The WP4.4 shared-selector finding stands and was not touched.** The
+   `components.css` `:is()` arm exports ID-level specificity to four route
+   branches, which is why page-local table-cell overrides on this page are
+   effectively impossible. Repairing it is cross-page work.
+2. **The five retained empty media shells** are a deliberate scope choice, not an
+   oversight. Collapsing them belongs to a structural packet.
+3. **The families the j-b audit never measured remain unclassified** — they were
+   retained on that basis, not because they were proven live.
+4. **The full-page pixel oracle remains unusable on this route** until the
+   animated navbar logo is stabilized. Any future Workout Log pixel claim should
+   scope to the element under test.

--- a/docs/MASTER_HANDOVER.md
+++ b/docs/MASTER_HANDOVER.md
@@ -4,7 +4,49 @@
 
 ## Current State
 
-> **2026-07-26 (LATEST) — WP4.3j-a is merged; WP4.3j-b closed as an audit-only
+> **2026-07-26 (LATEST) — WP4.3j-b-dead SHIPPED: the deletion packet the j-b
+> audit nominated but did not authorize.** It removed the three responsive
+> families j-b proved inert from `static/css/pages-workout-log.css`: the complete
+> eight-query `RESPONSIVE FRAME ADJUSTMENTS` block, the `thead th` / `td`
+> padding/type blocks in the first responsive ladder, and the base
+> `.workout-log-frame` `padding: var(--frame-padding, 1.25rem)` declaration.
+> **Lines 2,180 → 2,025 (−155); `@media` 17 → 9.**
+>
+> **The j-b findings were re-proven from scratch, not trusted.** A fresh 14-width
+> browser walk (1200/1201 … 2560/2561) examined **385 declaration-instances** in
+> the deletion scope and found **0** that ever owned a computed value. Before vs
+> after: **0 differing records / 504** and **14/14 zero-diff** frame pixels.
+> Measured invariants, identical on both sides at every probe: cell padding
+> `12px 16px`, font size `14.08px`, frame padding `0px`.
+>
+> **Two oracle lessons, both worth keeping.** (1) The **full-page pixel oracle is
+> unusable on this route** — a same-CSS control drifted at 10 of 14 widths, all of
+> it inside the animated navbar strip `y ∈ [18,40]`. The oracle was scoped to
+> `.workout-log-frame`, where the claim lives. (2) A regex specificity model with
+> a naive `,` split **reported an owner that contradicted the measured computed
+> value**, because it shreds the `components.css` `:is(...)` selector and does not
+> give `:is()` the specificity of its most specific argument. A reported owner
+> that disagrees with the computed value is a broken oracle, not a finding.
+>
+> **Stylelint moved by zero, and that is reported as zero** — focused 717 → 717,
+> total 5,784 → 5,784, no category increased, `!important` 285 → 285. None of the
+> deleted declarations triggered a rule in this config. The win is 155 lines that
+> could never render.
+>
+> Gates: visuals **6/6** update-free (`PW_VISUAL_SEED=1`, no baseline updated),
+> contracts **31/31** (30 + one new, red path proven), focused functional Chromium
+> **33/33**, full pytest **1,857 passed / 1 skipped** (baseline 1,856 + the new
+> contract). Evidence:
+> [`CSS_PHASE4_WP4_3J_B_DEAD_EVIDENCE.md`](CSS_PHASE4_WP4_3J_B_DEAD_EVIDENCE.md).
+>
+> Deliberately retained and asserted present by the contract: the `992px` table
+> overflow rule, page padding, delete-button/icon sizing, routine-cell widths and
+> typography, and the late legend query. The five first-ladder media **shells**
+> that became empty were kept with an explanatory comment — collapsing them is
+> structural work, not deletion of dead declarations. **j-c and WP4.4 remain
+> unstarted and owner-gated.**
+>
+> **2026-07-26 — WP4.3j-a is merged; WP4.3j-b closed as an audit-only
 > no-op.** WP4.3j-a reached `main` through PR #181 at **`99dfee1`**, removing
 > five overpainted dark-mode table-cell `background-color` declarations.
 > Production delta: five deletions; `!important` **292 → 287**; focused and

--- a/docs/REFACTOR_PLAN.md
+++ b/docs/REFACTOR_PLAN.md
@@ -3,7 +3,8 @@
 **Status (2026-07-26): Track A, Phases -1 through 3, and Phase-4 packets
 WP4.-1, WP4.0a, WP4.0, WP4.1, WP4.2, and WP4.3a–WP4.3h are complete, as is the
 WP4.3i Workout Plan dead-CSS arc through WP4.3i-filter-btn. WP4.3j-a is merged,
-and WP4.3j-b is complete as an audit-only no-op.** WP2.2 is committed
+WP4.3j-b is complete as an audit-only no-op, and WP4.3j-b-dead has shipped the
+deletion it nominated.** WP2.2 is committed
 as `c461840`; optional WP3.6 is committed as `0cbedac`. WP4.0 measurement
 provenance remains unchanged head `e46b67e`, with its ledger committed as
 `ca725c2`. Local integration verification through WP4.3d is complete
@@ -80,10 +81,26 @@ dead-CSS packet on this page must pair the sweep with a rest-state differential
    ladder's page/button/routine families, and the separate legend query were not
    measured and are not classified as dead. Evidence:
    [`CSS_PHASE4_WP4_3J_B_EVIDENCE.md`](CSS_PHASE4_WP4_3J_B_EVIDENCE.md).
-   A separate deletion packet limited to the proven-inert families and j-c
-   header/cell glass are **not started** and stay owner-gated. The shared
-   ID-bearing `:is()` specificity finding belongs to WP4.4 and is recorded, not
-   acted on.
+   **WP4.3j-b-dead then SHIPPED the deletion packet j-b had only nominated.** It
+   removed the eight-query `RESPONSIVE FRAME ADJUSTMENTS` block, the first
+   ladder's `thead th` / `td` padding and type blocks, and the base
+   `.workout-log-frame` `padding: var(--frame-padding, 1.25rem)` declaration:
+   lines **2,180 → 2,025**, `@media` **17 → 9**. Every j-b claim was re-proven on
+   a branch cut fresh from merged `main` — **385 declaration-instances across 14
+   widths, 0 ever a winning owner**; before vs after **0 differing records / 504**
+   and **14/14 zero-diff** frame pixels; invariants measured identical
+   (`12px 16px`, `14.08px`, `0px`). Gates: visuals **6/6** update-free, contracts
+   **31/31** (red path proven), functional Chromium **33/33**, pytest **1,857 / 1
+   skipped**. Stylelint moved by **zero** and is reported as zero. Evidence:
+   [`CSS_PHASE4_WP4_3J_B_DEAD_EVIDENCE.md`](CSS_PHASE4_WP4_3J_B_DEAD_EVIDENCE.md).
+   **Two oracle rules added by this packet:** the full-page pixel oracle is
+   unusable on this route (same-CSS control drifts at 10/14 widths inside the
+   animated navbar strip `y ∈ [18,40]` — scope pixel claims to the element under
+   test), and a specificity model that mishandles `:is()` or splits selectors on a
+   naive comma will report an owner contradicting the computed value.
+   **j-c header/cell glass is still not started** and stays owner-gated. The
+   shared ID-bearing `:is()` specificity finding belongs to WP4.4 and is recorded,
+   not acted on.
 6. Deferred and unacted: the superset dark-tint gap (`--superset-bg-1..4` has no
    live dark override) and the dead `body.dark-mode` in
    `static/css/layout.css:1120` (→ WP4.4).

--- a/static/css/pages-workout-log.css
+++ b/static/css/pages-workout-log.css
@@ -702,17 +702,6 @@ table.workout-log-table tbody td:nth-child(14) {
         padding: 0 !important;
     }
 
-    .workout-log-table thead th {
-        padding: 2px 1px;
-        font-size: 0.52rem;
-        letter-spacing: 0;
-    }
-
-    .workout-log-table td {
-        padding: 2px 1px;
-        font-size: 0.6rem;
-    }
-
     .workout-log-table .delete-btn,
     .workout-log-table .btn-danger.btn-sm {
         font-size: 0.8rem;
@@ -743,45 +732,18 @@ table.workout-log-table tbody td:nth-child(14) {
 }
 
 /* 1366x768 (1281px - 1366px) - Compact */
+/* Shell retained; its thead th / td declarations were inert (WP4.3j-b-dead). */
 @media (min-width: 1281px) and (max-width: 1366px) {
-    .workout-log-table thead th {
-        padding: 5px 2px;
-        font-size: 0.58rem;
-        letter-spacing: 0;
-    }
-
-    .workout-log-table td {
-        padding: 3px 2px;
-        font-size: 0.68rem;
-    }
 }
 
 /* 1536x864 (1367px - 1536px) - Compact+ */
+/* Shell retained; its thead th / td declarations were inert (WP4.3j-b-dead). */
 @media (min-width: 1367px) and (max-width: 1536px) {
-    .workout-log-table thead th {
-        padding: 5px 2px;
-        font-size: 0.6rem;
-        letter-spacing: 0;
-    }
-
-    .workout-log-table td {
-        padding: 4px 2px;
-        font-size: 0.7rem;
-    }
 }
 
 /* 1600x900 (1537px - 1600px) - Medium Compact */
+/* Shell retained; its thead th / td declarations were inert (WP4.3j-b-dead). */
 @media (min-width: 1537px) and (max-width: 1600px) {
-    .workout-log-table thead th {
-        padding: 5px 3px;
-        font-size: 0.62rem;
-        letter-spacing: 0;
-    }
-
-    .workout-log-table td {
-        padding: 4px 3px;
-        font-size: 0.72rem;
-    }
 }
 
 /* 1080p (1601px - 1920px) - Standard */
@@ -789,16 +751,6 @@ table.workout-log-table tbody td:nth-child(14) {
     .workout-log-page {
         padding-left: 0 !important;
         padding-right: 0 !important;
-    }
-
-    .workout-log-table thead th {
-        padding: 3px 1px;
-        font-size: 0.62rem;
-    }
-
-    .workout-log-table td {
-        padding: 2px 1px;
-        font-size: 0.7rem;
     }
 
     .workout-log-table .delete-btn,
@@ -817,31 +769,13 @@ table.workout-log-table tbody td:nth-child(14) {
 }
 
 /* 1440p (1921px - 2560px) - Standard */
+/* Shell retained; its thead th / td declarations were inert (WP4.3j-b-dead). */
 @media (min-width: 1921px) and (max-width: 2560px) {
-    .workout-log-table thead th {
-        padding: 8px 4px;
-        font-size: 0.7rem;
-        letter-spacing: 0.2px;
-    }
-
-    .workout-log-table td {
-        padding: 5px 4px;
-        font-size: 0.8rem;
-    }
 }
 
 /* 4K (2561px+) - Large */
+/* Shell retained; its thead th / td declarations were inert (WP4.3j-b-dead). */
 @media (min-width: 2561px) {
-    .workout-log-table thead th {
-        padding: 10px 6px;
-        font-size: 0.85rem;
-        letter-spacing: 0.25px;
-    }
-
-    .workout-log-table td {
-        padding: 6px 6px;
-        font-size: 0.95rem;
-    }
 }
 
 /* Editable field styling */
@@ -2020,7 +1954,6 @@ table.workout-log-table tbody tr:nth-child(even) td.metric-lane,
       0 8px 32px rgba(79, 140, 255, 0.08),
       0 2px 8px rgba(0, 0, 0, 0.04),
       inset 0 1px 0 rgba(255, 255, 255, 0.9);
-    padding: var(--frame-padding, 1.25rem);
     margin: 1rem 0;
     width: 100%;
     max-width: 100%;
@@ -2069,100 +2002,12 @@ table.workout-log-table tbody tr:nth-child(even) td.metric-lane,
 
 /* Table Header - Glass Style - Deferred to the workout-log-derived rules for specificity */
 
-/* ============================================================
-   RESPONSIVE FRAME ADJUSTMENTS - Multi-Resolution
-   ============================================================ */
-
-/* Mobile/Tablet fallback */
-@media (max-width: 1200px) {
-    .workout-log-frame {
-        padding: 1rem;
-    }
-}
-
-/* 720p (max-width: 1280px) - Very Compact */
-@media (min-width: 1201px) and (max-width: 1280px) {
-    .workout-log-frame {
-        padding: 0.5rem;
-    }
-
-    .workout-log-frame .workout-log-table thead th {
-        padding: 0.35rem 0.15rem;
-        font-size: 0.62rem;
-    }
-}
-
-/* 1366x768 (1281px - 1366px) - Compact */
-@media (min-width: 1281px) and (max-width: 1366px) {
-    .workout-log-frame {
-        padding: 0.55rem;
-    }
-
-    .workout-log-frame .workout-log-table thead th {
-        padding: 0.4rem 0.175rem;
-        font-size: 0.65rem;
-    }
-}
-
-/* 1536x864 (1367px - 1536px) - Compact+ */
-@media (min-width: 1367px) and (max-width: 1536px) {
-    .workout-log-frame {
-        padding: 0.6rem;
-    }
-
-    .workout-log-frame .workout-log-table thead th {
-        padding: 0.425rem 0.2rem;
-        font-size: 0.67rem;
-    }
-}
-
-/* 1600x900 (1537px - 1600px) - Medium Compact */
-@media (min-width: 1537px) and (max-width: 1600px) {
-    .workout-log-frame {
-        padding: 0.65rem;
-    }
-
-    .workout-log-frame .workout-log-table thead th {
-        padding: 0.45rem 0.225rem;
-        font-size: 0.68rem;
-    }
-}
-
-/* 1080p (1601px - 1920px) - Standard Compact */
-@media (min-width: 1601px) and (max-width: 1920px) {
-    .workout-log-frame {
-        padding: var(--space-md, 0.75rem);
-    }
-
-    .workout-log-frame .workout-log-table thead th {
-        padding: 0.5rem 0.25rem;
-        font-size: 0.7rem;
-    }
-}
-
-/* 1440p (1921px - 2560px) - Standard */
-@media (min-width: 1921px) and (max-width: 2560px) {
-    .workout-log-frame {
-        padding: 1rem;
-    }
-
-    .workout-log-frame .workout-log-table thead th {
-        padding: 0.65rem 0.35rem;
-        font-size: 0.78rem;
-    }
-}
-
-/* 4K (2561px+) - Large */
-@media (min-width: 2561px) {
-    .workout-log-frame {
-        padding: 1.25rem;
-    }
-
-    .workout-log-frame .workout-log-table thead th {
-        padding: 0.85rem 0.5rem;
-        font-size: 0.95rem;
-    }
-}
+/* The eight-query RESPONSIVE FRAME ADJUSTMENTS ladder that used to sit here was
+   removed by WP4.3j-b-dead. Every one of its declarations was inert: the frame
+   padding lost to the important zero-padding `html body .workout-log-frame` rule
+   at the top of this file, and the `.workout-log-frame .workout-log-table thead th`
+   padding/font-size lost to the important `:is()` table-cell rule in
+   components.css. See docs/CSS_PHASE4_WP4_3J_B_DEAD_EVIDENCE.md. */
 
 /* Preserve the original late generic legend sizing used by the workout-log legend. */
 .legend-item {

--- a/tests/test_css_cascade_contracts.py
+++ b/tests/test_css_cascade_contracts.py
@@ -1409,3 +1409,117 @@ def test_workout_plan_drops_dead_filter_button_family() -> None:
     assert not re.search(r"\{\s*\}", css)
     assert css.count("@layer workout {") == 1
     assert css.count("@layer workout-dropdowns {") == 1
+
+
+def test_workout_log_drops_inert_responsive_table_and_frame_families() -> None:
+    """WP4.3j-b-dead: the responsive families the j-b audit proved inert are gone.
+
+    Three families were deleted from `pages-workout-log.css`, each because a
+    browser walk at fourteen widths (1200/1201 ... 2560/2561) showed it never
+    owned a computed value:
+
+    * the eight-query `RESPONSIVE FRAME ADJUSTMENTS` ladder -- its frame padding
+      lost to the important zero-padding `html body .workout-log-frame` rule, and
+      its `thead th` padding/font-size lost to the important `:is()` table-cell
+      rule in `components.css`;
+    * the `thead th` and `td` padding/font-size/letter-spacing blocks in the
+      first responsive ladder, which lost to that same shared rule;
+    * the base `.workout-log-frame` `padding: var(--frame-padding, ...)`
+      declaration, which lost to the same important zero-padding rule.
+
+    The second half of this contract is the more important half: the families the
+    audit did *not* classify -- the 992px table overflow rule, page padding,
+    delete-button and icon sizing, routine-cell widths and typography, and the
+    late legend query -- must still be present. This packet was a deletion of
+    proven-dead declarations, not a redesign of responsive behavior.
+    """
+    css = (ROOT / "static" / "css" / "pages-workout-log.css").read_text(
+        encoding="utf-8"
+    )
+    body = COMMENT_RE.sub("", css)
+
+    # --- 1. The eight-query frame ladder is gone. ---
+    # Only the standalone media-gated rules were deleted. The same selector still
+    # appears as a comma arm of the live base header group, which must survive --
+    # hence matching on the `{` terminator rather than the bare selector.
+    assert "RESPONSIVE FRAME ADJUSTMENTS" not in body
+    assert ".workout-log-frame .workout-log-table thead th {" not in body
+    assert ".workout-log-frame .workout-log-table thead th,\n" in body
+    for dead_padding in (
+        "padding: 0.35rem 0.15rem;",
+        "padding: 0.4rem 0.175rem;",
+        "padding: 0.425rem 0.2rem;",
+        "padding: 0.45rem 0.225rem;",
+        "padding: 0.5rem 0.25rem;",
+        "padding: 0.65rem 0.35rem;",
+        "padding: 0.85rem 0.5rem;",
+    ):
+        assert dead_padding not in body
+
+    # --- 2. The base frame padding declaration is gone; the owner remains. ---
+    assert "--frame-padding" not in body
+    assert "html body .workout-log-frame," in body
+    owner = re.search(
+        r"html body \.workout-log-frame,\s*html body \.workout-log-frame \.tbl-wrap \{[^}]*\}",
+        body,
+    )
+    assert owner is not None
+    assert "padding: 0 !important;" in owner.group(0)
+
+    # --- 3. The dead first-ladder cell blocks are gone. ---
+    # Anchored on the media-query indent: `table.workout-log-table thead th {`
+    # closes the live base group at column 0 and must not be matched here.
+    for dead_cell_rule in (
+        "\n    .workout-log-table thead th {",
+        "\n    .workout-log-table td {",
+    ):
+        assert dead_cell_rule not in body
+
+    # --- 4. The shared owner that beat them is untouched. ---
+    components = (ROOT / "static" / "css" / "components.css").read_text(
+        encoding="utf-8"
+    )
+    assert '#workout[data-page="workout-plan"], .workout-log-page' in components
+    assert "var(--wp-table-cell-padding, 0.75rem 1rem) !important" in components
+    assert "var(--wp-table-fs, 0.88rem) !important" in components
+
+    # --- 5. Every explicitly out-of-scope responsive family survives. ---
+    # The 992px table overflow rule.
+    overflow = re.search(
+        r"@media \(max-width: 992px\) \{\s*\.workout-log-table \{[^}]*\}", body
+    )
+    assert overflow is not None
+    assert "overflow-x: auto;" in overflow.group(0)
+    assert "display: block;" in overflow.group(0)
+
+    # Page padding, delete-button and icon sizing, routine-cell width + type.
+    assert ".workout-log-page {\n        padding: 0 !important;\n    }" in body
+    assert ".workout-log-table .btn-danger.btn-sm {" in body
+    assert ".workout-log-table .btn-danger i {" in body
+    assert "min-width: 28px !important;" in body
+    assert "min-width: 30px !important;" in body
+    assert ".workout-log-table .routine-cell {" in body
+    assert ".workout-log-table .routine-cell .routine-program {" in body
+
+    # The separate late legend query.
+    legend = re.search(
+        r"@media \(max-width: 1200px\) \{\s*\.legend-item \{[^}]*\}", body
+    )
+    assert legend is not None
+    assert "min-width: 180px;" in legend.group(0)
+
+    # --- 6. The ladder shells are retained, only their dead rules removed. ---
+    for shell in (
+        "@media (min-width: 1281px) and (max-width: 1366px) {",
+        "@media (min-width: 1367px) and (max-width: 1536px) {",
+        "@media (min-width: 1537px) and (max-width: 1600px) {",
+        "@media (min-width: 1921px) and (max-width: 2560px) {",
+        "@media (min-width: 2561px) {",
+    ):
+        assert shell in body
+
+    # --- 7. Deleting inert declarations must not have added weight. ---
+    # None of the deleted declarations carried `!important`, so the real
+    # declaration count is unchanged rather than reduced. Counted on the
+    # comment-stripped body: three of the file's raw occurrences sit in prose.
+    assert body.count("!important") == 285


### PR DESCRIPTION
## What this is

WP4.3j-b was an **audit-only no-op** that classified three property families as inert but explicitly did **not** authorize their removal:

> "Such a packet needs its own before/after pixel oracle, same-CSS control, cascade contracts, functional checks, and owner approval. This audit does not authorize the deletion."

This is that separate deletion packet, cut fresh from merged `main` at `ff9fe4b` rather than continued from the pre-squash j-b branch history.

## Deleted

From `static/css/pages-workout-log.css`:

1. the complete eight-query `RESPONSIVE FRAME ADJUSTMENTS` block;
2. the `thead th` (padding / font-size / letter-spacing) and `td` (padding / font-size) blocks in the first responsive ladder;
3. the base `.workout-log-frame` `padding: var(--frame-padding, 1.25rem)` declaration.

Lines **2,180 → 2,025** (−155); `@media` **17 → 9**. All 11 insertions are comments.

The five first-ladder media **shells** that became empty are retained with a one-line comment. Collapsing them is structural work, not deletion of dead declarations — that is the only reason this is not a pure deletion.

## Proof — the j-b findings were re-proven, not trusted

A fresh 14-width browser walk (**1200, 1201, 1280, 1281, 1366, 1367, 1536, 1537, 1600, 1601, 1920, 1921, 2560, 2561**) captured computed values *and* full declaration-ownership for a representative `thead th`, `tbody td`, and the frame.

| Check | Result |
|---|---|
| Declaration-instances in deletion scope examined | **385** |
| ...of which ever a winning owner | **0** |
| Before vs after, computed + ownership records | **0 differing / 504** |
| Before vs after, frame pixels at all 14 widths | **14/14 zero-diff** |

Invariants **measured, not assumed**, identical on both sides at every probe: cell padding `12px 16px`, font size `14.08px`, frame padding `0px`. The winning owners are the important `components.css` `:is()` cell rule (spec `(1,3,1)`) and `html body .workout-log-frame` (spec `(0,1,2)`) — independently reproducing j-b, including the ID-bearing `:is()` specificity trap.

## Two oracle lessons

1. **The full-page pixel oracle is unusable on this route.** A same-CSS control drifted at **10 of 14** widths, all of it inside the animated navbar strip `y ∈ [18,40]` (the known WP4.0 logo drift). The oracle was scoped to `.workout-log-frame`, where the claim lives.
2. **A broken specificity model reported an owner contradicting the computed value.** A regex model with a naive `,` split shreds the `components.css` `:is(...)` selector and does not give `:is()` the specificity of its most specific argument. It was rewritten before any conclusion was drawn.

One after-run flake is disclosed in the evidence: `after-B` differed at two widths with **identical computed values** (~1px text-baseline jitter). Five other runs plus both final runs are mutually byte-identical in the frame.

## Explicitly retained (and contract-asserted present)

The `992px` table overflow rule, page padding, delete-button and icon sizing, routine-cell widths and typography, and the late `.legend-item` query. `components.css` is untouched. **WP4.4 and j-c remain owner-gated and unstarted.**

## Stylelint moved by zero

focused **717 → 717**, total **5,784 → 5,784**, `!important` **285 → 285**, **no category increased**. None of the deleted declarations triggered a rule in this config. The win is 155 lines that could never render — reported as zero rather than dressed up.

## Gates

| Gate | Result |
|---|---|
| Workout Log visuals (6 win32 variants, `PW_VISUAL_SEED=1`) | **6 passed**, update-free |
| Cascade + visual selector contracts | **31 passed** (30 + 1 new, red path proven) |
| Focused functional Chromium (`workout-log`, `smoke-navigation`) | **33 passed** |
| Full pytest | **1,857 passed / 1 skipped** |

Baseline at `ff9fe4b` was 1,856 / 1 skipped; the +1 is the new contract. **No visual baseline updated.** No generated file, database, snapshot, SCSS, template, or JavaScript in the diff.

Evidence: `docs/CSS_PHASE4_WP4_3J_B_DEAD_EVIDENCE.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
