### PR TITLE
css(workout-log): remove cascade-dead hover paint (WP4.3j-d)

### DIFF
--- a/docs/ACTIVE_DEVELOPMENT.md
+++ b/docs/ACTIVE_DEVELOPMENT.md
@@ -4,7 +4,36 @@ This file is the execution source of truth for autonomous development sessions. 
 
 ## Current Objective
 
-**2026-07-27 (LATEST) — WP4.3j-c-dead SHIPPED: the 37 cascade-dead header and
+**2026-07-27 (LATEST) — finish shipping WP4.3j-d-hover-paint, then stop.**
+The packet removes exactly four cascade-dead declarations from the two retained
+Region G Workout Log hover rules: light/dark `background` and `box-shadow`.
+Both full selector lists and both live filters are byte-identical; the rules are
+now filter-only. `!important` **217 → 213**.
+
+The real-hover differential is green across light/dark ×
+desktop/tablet/mobile: **11,016 records, 0 computed-value differences, 0
+declaration-owner differences, 6/6 byte-identical frame captures**. Known-live
+filter controls passed 6/6 before and after. Same-CSS controls were 0 on both
+sides; resolution self-check was **2,924 / 0 per side**; sentinels were **24/24
+effective per side**. Positive control: **408 records lost candidates, 0 gained
+any**, while rule counts remained unchanged.
+
+The prior Region H hash contract accidentally anchored on an earlier prose
+mention and covered Region G. Its unique banner anchor and corrected 282-line
+span are now explicit; the old defect caused false failures, never false passes.
+The new hover contract pins both selector lists and filter-only bodies and goes
+red against the historical bundle, a removed live filter, and a restored
+background.
+
+Gates: visuals **6/6** update-free, CSS/visual contracts **33/33**, focused
+functional Chromium **33/33**, full pytest **1,859 passed / 1 skipped**.
+Stylelint total **5,498 → 5,490**, focused **431 → 423**, no category increased.
+Evidence:
+[`CSS_PHASE4_WP4_3J_D_HOVER_PAINT_EVIDENCE.md`](CSS_PHASE4_WP4_3J_D_HOVER_PAINT_EVIDENCE.md).
+After this packet lands, await owner direction; do not begin further Workout Log
+cleanup or WP4.4.
+
+**2026-07-27 — WP4.3j-c-dead SHIPPED: the 37 cascade-dead header and
 table-cell glass rules the j-c audit nominated are deleted.** Regions D (dark
 cell glass, 3 rules), E (positional metric-lane glass, 20), F (dark-mode
 visibility, 8) and six of the eight region-G final-override rules are gone from
@@ -137,11 +166,12 @@ The root-cleanup / data-packaging track also remains CLOSED. All packets shipped
 all 225 checklist items in [`rootdircleanup.md`](rootdircleanup.md) are ticked,
 and that closed record must not be re-executed.
 
-The Phase-4 CSS track is paused and owner-gated. The Workout Log dead-CSS packet
-that j-b nominated **has now shipped as WP4.3j-b-dead** and is closed. WP4.4 may
-review the shared `:is()` specificity trap; it is not authorized or started, and
-neither is j-c header/cell-glass work. The ten WP4.3i deferred interaction-state
-declarations and WP4.3i-c Page Header contract remain untouched.
+The Phase-4 CSS track is paused and owner-gated after WP4.3j-d ships. The j-b
+and j-c dead-CSS packets are closed, and WP4.3j-d removes the final four
+authorized Region G hover-paint declarations. WP4.4 may review the shared
+`:is()` specificity trap, but it is not authorized or started. The ten WP4.3i
+deferred interaction-state declarations and WP4.3i-c Page Header contract remain
+untouched.
 
 WPB.4 also remains unimplemented and owner-gated: it requires retaining one
 synthetic `Unassigned` session, an explicit unresolved-denominator decision, and
@@ -149,11 +179,9 @@ intentional review of the exact golden diff before any behavior change.
 
 ## Next Action
 
-Await owner direction. Nothing is in flight, and no packet is waiting to be
-picked up. WP4.3j-c-dead is **shipped and closed**; the deletion packet the j-c
-audit nominated no longer exists as pending work. Do not begin another Workout
-Log packet, WP4.4, fatigue, or feature work — and do not reopen the root-cleanup
-track.
+Complete the WP4.3j-d ship sequence, then await owner direction. No further
+Workout Log packet is authorized. Do not begin WP4.4, fatigue, or feature work,
+and do not reopen the root-cleanup track.
 
 The sequencing constraint is now **discharged**: a WP4.4 repair of the shared
 `:is()` selector would have **resurrected** regions D–G on this page, which is
@@ -162,9 +190,8 @@ evaluated on its own merits whenever the owner authorizes it. Regions A, B and C
 remain page-local and ID-free, so a WP4.4 selector repair would still change what
 they own — that is a WP4.4 question, not an open item here.
 
