### PR TITLE
docs(css): audit Workout Log header/cell glass ownership (WP4.3j-c)

### DIFF
--- a/docs/ACTIVE_DEVELOPMENT.md
+++ b/docs/ACTIVE_DEVELOPMENT.md
@@ -4,9 +4,50 @@ This file is the execution source of truth for autonomous development sessions. 
 
 ## Current Objective
 
-**2026-07-26 — no workstream is in flight. WP4.3j-b-dead is the latest shipped
-packet; WP4.3j-a is merged at `99dfee1` (PR #181), and WP4.3j-b was an
-audit-only, no-op investigation.**
+**2026-07-27 — no workstream is in flight. WP4.3j-c is complete as an
+evidence-only audit that changed no production file.** It audited the
+overlapping header and table-cell glass systems in
+`static/css/pages-workout-log.css` across all 17 columns, both themes, and
+desktop/tablet/mobile.
+
+Result: **the Workout Log table is painted by the shared `components.css`
+`.table.table-calm` system, not by the page's own glass systems.** Of **322**
+audited declarations in regions A–I, **227 never win anywhere**, **31** are live,
+**55** are mixed, **9** are unverified, and **0** are winning-but-overpainted.
+Regions **D (dark cell), E (metric-lane `nth-child` glass) and F (dark-mode
+visibility)** are dead in their entirety. The cause is that the shared selector's
+`:is()` carries an ID arm and so exports `(1,3,1)`/`(1,3,2)` ID-level
+specificity, which no ID-free page-local rule can reach no matter how much
+`!important` it carries. The one page-local family that *does* render — the
+region-H lane rules — is the only one written with an ID, at `(1,5,2)`.
+
+Gates for the audit itself: same-CSS pixel control **0 differing pixels in 6/6
+contexts**, resolution self-check **9,358 checks / 0 mismatches**, sentinel
+probes **222/222 verified effective**, **0** unexplained zero-diffs, **15,336**
+ownership records. Evidence:
+[`CSS_PHASE4_WP4_3J_C_AUDIT_EVIDENCE.md`](CSS_PHASE4_WP4_3J_C_AUDIT_EVIDENCE.md).
+
+The audit **corrects a claim in the shipped WP4.3j-a evidence**: the eight
+`color: #e0e0e0 !important` declarations in the dark-mode visibility block are
+cascade-dead, not live winners — the computed dark cell colour is
+`rgb(238, 241, 246)` from `components.css` at `(1,4,2)`. The j-a packet itself is
+unaffected; only its stated reason for retaining that block was wrong.
+
+A deletion candidate is **documented with exact selectors, oracle and gates —
+37 rules, 436 lines, 71 `!important` — and is NOT authorized.** Do not start it
+without new owner approval.
+
+**Method rule added:** *a probe that changes nothing proves nothing.* Four
+separate oracle defects in this packet each produced confident false "dead CSS"
+before being caught — a `var()`-bearing shorthand being invisible to longhand
+CSSOM queries, an injected sentinel losing the cascade, a running CSS transition
+outranking important author declarations, and `page.screenshot` not painting
+clip regions beyond the viewport. Every negative pixel result must carry
+positive evidence that the probe worked.
+
+**2026-07-26 — WP4.3j-b-dead was the previously shipped packet; WP4.3j-a is
+merged at `99dfee1` (PR #181), and WP4.3j-b was an audit-only, no-op
+investigation.**
 
 WP4.3j-b-dead is the deletion packet the j-b audit nominated but explicitly did
 not authorize. It removed three inert responsive families from
@@ -65,9 +106,14 @@ intentional review of the exact golden diff before any behavior change.
 ## Next Action
 
 Await owner direction. Nothing is in flight, and no packet is waiting to be
-picked up. The Workout Log deletion candidate is **done** (WP4.3j-b-dead). Do not
-begin WP4.3j-c, WP4.4, fatigue, or feature work — and do not reopen the
+picked up. WP4.3j-c is **closed as evidence-only**. Do not begin the deletion
+packet it nominates, WP4.4, fatigue, or feature work — and do not reopen the
 root-cleanup track.
+
+Note on sequencing, recorded for whenever the owner does decide: a WP4.4 repair
+of the shared `:is()` selector would **resurrect** the dead regions A–G on this
+page unless they are deleted first. The deletion packet should therefore precede
+WP4.4, not follow it.
 
 ---
 

--- a/docs/CSS_PHASE4_WP4_3J_C_AUDIT_EVIDENCE.md
+++ b/docs/CSS_PHASE4_WP4_3J_C_AUDIT_EVIDENCE.md
@@ -1,0 +1,365 @@
+# WP4.3j-c — Workout Log header / table-cell glass ownership audit
+
+**Branch:** `wt/wp4-3j-c-audit` · **Base:** merged `origin/main` @ `9a3f205`
+**Production diff:** none · **Outcome:** evidence-only packet
+
+---
+
+## What this packet is
+
+An audit of the overlapping header and table-cell glass systems in
+`static/css/pages-workout-log.css`. It classifies every relevant declaration
+across all 17 columns, in light and dark, at desktop, tablet and mobile widths.
+**No production CSS was modified**, and the packet does not authorize any
+deletion. The branch was cut fresh from merged `main` at `9a3f205`, not
+continued from the pre-squash `wt/wp4-3j-b-dead` history.
+
+Regions audited, all in `pages-workout-log.css` unless noted:
+
+| ID | Region | Lines |
+|---|---|---|
+| A | Base light header block | 207–240 |
+| B | Dark-mode header counterpart | 241–261 |
+| C | Base light cell block (+ even / hover) | 262–304 |
+| D | Dark-mode cell counterpart (+ even / hover) | 361–392 |
+| E | Column colour pairing / metric-lane glass | 393–645 |
+| F | Comprehensive dark-mode visibility block | 1366–1440 |
+| G | Final override block | 1441–1548 |
+| H | Explicit metric-lane pairing / table-calm compat | 1549–1830 |
+| I | Late frame / table glass block | 1946–2002 |
+| — | Shared `components.css` `.table.table-calm` owner (**read only, never modified**) | 3335–3411, 4433 |
+
+---
+
+## Headline
+
+**The Workout Log table is painted by the shared `components.css`
+`.table.table-calm` system, not by the page's own glass systems.** Of the 322
+distinct source declarations audited across regions A–I, **227 never win
+anywhere** — and the losses are not marginal. Nearly every page-local table rule
+is `!important` yet still loses, because the shared selector carries an ID:
+
+```css
+:is(#workout[data-page="workout-plan"],      /* ← (1,1,0): most specific arm */
+    .workout-log-page,                       /* ← the arm that actually matches */
+    .summary-frame.frame-calm-glass,
+    .progression-plan-container) .table.table-calm > :not(caption) > * > * { … !important }
+```
+
+`:is()` takes the specificity of its **most specific argument**, even when a
+less specific argument is the one that matches. The shared cell rule is
+therefore `(1,3,1)` and the header/body rules `(1,3,2)`, all `!important`. Every
+page-local rule in regions A–G is ID-free — `(0,1,1)` to `(0,4,3)` — so no
+amount of added `!important` or extra class chaining can reach it.
+
+**The single exception is the one family that does carry an ID.** The region-H
+`table-calm` compatibility rules are written
+`.workout-log-page #workout-log-table.table.table-calm …` = **`(1,5,2)`**, which
+out-specifies the shared owner. Those are the rules that put the metric-lane
+tints on screen. The comment above them at line 1728 says exactly this, and it
+is the only place in the file where the problem was diagnosed and solved rather
+than answered with more `!important`.
+
+This reframes the page: **`pages-workout-log.css` is not the owner of its own
+table.** Regions A–G are a historical stack of four successive attempts to
+restyle cells that had already lost the cascade.
+
+---
+
+## Method
+
+### Oracle 1 — nesting-aware CSSOM ownership
+
+For each target element and each of 36 properties, every rule in every
+same-origin stylesheet was enumerated (recursing into `@media`/`@supports`/
+`@layer`, skipping media conditions that do not currently match), the
+best-matching selector arm was found, and candidates were ranked by importance,
+specificity and source order. The WP4.3j-b-dead rule was honoured: **no naive
+comma splitting and no regex specificity model.** The splitter respects `()`,
+`[]` and quoting; the specificity model gives `:is()`/`:not()`/`:has()` the
+specificity of their most specific argument, `:where()` zero, and handles
+`:nth-child(An+B of S)` and pseudo-elements.
+
+The model was unit-checked against hand-computed specificities before use,
+including the shared `:is()` selector `(1,3,1)`, the `(1,5,2)` lane rule, and
+`:where(.x) .y` = `(0,1,0)`.
+
+### Oracle 2 — frame-scoped pixel contribution
+
+To separate "wins the cascade" from "reaches the screen", each property was
+overwritten on the live elements with a garish sentinel and the frame was
+re-photographed. A zero diff means the winning value contributes no pixels.
+
+The full-page oracle remains unusable on this route (j-b-dead: a same-CSS
+control drifts inside the animated navbar strip), so every capture is scoped to
+`.workout-log-frame`.
+
+### Self-checks that gate every claim
+
+| Check | Result |
+|---|---|
+| Same-CSS pixel control, two independent page loads per context | **0 differing pixels, 6/6 contexts** |
+| Resolution self-check — reapplying the reported winner reproduces the computed value | **9,358 checks, 0 mismatches** |
+| Sentinel took effect (computed value actually moved) | **222 / 222** |
+| Sentinel zero-diffs not explained by the target being outside the capture | **0 unexplained** |
+| Sentinels fully reverted afterwards | **6/6 clean** |
+
+Ownership records: **15,336** (2,556 per context), against 2,196 / 2,052 / 1,950
+matching rules at desktop / tablet / mobile.
+
+### Four oracle defects found and fixed — all of which would have invented dead CSS
+
+These cost most of the packet's time and are the most reusable part of it. Each
+one produced a *confident, wrong* answer before it was caught.
+
+1. **A `var()`-bearing shorthand is invisible to longhand queries.** CSSOM
+   cannot expand `padding: var(--wp-table-cell-padding, 0.75rem 1rem)` into
+   longhands — it is stored as a pending-substitution value, and
+   `getPropertyValue('padding-top')` returns `''`. Querying longhands alone
+   therefore hid **exactly the shared `components.css` owners that win**, and
+   the audit reported page-local declarations as winners while the measured
+   computed value disagreed. 338 resolution mismatches. Fixed by falling back
+   from each longhand to its shorthands; mismatches went to **0**.
+2. **A stylesheet sentinel has to win the cascade, and often did not.** An
+   injected `#workout-log-table tbody td.metric-lane { … !important }` is
+   `(1,1,2)` and loses to the page's own `(1,5,2)` lane rules. It changed
+   nothing, produced a zero pixel diff, and that reads as "this value never
+   renders". Fixed by applying sentinels as **inline** `!important`, which
+   outranks every author rule, and by asserting the computed value moved.
+3. **A running CSS transition outranks even important author declarations.**
+   `components.css` puts an important 150ms transition on these cells, which the
+   injected `*` stabilizer `(0,0,0)` cannot outrank, so reading the computed
+   value immediately after applying a sentinel returned the *pre*-transition
+   value — again indistinguishable from a failed sentinel. Fixed with a 400ms
+   settle before every read and capture.
+4. **`page.screenshot` does not paint clip regions beyond the viewport.** At
+   mobile the frame starts at y≈649 and is ~8,000px tall; a naive frame-top clip
+   returned a near-blank 3.5KB image, and **every sentinel on it read as a zero
+   diff**. Fixed by scrolling the frame top to the viewport top and bounding the
+   capture by the viewport, plus recording whether the sentinel's elements were
+   actually inside the captured region and inside their scrollable ancestors.
+
+Two smaller harness traps, recorded because they cost real time: `img.decode()`
+on a `loading="lazy"` image that has never been fetched **never settles** (at
+mobile the stacked table pushes most thumbnails below the fold, which hung the
+run — the barrier now covers `complete` images only and is bounded); and Node
+block-buffers a piped stdout, which makes a long run look hung.
+
+> **General rule this packet adds:** *a probe that changes nothing proves
+> nothing.* Every negative pixel result must carry positive evidence that the
+> probe itself worked — the value moved, and the thing it moved was in frame.
+
+---
+
+## Results
+
+### Declaration inventory by region
+
+Counted as distinct source declarations (file, line, property). "Mixed" means
+live in some context/role and dead in others — most commonly a light-mode
+declaration that loses to its own dark-mode counterpart.
+
+| Region | Total | Cascade-dead | Live winner | Mixed | Unverified | Overpainted |
+|---|---:|---:|---:|---:|---:|---:|
+| A base light header (208) | 28 | **17** | 6 | 4 | 1 | 0 |
+| B dark header (242) | 12 | **10** | 2 | 0 | 0 | 0 |
+| C base light cell (263/287/295) | 28 | **24** | 2 | 2 | 0 | 0 |
+| D dark cell (362/375/383) | 16 | **16** | 0 | 0 | 0 | 0 |
+| E metric-lane glass (401–643) | 70 | **70** | 0 | 0 | 0 | 0 |
+| F dark visibility block (1371–1438) | 8 | **8** | 0 | 0 | 0 | 0 |
+| G final override (1447–1547) | 58 | **56** | 1 | 1 | 0 | 0 |
+| H lane pairing / table-calm (1553–1829) | 81 | 21 | 18 | 34 | 8 | 0 |
+| I late frame / table glass (1947–2001) | 21 | 5 | 2 | 14 | 0 | 0 |
+| **Total A–I** | **322** | **227** | **31** | **55** | **9** | **0** |
+
+**Regions D, E and F are dead in their entirety** — every declaration, every
+column, every role, both themes, all three widths.
+
+### No declaration is "winning but visually overpainted"
+
+The category is **empty** in this scope, and that is a measured result rather
+than an unexamined one: all 37 sentinel probes moved real pixels in every
+context where their targets were in frame (e.g. `tbody td background-color`
+464,416 px; `thead th box-shadow` 18,454 px; `td.metric-lane background-color`
+263,544 px).
+
+This does **not** contradict WP4.3j-a. That packet's overpaint arose from a
+page-local `background-color` sitting under a page-local opaque `background`
+gradient *on the same element*; those five declarations are already deleted, and
+`components.css` now owns the background outright, so the configuration no
+longer exists here.
+
+### Complementary declarations
+
+Twelve declarations win only because nobody else sets that exact longhand, while
+a sibling longhand of the same shorthand is owned elsewhere. They are live but
+inert in isolation:
+
+- **`border-top-width` / `border-top-style` at L208 (light) and L242 (dark)** —
+  both win, but `border-top-color` is owned by `components.css`
+  `border-color: transparent !important` `(1,3,1)`. The header therefore reserves
+  a 1px top border that is **always transparent**: it occupies layout space and
+  paints nothing. Deleting the colour alone would change nothing; deleting the
+  width would shift layout by 1px.
+- **`background-clip` at L1731 / L1740 / L1749 / L1756 (light) and L1781 / L1790 /
+  L1799 / L1806 (dark)** — live, but the `background-image` beside it is owned by
+  `components.css`, so the clip applies to a background the page does not own.
+
+### Per-column result — the split is 2-way, not 17-way
+
+Across all 17 columns the ownership pattern collapses into exactly two groups,
+identical in light and dark:
+
+| Property | Columns 1–4, 15–17 | Columns 5–14 (metric lanes) |
+|---|---|---|
+| `background-color` / `background-image` | `components.css` `(1,3,2)` | `pages-workout-log.css` `(1,5,2)` |
+| `border-bottom-color` | `components.css` `(1,3,2)` | `(1,5,2)` on `th`, `components.css` on `td` |
+| `color` | `components.css` | `(1,5,2)` on `th`, `components.css` on `td` |
+| `box-shadow`, `padding`, `font-size`, `letter-spacing`, `border-top-color`, `text-shadow`, `font-weight` | `components.css` `(1,3,1)` / `(1,3,2)` | identical |
+
+**No individual column deviates from its group.** The per-column `nth-child`
+rules in region E, which exist precisely to differentiate columns 5–14, are
+entirely dead; the live per-column differentiation comes from the class-based
+region-H system instead. The `metric-lane` classes on the cells are what
+actually drive column colour, so this result does not depend on column order —
+a useful qualifier on the WP4.3j-a finding that "196 `nth-child` rules make
+every column rule positional."
+
+### Measured invariants (identical at all three widths, both themes)
+
+| Property | Computed | Winning owner |
+|---|---|---|
+| `th`/`td` padding | `12px 16px` | `components.css` `(1,3,1)` important |
+| `th`/`td` `font-size` | `14.08px` | same |
+| `th`/`td` `letter-spacing` | `normal` | same |
+| `th`/`td` `border-top-color` | `rgba(0, 0, 0, 0)` | same (`border-color: transparent`) |
+| `th`/`td` `box-shadow` | `none` | same (`box-shadow: none`) |
+| dark `td` `color` | `rgb(238, 241, 246)` | `components.css` `(1,4,2)` important |
+
+This independently reproduces the j-b / j-b-dead padding and type findings from
+a fresh harness.
+
+---
+
+## Correction to previously shipped evidence
+
+`CSS_PHASE4_WP4_3J_A_EVIDENCE.md` records, about the dark-mode visibility block
+(region F):
+
+> "**The `color` declarations are live winners, not dead.** They set `#e0e0e0`
+> at specificity (0,3,1), beating the earlier dark-glass rule's
+> `rgba(255, 255, 255, 0.9)` at (0,2,1)."
+
+**That is not what renders.** The comparison was made only against the
+page-local dark-glass rule and never against the shared bundle. All eight
+`color: #e0e0e0 !important` declarations in region F are **cascade-dead**: the
+computed dark cell colour is `rgb(238, 241, 246)`, owned by `components.css`
+`color: var(--ink-1, #eef1f6) !important` at `(1,4,2)`. Verified on all 17
+columns, both `th` and `td`, at all three widths, with the reported owner
+reproducing the computed value exactly.
+
+The j-a *packet* is unaffected — it deleted `background-color` declarations, not
+these — but the recorded reason for retaining region F does not hold. This is a
+worked example of the same mistake the `:is()` trap caused in j-b: **ranking a
+page-local declaration against its page-local neighbours instead of against
+every loaded stylesheet.**
+
+---
+
+## Deletion candidate — documented, NOT implemented
+
+A coherent candidate exists. **It is not authorized by this audit and must not
+be started without new owner approval.**
+
+### Exact scope
+
+| Region | Rules | Lines | `!important` | Selector family |
+|---|---:|---:|---:|---|
+| D | 3 | 31 (361–391) | 8 | `[data-theme='dark'] .workout-log-table td` base / even / hover |
+| E | 20 | 251 (393–643) | 30 | `.workout-log-table thead th:nth-child(N)` + `td:nth-child(N)` lane colours, light and dark |
+| F | 8 | 74 (1366–1439) | 11 | `[data-theme='dark'] .workout-log-table` `td`/`th` `color: #e0e0e0` |
+| G (6 of 8 rules) | 6 | 80 (1446–1525) | 22 | `.tbl…`/`.tbl--responsive…` header, cell, dark and even-row overrides |
+| **Total** | **37** | **436** | **71** | |
+
+**Properties:** every declaration in those rules. All are proven dead in all six
+contexts, all 17 columns and all four cell roles.
+
+**Explicitly retained inside region G:** the two hover rules at **L1527** and
+**L1538**. Their background and box-shadow declarations are dead, but their
+`filter: saturate(…) brightness(…)` is the **winning owner** of `filter` on
+hovered cells — L1527 in light, L1538 in dark. Three other rules propose a hover
+`filter` (L295, L383, L680) and all three lose. A deletion packet must keep the
+`filter` declarations or prove them inert separately.
+
+### Oracle a deletion packet would need
+
+1. **Before/after computed-value + declaration-owner differential** over all
+   15,336 records, expecting **0 differing records**.
+2. **Frame-scoped pixel differential** at all six contexts, expecting
+   **6/6 zero-diff**, preceded by a same-CSS control that reaches zero.
+3. **Same-CSS control** on both sides — the j-dead rule; a sweep alone
+   over-reports.
+4. **Positive-control evidence** for every negative result, per the rule this
+   packet adds.
+
+### Proposed gates
+
+- New cascade contract asserting the 37 rules are absent, that the
+  `components.css` owners that beat them are unchanged, that `filter` survives at
+  L1527/L1538, and that the region-H `(1,5,2)` lane family is untouched.
+- Red path proven against the pre-deletion bundle.
+- Workout Log visuals **6/6 update-free** with `PW_VISUAL_SEED=1`.
+- Focused functional Chromium (`workout-log`, `smoke-navigation`).
+- Full pytest.
+- Stylelint before/after with no category increased. Expected movement is real
+  here, unlike j-b-dead: **71 `!important` (285 → 214)** plus the colour literals
+  in region E.
+
+### Risk to state in that packet
+
+The deadness of regions A–G is **conditional on `#workout-log-table` keeping its
+`table` and `table-calm` classes**, which is what lets the shared
+`components.css` rule match. Those classes are hardcoded in
+`templates/workout_log.html:66` and no JavaScript mutates them — the only
+runtime class changes are `tbl--view-simple` / `tbl--view-advanced` in
+`static/js/table-responsiveness.js:335-339`, which hide Workout Plan columns
+(`Movement Pattern`, `Stabilizers`, `Synergists`, `Tertiary Muscle`, `Utility`,
+`Movement Subpattern`) and no Workout Log column. If `table-calm` were ever
+removed from the log table, the deleted rules would have been the fallback.
+
+---
+
+## Findings recorded, not acted on
+
+1. **The WP4.4 shared-selector finding is now quantified.** The ID-bearing
+   `:is()` arm is not merely awkward — it is why four successive generations of
+   page-local table styling in this file are dead. Any WP4.4 repair of that
+   selector would **resurrect** regions A–G unless they are deleted first, which
+   is an argument for sequencing the deletion packet *before* WP4.4, not after.
+2. **Region H is the only correct pattern in the file** and should be the model
+   for any future page-local table styling: match the shared owner's ID-level
+   specificity deliberately, with a comment explaining why.
+3. **The transparent 1px header top border** (`border-top-width`/`-style` live,
+   `border-top-color` forced transparent by the shared bundle) is a latent
+   layout-only artifact. Left alone.
+4. **Region I is mostly `MIXED`**, driven by `theme-dark.css:88`
+   `:where([data-theme="dark"] .workout-log-frame)` — specificity `(0,0,0)` but
+   `!important` and loaded after the page bundle, so it takes the frame's
+   background, border and box-shadow in dark mode while region I keeps them in
+   light. Not a defect; recorded because it is easy to misread as duplication.
+5. **Nine declarations remain `unverified`**, all in region H, all because their
+   target cells are outside the captured region at mobile width where the table
+   becomes an `overflow-x` scroll container. They are **not** classified as dead.
+
+---
+
+## Explicitly out of scope, and untouched
+
+CSS deletion and tokenization; `components.css` and WP4.4; the five retained
+empty media shells; the `992px` overflow rule and the other retained responsive
+families; `nth-child` restructuring; modal and editable-input styling and
+redesign; templates, JavaScript, SCSS, generated Bootstrap, databases, and
+visual baselines.
+
+`git status -- e2e/__screenshots__` is empty. The diff for this packet is
+documentation only.

--- a/docs/MASTER_HANDOVER.md
+++ b/docs/MASTER_HANDOVER.md
@@ -4,7 +4,74 @@
 
 ## Current State
 
-> **2026-07-26 (LATEST) — WP4.3j-b-dead SHIPPED: the deletion packet the j-b
+> **2026-07-27 (LATEST) — WP4.3j-c CLOSED as an evidence-only audit; no
+> production file changed.** It audited the overlapping header and table-cell
+> glass systems in `static/css/pages-workout-log.css` — the base light header and
+> cell blocks, their dark counterparts, the comprehensive dark-mode visibility
+> block, the final override block, the late frame/table glass block, and the
+> shared `components.css` table-cell owner (read only) — across all 17 columns,
+> both themes, and desktop/tablet/mobile.
+>
+> **Headline: the Workout Log table is painted by the shared `components.css`
+> `.table.table-calm` system, not by the page's own glass systems.** Of **322**
+> distinct declarations audited in regions A–I, **227 never win anywhere**, 31
+> are live, 55 mixed, 9 unverified, and **0 are winning-but-overpainted**.
+> Regions **D (dark cell, 3 rules), E (metric-lane `nth-child` glass, 20 rules)
+> and F (dark-mode visibility, 8 rules)** are dead in their entirety. The cause is
+> the ID-bearing `:is()` arm in the shared selector, which exports `(1,3,1)` /
+> `(1,3,2)` ID-level specificity to the `.workout-log-page` branch that matches;
+> every page-local rule in regions A–G is ID-free at `(0,1,1)`–`(0,4,3)`, so no
+> amount of `!important` reaches it. **The one page-local family that does render
+> is region H**, the only one written with an ID (`(1,5,2)`) — and the only place
+> in the file where the problem was diagnosed rather than answered with more
+> `!important`. Regions A–G are a stack of four successive attempts to restyle
+> cells that had already lost the cascade.
+>
+> **Per-column result: the split is 2-way, not 17-way.** Columns 1–4/15–17 are
+> owned by `components.css`; columns 5–14 take background and header colour from
+> region H. No individual column deviates from its group, and the live
+> differentiation is class-driven (`metric-lane`), not positional — a useful
+> qualifier on the j-a note about 196 positional `nth-child` rules.
+>
+> **Audit gates:** same-CSS pixel control **0 differing pixels, 6/6 contexts**;
+> resolution self-check **9,358 checks / 0 mismatches**; sentinel probes
+> **222/222 verified effective**; **0** unexplained zero-diffs; **15,336**
+> ownership records against 2,196/2,052/1,950 matching rules. Evidence:
+> [`CSS_PHASE4_WP4_3J_C_AUDIT_EVIDENCE.md`](CSS_PHASE4_WP4_3J_C_AUDIT_EVIDENCE.md).
+>
+> **Correction to shipped evidence.** `CSS_PHASE4_WP4_3J_A_EVIDENCE.md` records
+> that the dark-mode visibility block's `color: #e0e0e0` declarations are "live
+> winners, not dead." They are **cascade-dead** — the computed dark cell colour is
+> `rgb(238, 241, 246)` from `components.css` `var(--ink-1, #eef1f6)` at `(1,4,2)`.
+> The j-a packet is unaffected (it deleted `background-color`, not these), but its
+> stated reason for retaining the block was wrong: it ranked a page-local
+> declaration against its page-local neighbours instead of against every loaded
+> stylesheet — the same error class as the j-b `:is()` trap.
+>
+> **Deletion candidate documented, NOT authorized, NOT started:** regions D + E +
+> F plus 6 of the 8 rules in region G — **37 rules, 436 lines, 71 `!important`** —
+> explicitly retaining the L1527/L1538 hover `filter` declarations, which are the
+> winning owners of `filter`. The evidence names the exact selectors, the required
+> oracle, and the proposed gates. **Do not begin it without new owner approval.**
+> Sequencing note: a WP4.4 repair of the shared `:is()` selector would
+> **resurrect** regions A–G unless they are deleted first.
+>
+> **Method rule added — *a probe that changes nothing proves nothing.*** Four
+> oracle defects each produced a confident false "dead CSS" verdict before being
+> caught: (1) CSSOM cannot expand a `var()`-bearing shorthand, so querying
+> longhands alone hid exactly the shared owners that win (338 resolution
+> mismatches → 0 after adding shorthand fallback); (2) an injected stylesheet
+> sentinel at `(1,1,2)` silently lost to the page's own `(1,5,2)` rules, and its
+> zero pixel diff read as deadness — sentinels must be applied **inline
+> `!important`** and asserted to have moved the computed value; (3) a running CSS
+> transition outranks even important author declarations, so a computed value read
+> immediately after applying a sentinel returns the pre-transition value; (4)
+> `page.screenshot` does not paint clip regions beyond the viewport — at mobile a
+> naive frame-top clip returned a near-blank image and **every** sentinel on it
+> read as zero-diff. Also: `img.decode()` on a never-fetched `loading="lazy"`
+> image never settles, which hung the run at mobile width.
+>
+> **2026-07-26 — WP4.3j-b-dead SHIPPED: the deletion packet the j-b
 > audit nominated but did not authorize.** It removed the three responsive
 > families j-b proved inert from `static/css/pages-workout-log.css`: the complete
 > eight-query `RESPONSIVE FRAME ADJUSTMENTS` block, the `thead th` / `td`

--- a/docs/REFACTOR_PLAN.md
+++ b/docs/REFACTOR_PLAN.md
@@ -1,10 +1,11 @@
 # Deep Refactor Plan — v3 (2026-07-04, full-scan grounded)
 
-**Status (2026-07-26): Track A, Phases -1 through 3, and Phase-4 packets
+**Status (2026-07-27): Track A, Phases -1 through 3, and Phase-4 packets
 WP4.-1, WP4.0a, WP4.0, WP4.1, WP4.2, and WP4.3a–WP4.3h are complete, as is the
 WP4.3i Workout Plan dead-CSS arc through WP4.3i-filter-btn. WP4.3j-a is merged,
-WP4.3j-b is complete as an audit-only no-op, and WP4.3j-b-dead has shipped the
-deletion it nominated.** WP2.2 is committed
+WP4.3j-b is complete as an audit-only no-op, WP4.3j-b-dead has shipped the
+deletion it nominated, and WP4.3j-c is complete as an evidence-only audit whose
+deletion candidate is documented but NOT authorized.** WP2.2 is committed
 as `c461840`; optional WP3.6 is committed as `0cbedac`. WP4.0 measurement
 provenance remains unchanged head `e46b67e`, with its ledger committed as
 `ca725c2`. Local integration verification through WP4.3d is complete
@@ -98,9 +99,36 @@ dead-CSS packet on this page must pair the sweep with a rest-state differential
    animated navbar strip `y ∈ [18,40]` — scope pixel claims to the element under
    test), and a specificity model that mishandles `:is()` or splits selectors on a
    naive comma will report an owner contradicting the computed value.
-   **j-c header/cell glass is still not started** and stays owner-gated. The
-   shared ID-bearing `:is()` specificity finding belongs to WP4.4 and is recorded,
-   not acted on.
+   **WP4.3j-c is now COMPLETE as an evidence-only audit** of the overlapping
+   header and table-cell glass systems — no production file changed. It found
+   that **the Workout Log table is painted by the shared `components.css`
+   `.table.table-calm` system, not by the page's own glass systems**: of **322**
+   declarations audited across regions A–I, **227 never win anywhere**, 31 are
+   live, 55 mixed, 9 unverified, and **0 are winning-but-overpainted**. Regions
+   **D (dark cell), E (metric-lane `nth-child` glass) and F (dark-mode
+   visibility)** are dead in their entirety. The cause is the ID-bearing `:is()`
+   arm exporting `(1,3,1)`/`(1,3,2)` specificity; every page-local rule in A–G is
+   ID-free and unreachable regardless of `!important`. The only page-local family
+   that renders is region H, the only one written with an ID at `(1,5,2)`.
+   Per-column ownership collapses to two groups (1–4/15–17 vs the 5–14 metric
+   lanes) with **no column deviating from its group**. Audit gates: pixel control
+   **0 diff 6/6**, resolution self-check **9,358 / 0 mismatches**, sentinels
+   **222/222 effective**, **15,336** records. Evidence:
+   [`CSS_PHASE4_WP4_3J_C_AUDIT_EVIDENCE.md`](CSS_PHASE4_WP4_3J_C_AUDIT_EVIDENCE.md).
+   It **corrects** the j-a claim that the dark `#e0e0e0` colours are live
+   winners — they are cascade-dead, beaten by `components.css` at `(1,4,2)`.
+   A deletion candidate (**37 rules, 436 lines, 71 `!important`**, retaining the
+   L1527/L1538 hover `filter`) is documented with exact selectors, oracle and
+   gates but is **NOT authorized and NOT started**. **Method rule added: a probe
+   that changes nothing proves nothing** — four oracle defects each produced a
+   confident false deadness verdict (`var()`-bearing shorthands invisible to
+   longhand CSSOM queries, an injected sentinel losing the cascade, a running
+   transition outranking important author declarations, and `page.screenshot`
+   not painting clip regions beyond the viewport).
+   The shared ID-bearing `:is()` specificity finding still belongs to WP4.4 and
+   is recorded, not acted on — but the audit adds a sequencing constraint:
+   **repairing that selector in WP4.4 would resurrect the dead regions A–G unless
+   they are deleted first.**
 6. Deferred and unacted: the superset dark-tint gap (`--superset-bg-1..4` has no
    live dark override) and the dead `body.dark-mode` in
    `static/css/layout.css:1120` (→ WP4.4).


### PR DESCRIPTION
Evidence-only packet for **WP4.3j-c**. The diff is **documentation only** — no CSS, template, JavaScript, SCSS, test, database, or visual baseline is touched.

## What it audits

The overlapping header and table-cell glass systems in `static/css/pages-workout-log.css` — the base light header and cell blocks, their dark counterparts, the comprehensive dark-mode visibility block, the final override block, the late frame/table glass block, and the shared `components.css` table-cell owner (read only) — across **all 17 columns**, both themes, and desktop / tablet / mobile.

## Headline

**The Workout Log table is painted by the shared `components.css` `.table.table-calm` system, not by the page's own glass systems.**

Of **322** distinct declarations audited in regions A–I:

| Classification | Count |
|---|---:|
| cascade-dead | **227** |
| live cascade winner | 31 |
| mixed (live in some contexts, dead in others) | 55 |
| unverified | 9 |
| winning but visually overpainted | **0** |

Regions **D** (dark cell, 3 rules), **E** (metric-lane `nth-child` glass, 20 rules) and **F** (dark-mode visibility, 8 rules) are dead **in their entirety**.

The cause: the shared selector's `:is()` carries an ID arm (`#workout[data-page="workout-plan"]`), so it exports `(1,3,1)`/`(1,3,2)` ID-level specificity to the `.workout-log-page` branch that actually matches. Every page-local rule in regions A–G is ID-free at `(0,1,1)`–`(0,4,3)` and cannot reach it regardless of `!important`. The one page-local family that *does* render is region **H**, the only one written with an ID at `(1,5,2)`.

Per-column ownership collapses into **two** groups — columns 1–4/15–17 vs the 5–14 metric lanes — with **no column deviating from its group**, and the live differentiation is class-driven rather than positional.

## Correction to shipped evidence

`CSS_PHASE4_WP4_3J_A_EVIDENCE.md` records that the dark-mode visibility block's `color: #e0e0e0` declarations are "live winners, not dead." They are **cascade-dead** — the computed dark cell colour is `rgb(238, 241, 246)` from `components.css` `var(--ink-1, #eef1f6)` at `(1,4,2)`. The j-a packet itself is unaffected (it deleted `background-color`, not these); only its stated reason for retaining the block was wrong.

## Gates

| Gate | Result |
|---|---|
| Same-CSS pixel control (2 independent loads per context) | **0 differing pixels, 6/6 contexts** |
| Resolution self-check (reported owner reproduces computed value) | **9,358 checks, 0 mismatches** |
| Sentinel probes verified to have taken effect | **222 / 222** |
| Unexplained zero-diffs | **0** |
| Ownership records | **15,336** |
| Full pytest | **1,857 passed / 1 skipped** (unchanged from baseline) |
| CSS cascade + visual selector contracts | **31 passed** (28 cascade + 3 visual selector) |

## Deletion candidate — documented, NOT authorized

Regions D + E + F plus 6 of the 8 rules in region G: **37 rules, 436 lines, 71 `!important`**, explicitly retaining the L1527/L1538 hover `filter` declarations. Exact selectors, required oracle and proposed gates are in the evidence doc. **Not started, and it must not begin without new owner approval.**

Sequencing note recorded: a WP4.4 repair of the shared `:is()` selector would **resurrect** the dead regions A–G unless they are deleted first.

## Method rule added

***A probe that changes nothing proves nothing.*** Four separate oracle defects each produced a confident **false** "dead CSS" verdict before being caught:

1. CSSOM cannot expand a `var()`-bearing shorthand, so querying longhands alone hid exactly the shared owners that win (338 resolution mismatches → 0).
2. An injected stylesheet sentinel at `(1,1,2)` silently lost to the page's own `(1,5,2)` rules; its zero pixel diff read as deadness. Sentinels are now applied inline `!important` and asserted to have moved the computed value.
3. A running CSS transition outranks even important author declarations, so a computed value read immediately after applying a sentinel returns the pre-transition value.
4. `page.screenshot` does not paint clip regions beyond the viewport — at mobile a naive frame-top clip returned a near-blank image and every sentinel on it read as zero-diff.

Evidence: [`docs/CSS_PHASE4_WP4_3J_C_AUDIT_EVIDENCE.md`](docs/CSS_PHASE4_WP4_3J_C_AUDIT_EVIDENCE.md)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
