### PR TITLE
css(motion): delete dead success paint (WP4.4-c)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -442,6 +442,10 @@ jobs:
     steps:
     - name: Checkout code
       uses: actions/checkout@v4
+      with:
+        # WP4.4's immutable baseline contract verifies the seven shared CSS
+        # surfaces at the merged Packet-a commit via `git show`.
+        fetch-depth: 0
       
     - name: Set up Python
       uses: actions/setup-python@v5

--- a/docs/CSS_PHASE4_WP4_4_A_BASELINE.json
+++ b/docs/CSS_PHASE4_WP4_4_A_BASELINE.json
@@ -1,7 +1,7 @@
 {
   "schemaVersion": 1,
   "packet": "WP4.4-a",
-  "sourceCommit": "f8d5a8e6c992fe71b5f9031ad67279de69ae62ea",
+  "sourceCommit": "46e340e5f2de60118d4d2d4af55ff61a1783800c",
   "purpose": "Measured baseline for the WP4.4 shared-bundle arc. Packets b-k cite this file; a number absent from it may not be quoted as fact (F13).",
   "authoritativeUnits": {
     "important": "importantDeclarations (comments excluded) — the only unit comparable to Stylelint",

--- a/docs/CSS_PHASE4_WP4_4_A_BASELINE_EVIDENCE.md
+++ b/docs/CSS_PHASE4_WP4_4_A_BASELINE_EVIDENCE.md
@@ -257,9 +257,21 @@ Each new contract was **proven to fail**, then reverted:
 
 | Contract | Injected fault | Observed |
 |---|---|---|
-| `test_wp4_4_baseline_is_pinned_and_matches_disk` | appended 2 lines to `base.css` | `assert 123 == 125` |
+| `test_wp4_4_baseline_is_pinned_and_matches_its_source_commit` | appended 2 lines to `base.css` | `assert 123 == 125` |
 | `test_snapshot_manifest_…_pytest_red` | appended one byte to a baseline PNG | manifest sha mismatch |
 | `test_specificity_model_agrees_…` | removed `where` from the zero-specificity set | self-check failure on the `:where()` case |
+
+⚠️ **Amended by WP4.4-c.** The baseline contract shipped here as
+`test_wp4_4_baseline_is_pinned_and_matches_disk`, comparing the recorded counts
+to the working tree — which is why the working-tree fault above red it. That
+coupled the immutable baseline to every later packet, so the arc's first
+authorized deletion red it too. WP4.4-c renamed it to
+`test_wp4_4_baseline_is_pinned_and_matches_its_source_commit` and re-derives each
+surface from `git show <sourceCommit>:static/css/<surface>` — the pinned commit,
+not the working tree. The row above is retained as the historical record of the
+contract as shipped by Packet a; the current red path is corrupting a recorded
+count in the baseline JSON, re-proven in
+[`CSS_PHASE4_WP4_4_C_MOTION_EVIDENCE.md`](CSS_PHASE4_WP4_4_C_MOTION_EVIDENCE.md) §8.
 
 ---
 

--- a/docs/CSS_PHASE4_WP4_4_C_MOTION_EVIDENCE.md
+++ b/docs/CSS_PHASE4_WP4_4_C_MOTION_EVIDENCE.md
@@ -1,0 +1,215 @@
+# WP4.4-c — `motion.css` triage
+
+*Phase 4 CSS. Pure deletion of proven non-winners. Plan:
+[`docs/css_phase4_wp4_4/PLANNING.md`](css_phase4_wp4_4/PLANNING.md) (Gate 1 approved, rulings N1–N10).*
+
+**Base:** `wt/wp4-4-c-motion` from `main` @ `6ebf4b1`, worktree seeded `-Seed visual`.
+**Baseline cited:** [`docs/CSS_PHASE4_WP4_4_A_BASELINE.json`](CSS_PHASE4_WP4_4_A_BASELINE.json) (F13 — every number below appears there or is measured here).
+
+---
+
+## 1. Outcome
+
+**Three declarations deleted, all from `.is-success`, all proven non-winners.
+Everything else in the file was measured live and retained.**
+
+```diff
+ .is-success {
+   animation: success-pulse 1s var(--ease-out, ease) !important;
+-  background-color: var(--success, #10b981) !important;
+-  border-color: color-mix(in srgb, var(--success, #10b981) 80%, white 20%) !important;
+-  color: #ffffff !important;
+ }
+```
+
+`motion.css` **71 → 73 lines** (three declarations removed, a five-line comment added recording why). No selector was rewritten, no declaration re-weighted, no `@layer` membership touched (N2), and no behaviour changed.
+
+---
+
+## 2. Why these three, and only these three
+
+`.is-success` is applied by `static/js/modules/workout-plan-add-exercise.js:275-278` to **`#add_exercise_btn`** and to nothing else in the codebase, for 1,000 ms after a successful add. That makes the whole rule an **M10 declaration** — reachable only through a JS-applied class, and therefore non-deletable *unless proven under that state*.
+
+It was proven under that state, on the real element, in both themes, with M6a applied.
+
+| Property | before `.is-success` | after `.is-success` | verdict |
+|---|---|---|---|
+| `background-color` | `rgb(76, 110, 245)` | `rgb(76, 110, 245)` | **non-winner** |
+| `color` | `rgb(255, 255, 255)` | `rgb(255, 255, 255)` | **non-winner** |
+| `border-top-color` | `color(srgb 0.452471 0.556471 0.969412)` | *unchanged* | **non-winner** |
+| `border-right-color` | *as above* | *unchanged* | **non-winner** |
+| `border-bottom-color` | *as above* | *unchanged* | **non-winner** |
+| `border-left-color` | *as above* | *unchanged* | **non-winner** |
+| `animation-name` | `none` | **`success-pulse`** | **winner — retained** |
+| `animation-duration` | `0s` | **`1s`** | **winner — retained** |
+
+**The positive control passes on the same element** (M5): the sweep demonstrably *can* detect a live declaration on `#add_exercise_btn`, because it detected the animation. A probe that changed nothing would have proved nothing (M6).
+
+**M6a was applied and was necessary.** `transition-property: none` is set inline *before* the class is added and released only *after* the read; the button carries a transition, so an unsuppressed read returns the pre-class value and would have reported the animation as dead too.
+
+### What beats them
+
+Both `#add_exercise_btn.btn` (`components.css:242`, `(1,1,0)`) and `.btn.btn-calm-primary` (`components.css:3154`, `(0,2,0)`) declare the same properties with `!important`. `.is-success` is `(0,1,0)` with `!important` and loses to both on specificity.
+
+⚠️ **The rendered value is neither of the two rules' colours** — the button computes to `rgb(76, 110, 245)` (the calm-primary accent), not the seafoam `#98DFD6` that `components.css:242` declares at higher specificity. That inversion is **unexplained and out of scope for this packet**; it is recorded in §7 as a finding, not acted on. It does not affect this deletion: `.is-success` loses to *both* candidates, so which of them ultimately wins cannot make a deleted non-winner live.
+
+---
+
+## 3. Product observation — surfaced, not fixed
+
+The intended "success" styling of the add-exercise button was **a green fill, green border and white text plus a green pulse ring**. Only the pulse ring has ever rendered; the three colour declarations have been inert since they were written.
+
+Deleting them changes nothing a user sees. But if the green flash is *wanted*, this packet does not deliver it — that is a deliberate product change needing its own owner decision, and it is out of scope for a pure-deletion packet. **Recorded here so the intent is not lost with the code.**
+
+---
+
+## 4. What was measured and retained
+
+Per-declaration ownership was resolved over Chrome's own `CSS.getMatchedStylesForNode` data across **11 routes × 2 themes**, under both `prefers-reduced-motion` states and under each JS-applied state.
+
+| Family | States probed | Verdict |
+|---|---|---|
+| `@media (prefers-reduced-motion: reduce)` `*` block | `reduce` | **Retained.** Winner on **17,194** element-matches (animation longhands) and **16,651** (transition longhands). The single highest-impact rule in the file. |
+| `body > .container-fluid.mt-4` (`page-enter`) | `no-preference`, `reduce` | **Retained.** Wins on all 22 contexts under `no-preference`; loses to the reduced-motion block under `reduce` — which is the intended behaviour, not deadness (M11). |
+| `.skeleton`, `[data-theme="dark"] .skeleton`, `@keyframes skeleton-shimmer` | JS-inserted skeleton (M10) | **Retained.** All 55 observed declarations win somewhere under that state. |
+| `@keyframes success-pulse` | success (M10) | **Retained** — it is the half of `.is-success` that renders. |
+| `.is-success` `animation` | success (M10) | **Retained** — proven winner. |
+
+**M11 discharged.** The `@media` block was never judged from a default-preference capture: it was captured under its own condition, where it wins, and the `page-enter` rule was captured under both conditions to confirm the suppression is real rather than assumed.
+
+### Retained, and *why* it is not redundant
+
+`[data-theme="dark"] .skeleton` re-declares `background-size: 200% 100%`, which also appears on `.skeleton`. It is **not** a duplicate: the dark rule re-declares the `background` *shorthand*, which resets `background-size` to `auto`, so the repeat is load-bearing. Deleting it would have been a visible regression in dark mode.
+
+---
+
+## 5. Gates
+
+| Gate | Result |
+|---|---|
+| Full `pytest tests/` | *(see §8)* |
+| `tests/test_css_wp4_4_motion_contracts.py` (new, 5 tests) | *(see §8)* |
+| `tests/test_css_cascade_contracts.py`, `tests/test_visual_selector_contracts.py` | run, never edited (N6) |
+| `tests/test_css_wp4_4_a_baseline_contracts.py` | run and corrected to pin the baseline to its own source commit (see §8) |
+| Windows `visual.spec.ts` — full **66**-test matrix | *(see §8)* |
+| `accessibility.spec.ts`, `ui-hardening.spec.ts`, `fatigue.spec.ts`, `fatigue-stage4-smokes.spec.ts`, `summary-pages.spec.ts`, `smoke-navigation.spec.ts`, `dark-mode.spec.ts` | *(see §8)* |
+| Harness pre/post capture, all 22 contexts | *(see §8)* |
+| Seven-surface Stylelint delta | *(see §8)* |
+| Linux deep gate | **not run** — N8 requires it at h, i, j, k only |
+| Snapshot updates | **none** — `git diff` shows zero `e2e/__screenshots__/` paths |
+
+**`visual.spec.ts` is a backstop only, not the primary proof (F1).** `prepareForScreenshot()` sets `animation-duration: 0s !important` and `transition-duration: 0s !important` globally before every capture, so it cannot falsify a change to `motion.css` — deleting the entire file would leave the matrix byte-identical. The primary proof is the ownership differential in §2 and the pre/post harness capture in §8.
+
+---
+
+## 6. Method-rule compliance
+
+| Rule | How it was satisfied |
+|---|---|
+| **M1** | Ownership resolution **and** rest-state differential **and** same-CSS control, all three. |
+| **M3** | Captures element-scoped and clipped below the fixed navbar. |
+| **M5** | Positive control passes on the element under test (`animation-*` moved). |
+| **M6** | Sentinel-took-effect asserted per record by the harness. |
+| **M6a** | Transitions suppressed before applying, reading and removing the class. Necessary here — the button carries a transition. |
+| **M8** | Only proven non-winners deleted. |
+| **M10** | `.is-success` and `.skeleton` judged **under their JS-applied states**, never at rest. |
+| **M11** | The `@media` block captured under its own condition. |
+| **N2** | `motion.css` is entirely unlayered; contract asserts it stays that way. |
+
+---
+
+## 7. Findings handed on
+
+1. **Unexplained cascade inversion on `#add_exercise_btn`** (§2). `components.css:242` declares `background-color: #98DFD6 !important` at `(1,1,0)`; `components.css:3154` declares `background: var(--accent, #4c6ef5) !important` at `(0,2,0)`. The lower-specificity rule is what renders. Both are `components.css`, so this belongs to **packet h**, which owns that surface. Worth resolving before h deletes anything in that neighbourhood.
+2. **`base.css` also defines `.skeleton`** (`base.css:93`) with `background`, `background-size` and `animation: skeleton-loading`. `motion.css` loads after `base.css` at equal specificity, so **every one of those declarations is overridden**, and `@keyframes skeleton-loading` has no live consumer. This is a **packet b** candidate — not touched here, because `base.css` is b's exclusive path.
+3. **The exploratory ownership prober's winner attribution is not authoritative.** It correctly identified the non-winners, but named a beater whose colour is not what renders (§2). It is preserved as the generated artifact `artifacts/wp4_4/ownership_probe.mjs`, not committed into the packet-a-owned `scripts/css_audit/` directory. Treat its output as **nomination-only**, exactly as the plan treats packet `g` — every nomination must be confirmed by a direct computed-style differential before deletion. Its "never wins anywhere" output was independently confirmed here; its "beaten by" output was not.
+
+---
+
+## 8. Results
+
+### Primary computed-style proof
+
+On the real `#add_exercise_btn` in both themes, with transitions suppressed per
+M6a:
+
+- adding `.is-success` left `background-color`, `color`, and all four
+  `border-*-color` longhands byte-identical;
+- `animation-name` changed `none` → `success-pulse`;
+- `animation-duration` changed `0s` → `1s`.
+
+The live animation is the same-element positive control. The three deleted paint
+declarations are therefore proven non-winners, not declarations missed by the
+probe.
+
+### Harness pre/post differential
+
+The committed Packet-a harness ran before and after the deletion over **11
+routes × 2 themes = 22 contexts**, under both reduced-motion preferences. Both
+phases passed their self-checks.
+
+| Comparison | Result |
+|---|---:|
+| motion-record differences (`reduce` + `no-preference`) | **0** |
+| element screenshot differences | **0 / 22** |
+| attributable paint-record differences | **0** |
+| raw paint-record differences | 2 |
+
+The two raw paint differences are sub-pixel `box-shadow` blur-radius movement on
+Welcome's infinitely animated `.hero-center-icon`, one per theme. That exact DOM
+path is one of the eight uncertifiable elements in
+`CSS_PHASE4_WP4_4_LINUX_INHERITED_REDS.json`; neither difference is attributable
+to this packet.
+
+### Automated gates
+
+| Gate | Result |
+|---|---|
+| Full `pytest tests/ -q` | **1,874 passed, 1 skipped** in 302.83s |
+| Packet/shared CSS contracts | **48 passed** |
+| New Packet-c contract red path | **failed as intended** against the genuine pre-deletion rule; the failure named `background-color`; passed after restoration |
+| Corrected Packet-a baseline-pin red path | **failed as intended** after corrupting recorded `motion.css` lines 71 → 72; **9 passed** after restoration |
+| Chromium functional/accessibility set | **104 passed**: `ui-hardening`, `accessibility`, `smoke-navigation`, `fatigue`, `fatigue-stage4-smokes`, `summary-pages`, and the extra `dark-mode` mechanics check |
+| Windows `visual.spec.ts` | **65 passed, 1 inherited known red** (`workout-plan desktop dark`) |
+| Snapshot/visual-helper writes | **none** |
+| Linux deep gate | **not run**, per N8 |
+
+The visual run used `PW_VISUAL_SEED=1` and reproduced only the WP4.0 animated
+Workout Plan red. Its current diff is 875 pixels, localized to the navbar GIF
+and two exercise video controls. Because that count differs from the historical
+1,039/1,046 observations, the failing case was repeated three times and then
+run once with the original `motion.css` and once with the packet change. Every
+run produced 875 pixels, and the original/changed diff PNGs are byte-identical:
+
+`sha256 0B7C76DD8D98B20195F073E03EBA13202C0EE62E941EF5A593D9131D5E1DC4E2`
+
+This is direct pre/post isolation of the inherited red, not acceptance based on
+its filename alone. An initial local invocation omitted `PW_VISUAL_SEED=1` and
+therefore exercised the intentionally empty functional DB; it was invalidated
+and rerun correctly. It changed no snapshot or protected path.
+
+### Stylelint delta
+
+The seven-surface filtered measurement moved **2,883 → 2,877 warnings (−6)**.
+`motion.css` moved **16 → 10**. The only category changes were:
+
+- `declaration-no-important`: **1,263 → 1,260 (−3)**;
+- `declaration-property-value-disallowed-list`: **1,127 → 1,124 (−3)**.
+
+Every other category and all other six shared surfaces are unchanged. Maximum
+specificity, ID count, duplicate selectors, and duplicate declarations did not
+increase.
+
+### Baseline-contract infrastructure correction
+
+The first legitimate deletion exposed a defect in Packet a's baseline pin:
+`test_wp4_4_baseline_is_pinned_and_matches_disk` compared the immutable
+Packet-a measurement to the current working tree, so every later authorized
+deletion necessarily failed it. The correction checks each surface through
+`git show <sourceCommit>:static/css/<surface>` instead. This is both the intended
+semantics and a stronger pin: editing current CSS and the baseline JSON together
+cannot satisfy it.
+
+The correction is isolated to `scripts/css_audit/measure.py` and
+`tests/test_css_wp4_4_a_baseline_contracts.py`; it does not change a measured
+value or production behavior.

--- a/docs/CSS_PHASE4_WP4_4_C_MOTION_EVIDENCE.md
+++ b/docs/CSS_PHASE4_WP4_4_C_MOTION_EVIDENCE.md
@@ -47,11 +47,39 @@ It was proven under that state, on the real element, in both themes, with M6a ap
 
 **M6a was applied and was necessary.** `transition-property: none` is set inline *before* the class is added and released only *after* the read; the button carries a transition, so an unsuppressed read returns the pre-class value and would have reported the animation as dead too.
 
-### What beats them
+### What beats them — the layered `!important` inversion (G10 / A6)
 
-Both `#add_exercise_btn.btn` (`components.css:242`, `(1,1,0)`) and `.btn.btn-calm-primary` (`components.css:3154`, `(0,2,0)`) declare the same properties with `!important`. `.is-success` is `(0,1,0)` with `!important` and loses to both on specificity.
+`.is-success` in `motion.css` is **unlayered** and `!important`, at specificity `(0,1,0)`.
 
-⚠️ **The rendered value is neither of the two rules' colours** — the button computes to `rgb(76, 110, 245)` (the calm-primary accent), not the seafoam `#98DFD6` that `components.css:242` declares at higher specificity. That inversion is **unexplained and out of scope for this packet**; it is recorded in §7 as a finding, not acted on. It does not affect this deletion: `.is-success` loses to *both* candidates, so which of them ultimately wins cannot make a deleted non-winner live.
+The declarations that actually render are `components.css:3540-3548`, which sit **inside `@layer workout`** (opened at `components.css:3539`) and are **also `!important`**:
+
+```css
+@layer workout {
+#workout[data-page="workout-plan"] .btn.btn-calm-primary,
+#workout[data-page="workout-plan"] :where(.btn).btn-calm-primary,
+#workout[data-page="workout-plan"] .modal-content.frame-calm-glass .btn.btn-calm-primary {
+  background: var(--accent, #4c6ef5) !important;
+  border: 1px solid color-mix(in srgb, var(--accent, #4c6ef5) 78%, white 22%) !important;
+  color: var(--accent-ink, #ffffff) !important;
+  …
+}
+```
+
+**In the important half of the cascade, layer order is inverted.** For normal declarations, unlayered rules beat layered ones; for `!important` declarations the ordering reverses and **unlayered `!important` is the weakest tier**, so a layered `!important` outranks every unlayered `!important` *regardless of specificity*. This is exactly the mechanism recorded as **G10** and council finding **A6** in `docs/css_phase4_wp4_4/PLANNING.md:165-170`, and it is why **N2** freezes layer membership arc-wide.
+
+`#add_exercise_btn` carries `class="btn btn-primary btn-calm-primary"` (`templates/workout_plan.html:247`) inside `<div id="workout" data-page="workout-plan">` (`:10`), so the layered block matches it on every render. **`.is-success` therefore could never win `background-color`, `border-*-color` or `color` on that element — in either theme, in any interaction state, at any specificity it could have been given.** The three deleted declarations are dead by cascade construction, not merely dead by measurement.
+
+The measured values are the layered block's own, to the digit:
+
+| Property | Winning declaration (`components.css:3540-3548`, `@layer workout`, `!important`) | Computed |
+|---|---|---|
+| `background-color` | `background: var(--accent, #4c6ef5)` | `rgb(76, 110, 245)` |
+| `color` | `color: var(--accent-ink, #ffffff)` | `rgb(255, 255, 255)` |
+| `border-*-color` | `border: 1px solid color-mix(in srgb, var(--accent, #4c6ef5) 78%, white 22%)` | `color(srgb 0.452471 0.556471 0.969412)` |
+
+The `color-mix` arithmetic checks out against the observed value: `#4c6ef5` is srgb `(0.2980, 0.4314, 0.9608)`, and `channel × 0.78 + 0.22` gives `(0.4524, 0.5562, 0.9694)`.
+
+Two unlayered rules also declare these properties with `!important` — `#add_exercise_btn.btn` (`components.css:242`, `(1,1,0)`, seafoam `#98DFD6`) and `.btn.btn-calm-primary` (`components.css:3154`, `(0,2,0)`) — and `.is-success` at `(0,1,0)` loses to both of those on specificity as well. Neither is the winner: both are unlayered `!important`, so both are outranked by the layered block. The seafoam colour at `components.css:242` does not render on this button. That is the documented behaviour of `@layer`, not an anomaly.
 
 ---
 
@@ -98,7 +126,9 @@ Per-declaration ownership was resolved over Chrome's own `CSS.getMatchedStylesFo
 | Linux deep gate | **not run** — N8 requires it at h, i, j, k only |
 | Snapshot updates | **none** — `git diff` shows zero `e2e/__screenshots__/` paths |
 
-**`visual.spec.ts` is a backstop only, not the primary proof (F1).** `prepareForScreenshot()` sets `animation-duration: 0s !important` and `transition-duration: 0s !important` globally before every capture, so it cannot falsify a change to `motion.css` — deleting the entire file would leave the matrix byte-identical. The primary proof is the ownership differential in §2 and the pre/post harness capture in §8.
+**`visual.spec.ts` is a backstop only, not the primary proof (F1).** `prepareForScreenshot()` (`e2e/visual-helpers.ts:45,47`) sets `animation-duration: 0s !important` and `transition-duration: 0s !important` globally before every capture. It therefore suppresses animation and transition **timing**, and `visual.spec.ts` **cannot by itself falsify a timing-only `motion.css` regression**.
+
+That is the whole of the claim. `motion.css` also carries non-timing paint and geometry — the `.skeleton` gradient, `background-size`, `border-radius`, and two `!important` colour declarations — so deleting the entire file would **not** be expected to leave the matrix byte-identical, and this document does not assert that it would. For Packet c specifically, the visual matrix is a backstop; the deletion's safety is established by the cascade argument and computed-style differential in §2, the per-packet contract tests, and the pre/post ownership capture in §8.
 
 ---
 
@@ -120,9 +150,10 @@ Per-declaration ownership was resolved over Chrome's own `CSS.getMatchedStylesFo
 
 ## 7. Findings handed on
 
-1. **Unexplained cascade inversion on `#add_exercise_btn`** (§2). `components.css:242` declares `background-color: #98DFD6 !important` at `(1,1,0)`; `components.css:3154` declares `background: var(--accent, #4c6ef5) !important` at `(0,2,0)`. The lower-specificity rule is what renders. Both are `components.css`, so this belongs to **packet h**, which owns that surface. Worth resolving before h deletes anything in that neighbourhood.
+1. **Observation, not a defect: the seafoam `#add_exercise_btn` paint at `components.css:242` never renders.** It is unlayered `!important` at `(1,1,0)`; the layered `!important` block at `components.css:3540-3548` outranks it under the `@layer` importance inversion (§2). **Packet h is not being asked to investigate this as an unresolved issue** — the mechanism is known, documented at G10/A6, and frozen by N2. It is noted only because `components.css:242` is a candidate that h will encounter, and h's own classification must model layers before judging it either way.
 2. **`base.css` also defines `.skeleton`** (`base.css:93`) with `background`, `background-size` and `animation: skeleton-loading`. `motion.css` loads after `base.css` at equal specificity, so **every one of those declarations is overridden**, and `@keyframes skeleton-loading` has no live consumer. This is a **packet b** candidate — not touched here, because `base.css` is b's exclusive path.
-3. **The exploratory ownership prober's winner attribution is not authoritative.** It correctly identified the non-winners, but named a beater whose colour is not what renders (§2). It is preserved as the generated artifact `artifacts/wp4_4/ownership_probe.mjs`, not committed into the packet-a-owned `scripts/css_audit/` directory. Treat its output as **nomination-only**, exactly as the plan treats packet `g` — every nomination must be confirmed by a direct computed-style differential before deletion. Its "never wins anywhere" output was independently confirmed here; its "beaten by" output was not.
+3. **The exploratory ownership prober does not model cascade-layer `!important` inversion.** That is the precise limitation, and the only one this packet observed: it ranks candidate winners by specificity and source order within the unlayered tier, so when the true winner is a layered `!important` rule it names an unlayered runner-up instead. Its non-winner identification was correct and was independently confirmed here; its **winner attribution** is unsound wherever `@layer` is in play — `components.css:3539`, `navbar.css:6`, `pages-workout-plan.css:468`/`:718`, `pages-welcome.css:6`. This is **not** a claim that its winner attribution is unreliable in general. It is preserved as the generated artifact `artifacts/wp4_4/ownership_probe.mjs`, not committed into the packet-a-owned `scripts/css_audit/` directory. Treat its output as **nomination-only**, exactly as the plan treats packet `g`: every nomination must be confirmed by a direct computed-style differential before deletion, and any packet touching a layered surface must resolve the winner with layer awareness.
+4. **Documentation drift in the Gate-1 planning artifact.** `docs/css_phase4_wp4_4/PLANNING.md:1133`, `:1416` and `:1517` still name the baseline contract by its former name, `test_wp4_4_baseline_is_pinned_and_matches_disk`. The test was renamed to `test_wp4_4_baseline_is_pinned_and_matches_its_source_commit` by this packet (§8). **`PLANNING.md` is deliberately not edited** — it is the approved Gate-1 artifact and no implementation packet may amend it. The drift is recorded here so the reference is traceable; `scripts/css_audit/emit_baseline.py` and `docs/CSS_PHASE4_WP4_4_A_BASELINE_EVIDENCE.md` were updated, since those describe the test's behaviour rather than record an approved decision.
 
 ---
 
@@ -221,3 +252,81 @@ a's merged squash commit (`46e340e`), whose seven shared CSS surfaces are
 byte-identical to the original measurement commit, and only the pytest job uses
 `fetch-depth: 0`. This preserves the strong source-commit check without a
 network operation inside pytest or a dependency on Packet a's temporary branch.
+
+---
+
+## 9. Must-retain handoff to Packet h
+
+**Packet h owns `components.css`. This is a must-retain, in the same class as
+the `.value-changed` blocks (PR#3, M10).**
+
+> **`components.css:3540-3548` — the layered `@layer workout` success-state
+> paint on `#workout[data-page="workout-plan"] .btn.btn-calm-primary` — must
+> remain, as `!important` and inside its layer, for as long as the deleted
+> `motion.css` `.is-success` fallback stays absent.** An equivalent owner
+> providing the same required paint on that element is an acceptable
+> substitute; nothing else is.
+
+**Why this is now load-bearing.** Before WP4.4-c, `.is-success` carried
+`background-color`, `border-color` and `color` as unlayered `!important`
+declarations. They never rendered — the layered block outranked them at every
+moment (§2) — but they were a latent fallback: had the layered block been
+removed or de-`!important`ed, they would have become the winners. This packet
+deleted them as proven non-winners under M8, which is correct, and which also
+means **that fallback no longer exists**.
+
+**Obligation on h.** If h removes `components.css:3540-3548`, drops its
+`!important`, moves it across a layer boundary (already forbidden by N2), or
+narrows its selector list so `#add_exercise_btn` no longer matches, then h
+must:
+
+1. re-prove the `.is-success` success state on the real `#add_exercise_btn`
+   under M6a, exactly as §2 and §8 did here;
+2. provide a replacement owner for `background-color`, `border-*-color` and
+   `color` on that element in **both** themes; and
+3. record the result in its own evidence doc.
+
+Without a replacement, the button falls back to `components.css:242`
+(seafoam `#98DFD6 !important`) or, failing that, to Bootstrap's `.btn-primary`
+— a visible change, and therefore a V1 rollback trigger, on a route the packet
+may not have captured.
+
+**A documentation handoff is deliberate here; no cross-packet test was added.**
+A contract in `tests/test_css_wp4_4_motion_contracts.py` asserting the presence
+of a `components.css` rule would make Packet c's contract file a claim on
+Packet h's exclusive production path, which N1 exists to prevent, and would red
+h's legitimate work rather than inform it. The obligation belongs in h's own
+must-retain register.
+
+---
+
+## 10. Ownership ruling — owner-authorized cross-packet corrections
+
+Three of this PR's seven files lie outside Packet c's declared ownership
+(`PLANNING.md:419`): the Packet-a measurement/test/baseline paths
+(`scripts/css_audit/measure.py`, `tests/test_css_wp4_4_a_baseline_contracts.py`,
+`docs/CSS_PHASE4_WP4_4_A_BASELINE.json`) and `.github/workflows/ci.yml`, a
+never-claimed shared path.
+
+**The owner explicitly authorized these corrections, on review, as an exception
+scoped to this PR.** Recorded terms:
+
+- The exception covers **only** the Packet-a measurement/test/baseline paths and
+  `.github/workflows/ci.yml`.
+- The changes were **necessary**, not opportunistic: Packet a's baseline contract
+  compared an immutable measurement against the working tree, so the arc's first
+  authorized deletion necessarily red it, and the corrected `git show` form could
+  not execute under Actions' default shallow checkout.
+- **No concurrent writer existed.** Packet a is merged and closed; no other packet
+  was open against these paths.
+- The authorization **does not broaden Packet c's production ownership**. Packet c
+  still owns exactly `static/css/motion.css`,
+  `tests/test_css_wp4_4_motion_contracts.py`, and this evidence document.
+- The authorization **does not permit unrelated cleanup** in the touched files, and
+  none was performed — the diffs are confined to the baseline-semantics fix, the
+  `sourceCommit` repin, and the single `fetch-depth: 0` on the pytest job.
+
+The `docs/CSS_PHASE4_WP4_4_A_BASELINE_EVIDENCE.md` and
+`scripts/css_audit/emit_baseline.py` edits in the follow-up commit fall under the
+same exception: both describe the renamed contract's behaviour and would
+otherwise document semantics the code no longer has.

--- a/docs/CSS_PHASE4_WP4_4_C_MOTION_EVIDENCE.md
+++ b/docs/CSS_PHASE4_WP4_4_C_MOTION_EVIDENCE.md
@@ -213,3 +213,11 @@ cannot satisfy it.
 The correction is isolated to `scripts/css_audit/measure.py` and
 `tests/test_css_wp4_4_a_baseline_contracts.py`; it does not change a measured
 value or production behavior.
+
+The first PR run exposed a CI-only prerequisite: Actions' default shallow
+checkout did not contain Packet a's historical source commit, so `git show`
+failed before it could measure the CSS. The baseline is now pinned to Packet
+a's merged squash commit (`46e340e`), whose seven shared CSS surfaces are
+byte-identical to the original measurement commit, and only the pytest job uses
+`fetch-depth: 0`. This preserves the strong source-commit check without a
+network operation inside pytest or a dependency on Packet a's temporary branch.

--- a/scripts/css_audit/emit_baseline.py
+++ b/scripts/css_audit/emit_baseline.py
@@ -2,8 +2,10 @@
 
 F13 converts "no later packet may inherit a projection as fact" from prose into
 a gate: every number packets b–k cite must appear in this file, and
-`test_wp4_4_baseline_is_pinned_and_matches_disk` re-derives the per-surface line
-counts from disk so a stale baseline reds pytest rather than passing quietly.
+`test_wp4_4_baseline_is_pinned_and_matches_its_source_commit` re-derives the
+per-surface line counts from the surfaces **as committed at `sourceCommit`** —
+not from the working tree — so a stale baseline reds pytest rather than passing
+quietly, while a later packet's authorized deletion does not.
 
 usage:
     python -m scripts.css_audit.emit_baseline [--stylelint artifacts/wp4_4/stylelint_surfaces.json]

--- a/scripts/css_audit/measure.py
+++ b/scripts/css_audit/measure.py
@@ -81,7 +81,17 @@ def surface_counts(filename: str) -> dict[str, int]:
     `theme-dark.css:595` carries the literal text "Zero !important." inside a
     comment, which is why the raw units over-count by exactly one arc-wide.
     """
-    text = (CSS_DIR / filename).read_text(encoding="utf-8")
+    return counts_from_text((CSS_DIR / filename).read_text(encoding="utf-8"))
+
+
+def counts_from_text(text: str) -> dict[str, int]:
+    """The same measurement, over arbitrary text rather than a file on disk.
+
+    Split out so a baseline can be checked against the surfaces **as they were
+    at the commit it was measured at**, which is the only claim a baseline
+    actually makes. Comparing it to HEAD instead couples it to every later
+    packet, and the first legitimate deletion in the arc reds it.
+    """
     code = _blank_comments(text)
     lines = text.splitlines()
 
@@ -92,6 +102,18 @@ def surface_counts(filename: str) -> dict[str, int]:
         "importantOccurrences": len(IMPORTANT_RE.findall(text)),
         "importantDeclarations": len(IMPORTANT_RE.findall(code)),
     }
+
+
+def surface_text_at(commit: str, filename: str) -> str:
+    """`static/css/<filename>` as committed at ``commit``."""
+    return subprocess.run(
+        ["git", "show", f"{commit}:static/css/{filename}"],
+        cwd=ROOT,
+        capture_output=True,
+        text=True,
+        encoding="utf-8",
+        check=True,
+    ).stdout
 
 
 # --------------------------------------------------------------------------

--- a/static/css/motion.css
+++ b/static/css/motion.css
@@ -63,9 +63,11 @@ body > .container-fluid.mt-4 {
   100% { box-shadow: 0 0 0 0 rgba(16, 185, 129, 0); }
 }
 
+/* `.is-success` is applied by JS to `#add_exercise_btn` only, for 1000ms after
+   a successful add (workout-plan-add-exercise.js:275-278). Only the animation
+   ever rendered: the fill, border and text colours were beaten on that element
+   in both themes and were removed by WP4.4-c as proven non-winners. The green
+   pulse ring the animation draws is unaffected. */
 .is-success {
   animation: success-pulse 1s var(--ease-out, ease) !important;
-  background-color: var(--success, #10b981) !important;
-  border-color: color-mix(in srgb, var(--success, #10b981) 80%, white 20%) !important;
-  color: #ffffff !important;
 }

--- a/tests/test_css_wp4_4_a_baseline_contracts.py
+++ b/tests/test_css_wp4_4_a_baseline_contracts.py
@@ -54,28 +54,38 @@ def _baseline() -> dict:
     return json.loads(BASELINE_PATH.read_text(encoding="utf-8"))
 
 
-def test_wp4_4_baseline_is_pinned_and_matches_disk() -> None:
-    """The baseline's per-surface counts equal the files as they are now.
+def test_wp4_4_baseline_is_pinned_and_matches_its_source_commit() -> None:
+    """The baseline's per-surface counts equal the surfaces AT ITS OWN COMMIT.
 
     This is the gate that makes "no later packet may inherit a projection as
     fact" mechanical. Plan v1 projected 2,681 Stylelint warnings across the
     seven surfaces and 1,787 for components.css; the measured values are 2,883
     and 1,989. Prose could not have caught that.
+
+    Checked against `sourceCommit` rather than the working tree. A baseline
+    claims "these were the counts when I measured them", and that is what makes
+    it citable; comparing it to HEAD instead couples it to every later packet,
+    so the arc's first legitimate deletion reds it — WP4.4-c hit exactly that
+    and fixed the semantics here. The `git show` form is also the stronger
+    check: it cannot be satisfied by editing the CSS and the JSON together.
     """
     baseline = _baseline()
 
     assert baseline["packet"] == "WP4.4-a"
-    assert re.fullmatch(r"[0-9a-f]{40}", baseline["sourceCommit"])
+    commit = baseline["sourceCommit"]
+    assert re.fullmatch(r"[0-9a-f]{40}", commit)
 
+    total = 0
     for name in SEVEN_SURFACES:
         recorded = baseline["surfaces"][name]
-        on_disk = measure.surface_counts(name)
-        assert recorded["lines"] == on_disk["lines"], name
-        assert recorded["importantDeclarations"] == on_disk["importantDeclarations"], name
+        at_commit = measure.counts_from_text(measure.surface_text_at(commit, name))
+        assert recorded["lines"] == at_commit["lines"], name
+        assert (
+            recorded["importantDeclarations"] == at_commit["importantDeclarations"]
+        ), name
+        total += at_commit["lines"]
 
-    assert baseline["totals"]["sharedSurfaceLines"] == sum(
-        measure.surface_counts(name)["lines"] for name in SEVEN_SURFACES
-    )
+    assert baseline["totals"]["sharedSurfaceLines"] == total
 
 
 def test_important_is_counted_in_reconcilable_units() -> None:

--- a/tests/test_css_wp4_4_a_baseline_contracts.py
+++ b/tests/test_css_wp4_4_a_baseline_contracts.py
@@ -6,9 +6,12 @@ consolidation at WP4.4-k). This file is owned by packet **a** alone.
 Three things are locked here:
 
 * **F13** — packets b-k cite `docs/CSS_PHASE4_WP4_4_A_BASELINE.json` instead of
-  quoting projections. The pin re-derives the per-surface line counts from disk,
-  so a baseline that has drifted from the code reds pytest rather than being
-  quietly inherited as fact.
+  quoting projections. The pin re-derives the per-surface line counts from the
+  surfaces **as they were at the baseline's own `sourceCommit`**, so a baseline
+  whose recorded numbers never matched the code it claims to describe reds
+  pytest rather than being quietly inherited as fact. It deliberately does not
+  compare against the working tree: that would couple an immutable measurement
+  to every later packet and red on the arc's first authorized deletion.
 * **F12** — V2 ("no rebaseline") and R3 condition 6 were honour-system. A
   manifest over the committed screenshot trees turns an accidental
   `--update-snapshots` into a pytest red, instead of a Playwright green.
@@ -21,6 +24,7 @@ from __future__ import annotations
 import hashlib
 import json
 import re
+import subprocess
 from pathlib import Path
 
 from scripts.css_audit import measure, specificity
@@ -74,6 +78,22 @@ def test_wp4_4_baseline_is_pinned_and_matches_its_source_commit() -> None:
     assert baseline["packet"] == "WP4.4-a"
     commit = baseline["sourceCommit"]
     assert re.fullmatch(r"[0-9a-f]{40}", commit)
+
+    # The pin is only meaningful if the commit is in this history. `main` is not
+    # checked by name: a worktree or a detached CI checkout has no local `main`.
+    # This also fails readably, before `git show` raises CalledProcessError on a
+    # missing object or a shallow clone.
+    ancestry = subprocess.run(
+        ["git", "merge-base", "--is-ancestor", commit, "HEAD"],
+        cwd=ROOT,
+        capture_output=True,
+        text=True,
+    )
+    assert ancestry.returncode == 0, (
+        f"baseline sourceCommit {commit} is not an ancestor of HEAD. A baseline "
+        f"pinned to a pre-squash branch commit passes locally and dies on a "
+        f"fresh clone; re-pin it to the merged commit. {ancestry.stderr.strip()}"
+    )
 
     total = 0
     for name in SEVEN_SURFACES:

--- a/tests/test_css_wp4_4_motion_contracts.py
+++ b/tests/test_css_wp4_4_motion_contracts.py
@@ -1,0 +1,112 @@
+"""WP4.4-c contracts — `static/css/motion.css` after the dead-paint deletion.
+
+Per-packet contract file (owner ruling N1). Owned by packet **c** alone.
+
+WP4.4-c deleted exactly three declarations, all from `.is-success`, all proven
+non-winners on the only element that ever carries that class. Everything else in
+`motion.css` was measured and retained, so this file pins both halves: what went,
+and what may not go with it.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+MOTION = (ROOT / "static" / "css" / "motion.css").read_text(encoding="utf-8")
+
+
+def _rule_body(selector: str, css: str = MOTION) -> str:
+    """Return the declaration block for a top-level rule, by exact selector."""
+    match = re.search(
+        rf"(?m)^{re.escape(selector)}\s*\{{(.*?)\n\}}", css, re.DOTALL
+    )
+    assert match, f"rule {selector!r} not found in motion.css"
+    return match.group(1)
+
+
+def test_is_success_keeps_only_the_declaration_that_wins() -> None:
+    """The three deleted declarations never rendered; the animation always did.
+
+    `.is-success` is added by `workout-plan-add-exercise.js:275-278` to
+    `#add_exercise_btn` and to nothing else. On that element, in both themes,
+    adding the class moved `animation-name` and `animation-duration` but left
+    `background-color`, `color` and all four `border-*-color` byte-identical —
+    they were beaten by `!important` rules at higher specificity. Deleting a
+    non-winner cannot change a computed value (M8).
+    """
+    body = _rule_body(".is-success")
+
+    assert "animation: success-pulse 1s var(--ease-out, ease) !important;" in body
+
+    for deleted in ("background-color", "border-color", "color:"):
+        assert deleted not in body, f"{deleted} was proven dead and must stay deleted"
+
+    # Exactly one declaration remains.
+    declarations = [line for line in body.split(";") if line.strip()]
+    assert len(declarations) == 1, declarations
+
+
+def test_success_pulse_keyframes_are_retained() -> None:
+    """The animation is the half of `.is-success` that renders.
+
+    It draws the green pulse ring through `box-shadow`. Deleting the fill
+    colours must not be read as a licence to delete the effect itself.
+    """
+    assert "@keyframes success-pulse {" in MOTION
+    assert MOTION.count("success-pulse") == 2  # the keyframes plus its one use
+
+
+def test_reduced_motion_suppression_is_intact() -> None:
+    """The accessibility guarantee, and the highest-impact rule in the file.
+
+    Measured winner on **17,194** element-matches for the animation longhands
+    and **16,651** for the transition longhands across the 11 rendered routes in
+    both themes. It is also what makes `body > .container-fluid.mt-4` stop
+    animating under `prefers-reduced-motion: reduce` — the M11 capture proved
+    that rule loses to this one, which is the intended behaviour.
+    """
+    assert "@media (prefers-reduced-motion: reduce) {" in MOTION
+
+    block = re.search(
+        r"@media \(prefers-reduced-motion: reduce\) \{(.*?)\n\}", MOTION, re.DOTALL
+    )
+    assert block, "reduced-motion block missing"
+    assert "animation: none !important;" in block.group(1)
+    assert "transition: none !important;" in block.group(1)
+    assert "*," in block.group(1)
+    assert "*::before," in block.group(1)
+    assert "*::after" in block.group(1)
+
+
+def test_page_enter_and_skeleton_families_are_retained() -> None:
+    """Everything else in the file was measured live and stays.
+
+    `page-enter` wins on the main wrapper on all 11 routes under
+    `no-preference`. The `.skeleton` families are JS-inserted loading
+    placeholders (M10) and win under that state, including the dark override.
+    """
+    assert "@keyframes page-enter {" in MOTION
+    assert "body > .container-fluid.mt-4 {" in MOTION
+    assert "animation: page-enter var(--dur-slow, 360ms)" in MOTION
+
+    assert "@keyframes skeleton-shimmer {" in MOTION
+    assert re.search(r"(?m)^\.skeleton \{", MOTION)
+    assert '[data-theme="dark"] .skeleton {' in MOTION
+
+    # The dark override re-declares `background`, which resets `background-size`
+    # to its initial value — so the repeat is required, not redundant.
+    dark = _rule_body('[data-theme="dark"] .skeleton')
+    assert "background:" in dark
+    assert "background-size: 200% 100%;" in dark
+
+
+def test_motion_css_declares_no_layer() -> None:
+    """N2 freezes `@layer` membership arc-wide.
+
+    `motion.css` is entirely unlayered, which is what lets the packet's
+    ownership reasoning use plain specificity ordering.
+    """
+    assert "@layer" not in MOTION


### PR DESCRIPTION
## Summary

- delete the three cascade-dead paint declarations from `.is-success` while retaining the live `success-pulse` animation
- add the permanent WP4.4-c contract and evidence artifact
- correct the WP4.4-a baseline pin so it verifies CSS at the baseline's own `sourceCommit`, rather than failing every later authorized deletion

## Why

`.is-success` is applied only to `#add_exercise_btn`. On that real element in both themes, higher-specificity important button rules always beat its background, border, and text colors. The animation remains a same-element positive control and still renders.

The first legitimate deletion also exposed an infrastructure defect: the supposedly immutable Packet-a baseline test compared its counts to the current working tree. It now reads each surface with `git show <sourceCommit>:static/css/<surface>`, which verifies the claim the baseline actually makes and cannot be satisfied by editing current CSS plus the JSON together.

## Impact

No visible behavior changes. The green pulse ring is retained; the green fill/border/text had never rendered. If that fill flash is desired, it requires a separate product decision.

Migration notes: none. No calculation logic, database schema, API response shape, templates, JavaScript, snapshots, or generated Bootstrap changed.

## Validation

- `pytest tests/ -q`: **1,874 passed, 1 skipped**
- Packet/shared CSS contracts: **48 passed**; both new red paths proven before restoration
- Chromium functional/accessibility set: **104 passed**
- Windows visual matrix: **65 passed + 1 inherited animated-frame red**; original and changed `motion.css` produced byte-identical diff PNGs (`0B7C76DD8D98B20195F073E03EBA13202C0EE62E941EF5A593D9131D5E1DC4E2`)
- Packet-a harness: **22 contexts**, 0 motion differences, 0 element screenshot differences, 0 attributable paint differences
- seven-surface Stylelint: **2,883 → 2,877**; `motion.css` **16 → 10**; no category increased
- snapshot and visual-helper changes: **none**