-Still untouched and owner-gated: the two region-G hover rules' dead
-`background`/`box-shadow` declarations, the remaining Workout Log raw-literal →
-token extraction, the ten WP4.3i deferred interaction-state declarations, and the
+Still untouched and owner-gated: the remaining Workout Log raw-literal → token
+extraction, the ten WP4.3i deferred interaction-state declarations, and the
 WP4.3i-c Page Header contract.
 
 ---

--- a/docs/ACTIVE_DEVELOPMENT.md
+++ b/docs/ACTIVE_DEVELOPMENT.md
@@ -4,7 +4,7 @@ This file is the execution source of truth for autonomous development sessions. 
 
 ## Current Objective
 
-**2026-07-27 (LATEST) — finish shipping WP4.3j-d-hover-paint, then stop.**
+**2026-07-27 (LATEST) — WP4.3j-d-hover-paint is complete in PR #186; then stop.**
 The packet removes exactly four cascade-dead declarations from the two retained
 Region G Workout Log hover rules: light/dark `background` and `box-shadow`.
 Both full selector lists and both live filters are byte-identical; the rules are
@@ -179,9 +179,9 @@ intentional review of the exact golden diff before any behavior change.
 
 ## Next Action
 
-Complete the WP4.3j-d ship sequence, then await owner direction. No further
-Workout Log packet is authorized. Do not begin WP4.4, fatigue, or feature work,
-and do not reopen the root-cleanup track.
+After WP4.3j-d PR #186, await owner direction. No further Workout Log packet is
+authorized. Do not begin WP4.4, fatigue, or feature work, and do not reopen the
+root-cleanup track.
 
 The sequencing constraint is now **discharged**: a WP4.4 repair of the shared
 `:is()` selector would have **resurrected** regions D–G on this page, which is

--- a/docs/CSS_PHASE4_WP4_3J_D_HOVER_PAINT_EVIDENCE.md
+++ b/docs/CSS_PHASE4_WP4_3J_D_HOVER_PAINT_EVIDENCE.md
@@ -1,0 +1,138 @@
+# CSS Phase 4 — WP4.3j-d Hover Paint Evidence
+
+Date: 2026-07-27
+Branch: `wt/wp4-3j-d-hover-paint`
+Base: merged `main` at `c29b05f`
+
+## Outcome
+
+WP4.3j-d removes exactly four cascade-dead declarations from the two retained
+Region G Workout Log hover rules in `static/css/pages-workout-log.css`:
+
+- light: `background` and `box-shadow`;
+- dark: `background` and `box-shadow`.
+
+Both selector lists are byte-identical to the base revision. The live filters
+are also byte-identical:
+
+- light: `saturate(1.02) brightness(0.99)`;
+- dark: `saturate(1.05) brightness(1.03)`.
+
+The two rules are now filter-only. No rule, selector, media query, template,
+JavaScript, SCSS, shared CSS, visual baseline, or database was changed.
+`!important` declarations in the comment-stripped bundle fall **217 → 213**.
+The file remains **1,621 lines** and contains **9 `@media` rules**.
+
+## Why the four declarations are dead
+
+The audit used real mouse hover, not a selector model. In each of six contexts
+(light/dark × desktop/tablet/mobile), row 0 was the only `:hover` row and its
+first metric-lane cell was the target.
+
+Before deletion, both Region G hover selectors resolved to exactly one CSSOM
+rule and declared `background`, `box-shadow`, and `filter`. The matching-theme
+rule owned only `filter`; its expanded `background-color`, `background-image`,
+`background-clip`, and `box-shadow` declarations entered the candidate set but
+lost everywhere.
+
+The winning paint owners were:
+
+| Target | Light owner | Dark owner |
+|---|---|---|
+| metric-lane background colour/image | Region H `(1,6,3)` / `(1,5,2)` | Region H `(1,7,3)` / `(1,6,2)` |
+| metric-lane box shadow | `components.css` `(1,4,3)` | `components.css` `(1,5,3)` |
+| non-metric hover paint | `components.css` `(1,4,3)` | `components.css` `(1,5,3)` |
+| filter | Region G light `(0,3,3)` | Region G dark `(0,4,3)` |
+
+`--lane-hover-bg` and `--lane-hover-shadow` are not orphaned. The separate
+Region C hover rule still consumes both variables and retains the third
+`filter: saturate(…)` declaration.
+
+## Before/after differential
+
+The browser harness audited 51 targets × 36 properties = **1,836 records per
+context**, **11,016 total**.
+
+| Oracle | Result |
+|---|---|
+| computed values | **0 differences / 11,016** |
+| declaration owners | **0 differences / 11,016** |
+| frame pixels | **0 differences, 6/6 byte-identical PNGs** |
+| same-CSS pixel controls | **0 differing pixels, before and after, 6/6** |
+| resolution self-check | **2,924 checks / 0 mismatches per side** |
+| sentinels | **24/24 effective per side; restoration clean 6/6** |
+| matching-rule count | unchanged: 2,159 / 2,015 / 1,913 by viewport |
+| candidate-count positive control | **408 records fell; 0 rose** |
+
+Candidate totals fell by 68 in each light context and 136 in each dark context.
+The larger dark movement is expected: both Region G rules match under the dark
+theme, although only the dark rule owns the live filter. Rule-count delta is
+zero because declarations, not rules, were removed.
+
+The known-live control passed before and after in all six contexts: computed
+filter was the expected theme value and the matching Region G rule remained its
+owner. A missing filter owner was a stop condition.
+
+Artifacts are gitignored under `artifacts/wp43jd/`, including
+`before-report.json`, `after-report.json`, `differential.json`, and the twelve
+frame captures.
+
+## Contract corrections and red path
+
+The WP4.3j-c-dead Region H sha256 contract had used the first occurrence of
+`EXPLICIT METRIC LANE PAIRING`. That phrase also appeared in an earlier deletion
+note, so the purported Region H span actually began near line 367 and included
+the authorized Region G edit. It was over-broad and produced a false failure;
+it never produced a false pass.
+
+WP4.3j-d fixes the contract by anchoring on the unique two-line banner at line
+1146, asserts that the span contains **282 newline-delimited lines**, and locks
+the corrected span at sha256:
+
+`18658442af0598e5612be704b7e655d14b1dab689efd404138d90a7a93988818`
+
+A new contract pins both complete Region G selector lists, requires each rule
+body to contain exactly its expected filter, rejects `background` and
+`box-shadow`, and proves the Region C hover family and third filter remain.
+The contract passed current CSS and went red against:
+
+1. the complete pre-deletion CSS read as bytes from `git show HEAD`;
+2. a targeted removal of the Region G light filter;
+3. a targeted restoration of a Region G light background.
+
+The comparator also needed one evidence-only correction. Its owner identity
+included `propKey`, the inventory of every property declared by the rule.
+Deleting losing properties from the unchanged filter-owning rule therefore
+reported 102 false owner changes. Owner identity now uses `viaProp` (the
+property actually supplying the record) and excludes mutable rule-wide
+`propKey`; the corrected differential is **0 owner changes**.
+
+## Stylelint
+
+The WP4.3j-c-dead after report is the before baseline. JSON was captured from
+Stylelint's stderr.
+
+| Scope | Before | After | Delta |
+|---|---:|---:|---:|
+| all CSS/SCSS warnings | 5,498 | 5,490 | −8 |
+| `pages-workout-log.css` warnings | 431 | 423 | −8 |
+| `declaration-no-important` (focused) | 217 | 213 | −4 |
+| `declaration-property-value-disallowed-list` (focused) | 166 | 162 | −4 |
+
+No warning category increased.
+
+## Gates
+
+- Real-hover after audit: **6/6 contexts green**.
+- Browser differential: **0 computed / 0 owner / 0 pixel differences**.
+- Workout Log visuals: **6/6 passed**, update-free; screenshot status empty.
+- CSS + visual-selector contracts: **33/33 passed**.
+- Workout Log + smoke navigation Chromium: **33/33 passed**.
+- Full pytest: **1,859 passed / 1 skipped**.
+- `git diff --check`: clean.
+
+## Scope boundary
+
+Regions A/B/C/H/I remain untouched, as do `components.css`,
+`theme-dark.css`, templates, JavaScript, SCSS, snapshots, and databases.
+WP4.4 remains unstarted and requires separate owner direction.

--- a/docs/CSS_PHASE4_WP4_3J_D_HOVER_PAINT_EVIDENCE.md
+++ b/docs/CSS_PHASE4_WP4_3J_D_HOVER_PAINT_EVIDENCE.md
@@ -3,6 +3,7 @@
 Date: 2026-07-27
 Branch: `wt/wp4-3j-d-hover-paint`
 Base: merged `main` at `c29b05f`
+Pull request: #186
 
 ## Outcome
 

--- a/docs/MASTER_HANDOVER.md
+++ b/docs/MASTER_HANDOVER.md
@@ -4,7 +4,7 @@
 
 ## Current State
 
-> **2026-07-27 (LATEST) — WP4.3j-d-hover-paint is COMPLETE and locally green.**
+> **2026-07-27 (LATEST) — WP4.3j-d-hover-paint is COMPLETE in PR #186.**
 > Exactly four declarations are gone from the two retained Region G Workout Log
 > hover rules: light/dark `background` and `box-shadow`. Both selector lists and
 > both live filters are byte-identical; the rules are now filter-only.
@@ -960,9 +960,8 @@
 
 ## Next Safe Step
 
-**Current:** finish shipping WP4.3j-d-hover-paint, then stop. No further Workout
-Log cleanup and no WP4.4 work is authorized. After this packet lands, await
-explicit owner direction.
+**Current:** after WP4.3j-d-hover-paint PR #186, stop and await explicit owner
+direction. No further Workout Log cleanup and no WP4.4 work is authorized.
 
 Use [docs/ACTIVE_DEVELOPMENT.md](ACTIVE_DEVELOPMENT.md) as the execution source
 of truth. The older Fatigue Stage-4 and Body Composition material below is

--- a/docs/MASTER_HANDOVER.md
+++ b/docs/MASTER_HANDOVER.md
@@ -4,7 +4,35 @@
 
 ## Current State
 
-> **2026-07-27 (LATEST) — WP4.3j-c-dead SHIPPED: the 37 cascade-dead rules the
+> **2026-07-27 (LATEST) — WP4.3j-d-hover-paint is COMPLETE and locally green.**
+> Exactly four declarations are gone from the two retained Region G Workout Log
+> hover rules: light/dark `background` and `box-shadow`. Both selector lists and
+> both live filters are byte-identical; the rules are now filter-only.
+> `!important` **217 → 213**, Stylelint total **5,498 → 5,490** and focused
+> **431 → 423**, with no category increase.
+>
+> **Real-hover proof:** 51 targets × 36 properties × 6 contexts = **11,016**
+> records, with **0 computed-value differences, 0 declaration-owner differences,
+> and 6/6 byte-identical frame captures**. Same-CSS controls were 0 before and
+> after in all contexts; resolution self-check was **2,924 / 0 mismatches per
+> side**; sentinels were **24/24 effective per side**. The known-live filters
+> remained the winning owners 6/6. Positive control: **408 records lost
+> candidates and 0 gained any**; rule counts stayed fixed.
+>
+> The previous Region H sha256 contract was over-broad: its first-occurrence
+> anchor began inside an earlier deletion note and accidentally covered Region
+> G. WP4.3j-d anchors the unique banner, asserts the **282-line** span, and locks
+> the corrected hash. The defect caused a false failure, never a false pass. A
+> separate hover contract pins both complete selector lists, exact filters,
+> filter-only bodies, and the retained Region C hover family; it goes red against
+> the full pre-deletion bundle, a removed filter, and a restored background.
+>
+> Gates: visuals **6/6** update-free, contracts **33/33**, focused functional
+> Chromium **33/33**, full pytest **1,859 passed / 1 skipped**. Evidence:
+> [`CSS_PHASE4_WP4_3J_D_HOVER_PAINT_EVIDENCE.md`](CSS_PHASE4_WP4_3J_D_HOVER_PAINT_EVIDENCE.md).
+> WP4.4 remains unstarted and owner-gated.
+>
+> **2026-07-27 — WP4.3j-c-dead SHIPPED: the 37 cascade-dead rules the
 > j-c audit nominated are deleted from `static/css/pages-workout-log.css`.**
 > Regions **D** (dark cell glass, 3 rules), **E** (positional metric-lane glass,
 > 20), **F** (dark-mode visibility, 8) and **six of the eight region-G**
@@ -932,13 +960,13 @@
 
 ## Next Safe Step
 
-**Current:** WP4.3b is integrated into local `main` as history-preserving merge
-`92291ed`; its narrow post-merge gates passed, protected identities remained
-unchanged, and nothing was pushed. Do not begin Progression, another WP4.3 page,
-or WP4.4 until explicitly directed. The older Stage-4 paragraph below is retained
-as historical context, not the current next action.
+**Current:** finish shipping WP4.3j-d-hover-paint, then stop. No further Workout
+Log cleanup and no WP4.4 work is authorized. After this packet lands, await
+explicit owner direction.
 
-Use [docs/ACTIVE_DEVELOPMENT.md](ACTIVE_DEVELOPMENT.md) as the execution source of truth. **Local `main` is in sync with `origin/main` (0 commits ahead) after pushing `df9b6f9` (movement_pattern cleanup), `f2cdc23` (Stage 4 observer tooling), and the 2026-05-29 handover sync.** The active tracking item is **Fatigue Meter Phase 2 Stage 4 calibration window — OPEN 2026-05-24, earliest close 2026-06-07** (≥2 weeks real use). The Stage 4 calibration observer (`scripts/fatigue_stage4_observer.py`, daily scheduled task) is ready and strictly read-only; it stays idle and appends nothing while `workout_log` is empty (verified 2026-05-29). **Automation observability tooling added 2026-05-30:** `scripts/check_fatigue_stage4_automation.ps1` (read-only health check — classifies the automation as [BROKEN] / [SKIPPED] / [IDLE] / [READY], explains task result codes incl. `0` and `0x800710E0`, reports the live `workout_log` count via the read-only `scripts/fatigue_stage4_status.py` helper) and `scripts/install_fatigue_stage4_observer_task.ps1` (idempotent `schtasks /Create ... /F` installer/repair, default daily 20:00). Verified 2026-05-30: check -> **[IDLE]** (last result `0`, `workout_log` empty); installer idempotent; `schtasks /Run` succeeded. No thresholds / scenarios / boundary tests / DB touched — see [PHASE2_PLANNING.md §10](fatigue_meter/PHASE2_PLANNING.md). Working tree should remain clean except for `data/database.db` runtime dirt after committing this tooling. Pre-existing closed-workstream rules still hold: redesign post-P8 triage closed (10 shipped, #1 deferred by owner choice), phase5_3i_plan closed as accepted-as-shipped. Fatigue calibration guardrails: no per-muscle threshold tuning without ≥2 same-direction real-use disagreements; no edits to `utils/fatigue.py::MUSCLE_VOLUME_LANDMARKS` / `SESSION_FATIGUE_BANDS` / `WEEKLY_FATIGUE_BANDS`; no `tests/test_fatigue.py` boundary-test edits; no `scripts/fatigue_calibration_report.py::SCENARIOS` tuning without a fresh owner override. See [docs/fatigue_meter/PHASE2_PLANNING.md](fatigue_meter/PHASE2_PLANNING.md) Stage 4 + §10 for evidence-collection guidance.
+Use [docs/ACTIVE_DEVELOPMENT.md](ACTIVE_DEVELOPMENT.md) as the execution source
+of truth. The older Fatigue Stage-4 and Body Composition material below is
+retained as historical verification context, not as the current next action.
 
 **Verification of Body Composition Issue #21 second slice (2026-05-20, later):**
 

--- a/docs/REFACTOR_PLAN.md
+++ b/docs/REFACTOR_PLAN.md
@@ -4,8 +4,8 @@
 WP4.-1, WP4.0a, WP4.0, WP4.1, WP4.2, and WP4.3a–WP4.3h are complete, as is the
 WP4.3i Workout Plan dead-CSS arc through WP4.3i-filter-btn. WP4.3j-a is merged,
 WP4.3j-b is complete as an audit-only no-op, WP4.3j-b-dead has shipped the
-deletion it nominated, and WP4.3j-c is complete as an evidence-only audit whose
-deletion candidate is documented but NOT authorized.** WP2.2 is committed
+deletion it nominated, WP4.3j-c-dead has shipped the c-audit deletion, and
+WP4.3j-d-hover-paint is complete and locally green.** WP2.2 is committed
 as `c461840`; optional WP3.6 is committed as `0cbedac`. WP4.0 measurement
 provenance remains unchanged head `e46b67e`, with its ledger committed as
 `ca725c2`. Local integration verification through WP4.3d is complete
@@ -64,8 +64,9 @@ dead-CSS packet on this page must pair the sweep with a rest-state differential
    consumers.
 4. The remaining Workout Plan **raw-literal → token extraction and `!important`
    weighting review** is redesign-sized, multi-packet, and **has not started**.
-5. **WP4.3j (Workout Log) is IN PROGRESS as a sub-arc**; **WP4.4 (shared bundles
-   / navbar / `theme-dark.css`)** has **not started**. WP4.3j-a merged through
+5. **WP4.3j (Workout Log) is complete through WP4.3j-d-hover-paint and pauses
+   there**; **WP4.4 (shared bundles / navbar / `theme-dark.css`)** has **not
+   started**. WP4.3j-a merged through
    PR #181 at `99dfee1`; it removed the five overpainted dark-mode
    `background-color` declarations on columns 1–4 and 15–17 — evidence:
    [`CSS_PHASE4_WP4_3J_A_EVIDENCE.md`](CSS_PHASE4_WP4_3J_A_EVIDENCE.md).
@@ -117,18 +118,27 @@ dead-CSS packet on this page must pair the sweep with a rest-state differential
    [`CSS_PHASE4_WP4_3J_C_AUDIT_EVIDENCE.md`](CSS_PHASE4_WP4_3J_C_AUDIT_EVIDENCE.md).
    It **corrects** the j-a claim that the dark `#e0e0e0` colours are live
    winners — they are cascade-dead, beaten by `components.css` at `(1,4,2)`.
-   A deletion candidate (**37 rules, 436 lines, 71 `!important`**, retaining the
-   L1527/L1538 hover `filter`) is documented with exact selectors, oracle and
-   gates but is **NOT authorized and NOT started**. **Method rule added: a probe
+   The documented deletion candidate later shipped as **WP4.3j-c-dead**: 37
+   rules / 69 declarations, lines **2,025 → 1,621**, `!important` **285 → 217**.
+   **WP4.3j-d-hover-paint** then removed the four cascade-dead light/dark
+   `background` and `box-shadow` declarations from the two retained Region G
+   hover rules while preserving their full selectors and live filters. Its
+   real-hover differential is **0 computed / 0 owner differences across 11,016
+   records and 6/6 byte-identical frames**; 408 records lost candidates and 0
+   gained any. Gates: contracts **33/33**, focused Chromium **33/33**, pytest
+   **1,859 / 1 skipped**. Stylelint total **5,498 → 5,490**, focused **431 →
+   423**, no category increased. Evidence:
+   [`CSS_PHASE4_WP4_3J_D_HOVER_PAINT_EVIDENCE.md`](CSS_PHASE4_WP4_3J_D_HOVER_PAINT_EVIDENCE.md).
+   **Method rule added by the c audit: a probe
    that changes nothing proves nothing** — four oracle defects each produced a
    confident false deadness verdict (`var()`-bearing shorthands invisible to
    longhand CSSOM queries, an injected sentinel losing the cascade, a running
    transition outranking important author declarations, and `page.screenshot`
    not painting clip regions beyond the viewport).
    The shared ID-bearing `:is()` specificity finding still belongs to WP4.4 and
-   is recorded, not acted on — but the audit adds a sequencing constraint:
-   **repairing that selector in WP4.4 would resurrect the dead regions A–G unless
-   they are deleted first.**
+   is recorded, not acted on. The sequencing constraint is discharged for the
+   deleted D–G families; regions A–C remain and must be re-measured if WP4.4
+   changes the shared selector.
 6. Deferred and unacted: the superset dark-tint gap (`--superset-bg-1..4` has no
    live dark override) and the dead `body.dark-mode` in
    `static/css/layout.css:1120` (→ WP4.4).
@@ -1239,6 +1249,22 @@ Evidence:
 first would have resurrected these rules. **Wait for explicit direction before
 the next packet.**
 
+**WP4.3j-d-hover-paint completed 2026-07-27 in
+`wt/wp4-3j-d-hover-paint`, cut fresh from merged `main` at `c29b05f`.** It
+removed exactly four cascade-dead declarations from the two retained Region G
+hover rules: light/dark `background` and `box-shadow`. Both complete selector
+lists and both winning filters are byte-identical. A real mouse-hover audit
+compared **11,016 records** across six contexts: **0 computed-value differences,
+0 declaration-owner differences, and 6/6 byte-identical frames**. Known-live
+filter controls passed 6/6 before and after; **408 records lost candidates and 0
+gained any**. The Region H contract's defective first-occurrence anchor was
+corrected to its unique 282-line banner span. Gates: visuals **6/6** update-free,
+contracts **33/33**, focused functional Chromium **33/33**, pytest **1,859
+passed / 1 skipped**; Stylelint total **5,498 → 5,490**, focused **431 → 423**,
+no category increased. Evidence:
+[`CSS_PHASE4_WP4_3J_D_HOVER_PAINT_EVIDENCE.md`](CSS_PHASE4_WP4_3J_D_HOVER_PAINT_EVIDENCE.md).
+**Wait for explicit direction before further Workout Log cleanup or WP4.4.**
+
 **WP4.3h User Profile and the WP4.3i Workout Plan dead-CSS arc followed and are
 complete through WP4.3i-filter-btn (`cb5ff6e`).** Their per-packet evidence docs
 are `CSS_PHASE4_WP4_3H_EVIDENCE.md` and `CSS_PHASE4_WP4_3I_EVIDENCE.md` plus
@@ -1252,9 +1278,10 @@ carries the narrative. **Wait for explicit direction before the next packet.**
 - **Prerequisite discharged 2026-07-27.** The `components.css` `:is()` arm that
   exports ID-level specificity is why four generations of page-local Workout Log
   table styling were dead. Repairing that selector would have *resurrected* them,
-  so WP4.3j-c-dead deleted them first. Regions A, B and C on that page remain
-  page-local and ID-free, so a selector repair still changes what they own —
-  re-measure before assuming otherwise.
+  so WP4.3j-c-dead deleted the dead rules first and WP4.3j-d removed the four
+  dead hover-paint declarations from the retained Region G rules. Regions A, B
+  and C on that page remain page-local and ID-free, so a selector repair still
+  changes what they own — re-measure before assuming otherwise.
 - Handle base/layout/components/a11y/motion separately from navbar/theme.
 - Triage navbar's three live generations rule by rule.
 - Triage `theme-dark.css` into legacy values versus legitimate token remaps; do not bulk

--- a/docs/REFACTOR_PLAN.md
+++ b/docs/REFACTOR_PLAN.md
@@ -5,7 +5,7 @@ WP4.-1, WP4.0a, WP4.0, WP4.1, WP4.2, and WP4.3a–WP4.3h are complete, as is the
 WP4.3i Workout Plan dead-CSS arc through WP4.3i-filter-btn. WP4.3j-a is merged,
 WP4.3j-b is complete as an audit-only no-op, WP4.3j-b-dead has shipped the
 deletion it nominated, WP4.3j-c-dead has shipped the c-audit deletion, and
-WP4.3j-d-hover-paint is complete and locally green.** WP2.2 is committed
+WP4.3j-d-hover-paint is complete in PR #186.** WP2.2 is committed
 as `c461840`; optional WP3.6 is committed as `0cbedac`. WP4.0 measurement
 provenance remains unchanged head `e46b67e`, with its ledger committed as
 `ca725c2`. Local integration verification through WP4.3d is complete

--- a/static/css/pages-workout-log.css
+++ b/static/css/pages-workout-log.css
@@ -1116,18 +1116,22 @@ body.modal-open #clearLogModal {
 /* The six non-hover override rules that stood here — header, cell, their dark
    counterparts and the two even-row rules — were removed in WP4.3j-c-dead as
    cascade-dead against the shared components.css owner. The two hover rules
-   below are RETAINED: their background and box-shadow are dead too, but their
-   `filter` is the winning owner of filter on hovered cells. */
+   below survived that packet with their paint declarations still attached;
+   WP4.3j-d-hover-paint then removed those four declarations, measured in the
+   real hover state. What is left is the only thing either rule ever owned. */
 
-/* Hover override */
+/* Hover tint. These two rules exist solely to own `filter` on hovered cells:
+   nothing else on the page declares it in this state, so they win at (0,3,3)
+   light / (0,4,3) dark without needing `!important`. Hover BACKGROUND and
+   BOX-SHADOW are owned elsewhere and were never taken from here — on metric
+   lanes by the region-H `(1,5,2)`–`(1,7,3)` rules below, and on every other
+   cell by the shared `components.css` `.table.table-calm` hover rule at
+   `(1,4,3)` / `(1,5,3)`. Do not reintroduce paint here; it cannot win.
+   Evidence: docs/CSS_PHASE4_WP4_3J_D_HOVER_PAINT_EVIDENCE.md */
 .tbl.workout-log-table tbody tr:hover td,
 .tbl--responsive.workout-log-table tbody tr:hover td,
 .workout-log-frame .tbl tbody tr:hover td,
 .workout-log-frame .tbl--responsive tbody tr:hover td {
-    background: var(--lane-hover-bg, linear-gradient(180deg,
-      rgba(255, 255, 255, 0.99) 0%,
-      rgba(250, 252, 255, 0.96) 100%)) !important;
-    box-shadow: var(--lane-hover-shadow, inset 0 0 0 1px rgba(79, 140, 255, 0.08), inset 0 1px 0 rgba(255, 255, 255, 0.55)) !important;
     filter: saturate(1.02) brightness(0.99);
 }
 
@@ -1135,10 +1139,6 @@ body.modal-open #clearLogModal {
 [data-theme='dark'] .tbl--responsive.workout-log-table tbody tr:hover td,
 [data-theme='dark'] .workout-log-frame .tbl tbody tr:hover td,
 [data-theme='dark'] .workout-log-frame .tbl--responsive tbody tr:hover td {
-    background: var(--lane-hover-bg, linear-gradient(180deg,
-      rgba(30, 36, 48, 0.99) 0%,
-      rgba(26, 32, 44, 0.97) 100%)) !important;
-    box-shadow: var(--lane-hover-shadow, inset 0 0 0 1px rgba(96, 165, 250, 0.12), inset 0 1px 0 rgba(255, 255, 255, 0.05)) !important;
     filter: saturate(1.05) brightness(1.03);
 }
 

--- a/tests/test_css_cascade_contracts.py
+++ b/tests/test_css_cascade_contracts.py
@@ -37,9 +37,10 @@ ROUTE_BUNDLES = {
     "backup.html": "pages-backup.css",
 }
 LAYER_ORDER = ("workout", "navbar", "workout-dropdowns", "welcome")
-# WP4.3j-c-dead: the region-H metric-lane block, the one page-local family on
-# the Workout Log page that wins anything. Locked byte-for-byte.
-REGION_H_SHA256 = "2d411015e933d5d7872fa4a25752ae657c5168217b57841e303113e0ab29281e"
+# WP4.3j-c-dead: the region-H metric-lane block, the one page-local paint family
+# on the Workout Log page that wins. Locked byte-for-byte. WP4.3j-d corrected
+# the original anchor, which accidentally started at an earlier prose mention.
+REGION_H_SHA256 = "18658442af0598e5612be704b7e655d14b1dab689efd404138d90a7a93988818"
 FRAME_ROUTE_BUNDLES = {
     "plan": "pages-workout-plan.css",
     "log": "pages-workout-log.css",
@@ -1526,9 +1527,9 @@ def test_workout_log_drops_inert_responsive_table_and_frame_families() -> None:
     # None of the declarations WP4.3j-b-dead removed carried `!important`, so
     # that packet left the count unchanged at 285. WP4.3j-c-dead then removed
     # 68 important declarations along with its 37 cascade-dead rules, taking it
-    # to 217; the current total is owned by
-    # `test_workout_log_drops_cascade_dead_header_and_cell_glass`.
-    assert body.count("!important") == 217
+    # to 217. WP4.3j-d-hover-paint then removed four more, taking it to 213; the
+    # current total is owned by the two Workout Log dead-CSS contracts below.
+    assert body.count("!important") == 213
 
 
 def test_workout_log_drops_cascade_dead_header_and_cell_glass() -> None:
@@ -1652,9 +1653,15 @@ def test_workout_log_drops_cascade_dead_header_and_cell_glass() -> None:
     # matches the shared owner's ID-level specificity deliberately rather than
     # answering it with more `!important`.
     raw = (ROOT / "static" / "css" / "pages-workout-log.css").read_text(encoding="utf-8")
-    start = raw.index("EXPLICIT METRIC LANE PAIRING")
+    region_h_anchor = (
+        "EXPLICIT METRIC LANE PAIRING\n"
+        "   Planned/scored pairs share a hue"
+    )
+    assert raw.count(region_h_anchor) == 1
+    start = raw.index(region_h_anchor)
     end = raw.index("NUMBER INPUT SPINNERS")
     region_h = raw[start:end]
+    assert region_h.count("\n") == 282
     assert (
         hashlib.sha256(region_h.replace("\r\n", "\n").encode()).hexdigest()
         == REGION_H_SHA256
@@ -1721,5 +1728,62 @@ def test_workout_log_drops_cascade_dead_header_and_cell_glass() -> None:
     # --- 8. The measured weight reduction. -----------------------------------
     # 68 `!important` declarations left with the 37 rules (285 -> 217). The j-c
     # audit projected 71 because it counted region F over its line span, which
-    # also covers the retained editable-input and badge rules.
-    assert body.count("!important") == 217
+    # also covers the retained editable-input and badge rules. WP4.3j-d then
+    # removed four cascade-dead hover-paint declarations (217 -> 213).
+    assert body.count("!important") == 213
+
+
+def _assert_workout_log_hover_rules_are_filter_only(css: str) -> None:
+    hover_rules = (
+        (
+            ".tbl.workout-log-table tbody tr:hover td,\n"
+            ".tbl--responsive.workout-log-table tbody tr:hover td,\n"
+            ".workout-log-frame .tbl tbody tr:hover td,\n"
+            ".workout-log-frame .tbl--responsive tbody tr:hover td",
+            ".workout-log-frame .tbl--responsive tbody tr:hover td",
+            "filter: saturate(1.02) brightness(0.99);",
+        ),
+        (
+            "[data-theme='dark'] .tbl.workout-log-table tbody tr:hover td,\n"
+            "[data-theme='dark'] .tbl--responsive.workout-log-table tbody tr:hover td,\n"
+            "[data-theme='dark'] .workout-log-frame .tbl tbody tr:hover td,\n"
+            "[data-theme='dark'] .workout-log-frame .tbl--responsive tbody tr:hover td",
+            "[data-theme='dark'] .workout-log-frame .tbl--responsive tbody tr:hover td",
+            "filter: saturate(1.05) brightness(1.03);",
+        ),
+    )
+    for selector_list, final_selector, expected_filter in hover_rules:
+        assert css.count(selector_list + " {") == 1
+        rule_body = _wp_rule_body(css, final_selector)
+        assert rule_body.strip() == expected_filter
+        assert "background" not in rule_body
+        assert "box-shadow" not in rule_body
+
+    # Region C's separate hover family and third filter remain deliberately
+    # untouched; its var()-backed paint still consumes the Region H variables.
+    region_c_selector = (
+        ".workout-log-table tbody tr:hover td,\n"
+        ".workout-log-frame .workout-log-table tbody tr:hover td,\n"
+        ".tbl--responsive.workout-log-table tbody tr:hover td"
+    )
+    assert css.count(region_c_selector + " {") == 1
+    region_c_body = _wp_rule_body(
+        css, ".tbl--responsive.workout-log-table tbody tr:hover td"
+    )
+    assert "background: var(--lane-hover-bg," in region_c_body
+    assert "box-shadow: var(--lane-hover-shadow," in region_c_body
+    assert "filter: saturate(1.02) brightness(0.99);" in region_c_body
+    assert css.count("filter: saturate(") == 3
+
+
+def test_workout_log_hover_rules_own_only_their_live_filters() -> None:
+    """WP4.3j-d: Region G hover rules retain selectors/filters, not dead paint.
+
+    Real mouse hover across light/dark and desktop/tablet/mobile proved all four
+    paint declarations entered the candidate set but never won. The two filters
+    are known-live controls and remain the winning owners in every context.
+    """
+    css = (ROOT / "static" / "css" / "pages-workout-log.css").read_text(
+        encoding="utf-8"
+    )
+    _assert_workout_log_hover_rules_are_filter_only(css)


### PR DESCRIPTION
## What changed

- Removed the light/dark `background` and `box-shadow` declarations from the two retained Region G Workout Log hover rules.
- Preserved both complete selector lists and both live `filter` declarations byte-for-byte.
- Corrected the Region H cascade-contract anchor so it locks the intended unique 282-line span, then added a filter-only hover contract with red-path proof.
- Added the WP4.3j-d evidence packet and synchronized the canonical development docs.

## Why

Real mouse-hover ownership tracing across light/dark and desktop/tablet/mobile proved the four paint declarations match live cells and enter the cascade, but never win. Region H and the shared `components.css` table rules own hover paint; the Region G rules own only their filters.

The preceding contract used the first prose occurrence of `EXPLICIT METRIC LANE PAIRING`, so its purported Region H checksum accidentally covered Region G and rejected an authorized edit. The corrected unique banner anchor removes that false-failure path; it never caused a false pass.

## Impact

No rendered or computed-value change is expected. The browser differential found 0 computed-value differences, 0 declaration-owner differences, and 6/6 byte-identical Workout Log frame captures across 11,016 records. `!important` falls 217 → 213 and Stylelint falls 5,498 → 5,490 with no category increase.

No workflow behavior, API response, database schema, migration, template, JavaScript, SCSS, or visual baseline changes.

## Validation

- Real-hover before/after audit: 6/6 contexts; known-live filters remained owners
- Differential: 0 computed / 0 owner differences; 408 candidate drops, 0 gains
- Workout Log visuals: 6/6 update-free
- CSS + visual-selector contracts: 33 passed
- Workout Log + smoke navigation Chromium: 33 passed
- Full pytest: 1,859 passed / 1 skipped
- Stylelint: total -8, focused -8, no category increased
- `git diff --check`: clean
