### PR TITLE
tooling(hooks): harden the destructive-command guard and add state reconciliation

### DIFF
--- a/.claude/agents/automation-qa.md
+++ b/.claude/agents/automation-qa.md
@@ -10,15 +10,15 @@ hooks:
     - matcher: "Edit|Write"
       hooks:
         - type: command
-          command: "powershell -NoProfile -ExecutionPolicy Bypass -File .claude/hooks/guard-test-write.ps1"
+          command: 'powershell -NoProfile -ExecutionPolicy Bypass -File "${CLAUDE_PROJECT_DIR}/.claude/hooks/guard-test-write.ps1"'
     - matcher: "Bash|PowerShell"
       hooks:
         - type: command
-          command: "powershell -NoProfile -ExecutionPolicy Bypass -File .claude/hooks/guard-destructive-command.ps1"
+          command: 'powershell -NoProfile -ExecutionPolicy Bypass -File "${CLAUDE_PROJECT_DIR}/.claude/hooks/guard-destructive-command.ps1"'
     - matcher: "Skill"
       hooks:
         - type: command
-          command: "powershell -NoProfile -ExecutionPolicy Bypass -File .claude/hooks/guard-skill.ps1 -AllowedCsv run-tests,run-e2e,verify-suite"
+          command: 'powershell -NoProfile -ExecutionPolicy Bypass -File "${CLAUDE_PROJECT_DIR}/.claude/hooks/guard-skill.ps1" -AllowedCsv run-tests,run-e2e,verify-suite'
 ---
 
 You independently translate approved acceptance criteria into tests.

--- a/.claude/agents/product-manager.md
+++ b/.claude/agents/product-manager.md
@@ -10,11 +10,11 @@ hooks:
     - matcher: "Edit|Write"
       hooks:
         - type: command
-          command: "powershell -NoProfile -ExecutionPolicy Bypass -File .claude/hooks/guard-planning-write.ps1"
+          command: 'powershell -NoProfile -ExecutionPolicy Bypass -File "${CLAUDE_PROJECT_DIR}/.claude/hooks/guard-planning-write.ps1"'
     - matcher: "Skill"
       hooks:
         - type: command
-          command: "powershell -NoProfile -ExecutionPolicy Bypass -File .claude/hooks/guard-skill.ps1 -AllowedCsv requirements"
+          command: 'powershell -NoProfile -ExecutionPolicy Bypass -File "${CLAUDE_PROJECT_DIR}/.claude/hooks/guard-skill.ps1" -AllowedCsv requirements'
 ---
 
 You own the active feature's planning document, not the implementation.

--- a/.claude/agents/senior-developer.md
+++ b/.claude/agents/senior-developer.md
@@ -23,11 +23,11 @@ hooks:
     - matcher: "Bash|PowerShell"
       hooks:
         - type: command
-          command: "powershell -NoProfile -ExecutionPolicy Bypass -File .claude/hooks/guard-destructive-command.ps1"
+          command: 'powershell -NoProfile -ExecutionPolicy Bypass -File "${CLAUDE_PROJECT_DIR}/.claude/hooks/guard-destructive-command.ps1"'
     - matcher: "Skill"
       hooks:
         - type: command
-          command: "powershell -NoProfile -ExecutionPolicy Bypass -File .claude/hooks/guard-skill.ps1 -AllowedCsv run-tests,run-e2e,verify-suite,verify-and-polish,verify,run,build-css,run-hypertrophy-toolbox"
+          command: 'powershell -NoProfile -ExecutionPolicy Bypass -File "${CLAUDE_PROJECT_DIR}/.claude/hooks/guard-skill.ps1" -AllowedCsv run-tests,run-e2e,verify-suite,verify-and-polish,verify,run,build-css,run-hypertrophy-toolbox'
 ---
 
 You are the sole production-code writer for an approved feature.

--- a/.claude/commands/status.md
+++ b/.claude/commands/status.md
@@ -1,0 +1,79 @@
+---
+description: Reconcile every status-claiming document against git/PR ground truth and print a drift table. Read-only; never starts work.
+---
+
+Establish where the work actually stands **before** any packet is dispatched.
+
+Agents have twice been sent at work that was already done — WP3.5 (shipped, but
+the plan doc carried no completion note) and WP4.3g (duplicated while an open PR
+existed). This repo keeps **three** documents that each claim to describe
+current state, and they drift apart from each other and from git. Treat all
+three as claims to be checked, never as the answer.
+
+## Rules
+- **Disk beats memory.** Session memory, handover docs, `ACTIVE_DEVELOPMENT.md`
+  and every `*_EVIDENCE.md` are claims. `git` and `gh` are the evidence.
+- **The plan doc is the plan.** Determine the next step from the canonical plan
+  and the active feature's `PLANNING.md`. Never infer it from an evidence doc —
+  those record what happened, not what is next.
+- **Read-only.** This command edits nothing, pushes nothing, starts nothing.
+- **Scope the table.** Do not attempt to re-verify every historical packet;
+  `git log -20` cannot substantiate a claim about a packet from three months
+  ago. Cover packets that are active, ongoing, owner-gated, or proposed-next,
+  then look up SHAs and PRs for exactly those.
+
+## Steps
+1. Ground truth:
+   ```
+   git status --short --branch
+   git fetch --quiet origin
+   git log --oneline -20
+   git log --oneline origin/main..HEAD      # local-only commits
+   git log --oneline HEAD..origin/main      # unpulled commits
+   git worktree list
+   git branch -a --format='%(refname:short) %(upstream:track)'
+   gh pr list --state open --limit 20 --json number,title,headRefName,isDraft,mergeStateStatus,reviewDecision
+   ```
+2. For **each** worktree from `git worktree list`, check whether it holds
+   uncommitted or unintegrated work — `git worktree list` alone will not show
+   this:
+   ```
+   git -C <worktree> status --short --branch
+   git -C <worktree> log --oneline origin/main..HEAD
+   ```
+3. For any open PR that a packet depends on, establish whether it is actually
+   mergeable — draft state and check results, not just existence:
+   ```
+   gh pr checks <number>
+   ```
+4. Read the status-claiming documents and record **what each one asserts**,
+   without adopting any of them:
+   - `docs/REFACTOR_PLAN.md` — shipped-packet table near the top, and the
+     **Owner review status table** near the bottom.
+   - `docs/MASTER_HANDOVER.md` — CLAUDE.md calls this canonical; it has
+     nonetheless carried self-contradictory sections.
+   - `docs/ACTIVE_DEVELOPMENT.md` — declares itself the execution source of
+     truth for autonomous sessions.
+   - The active feature's `PLANNING.md`. Find it rather than assuming a path.
+     Identify it from what the live state already points at — the plan doc's
+     Ongoing row, the open PR's branch and body, and the handover's current
+     block usually name it outright. Only fall back to recent history
+     (`git log --diff-filter=AM --name-only -15 -- 'docs/**/PLANNING.md'`) if
+     none of those resolve it; a long-running plan may not have been touched in
+     the last commits, so recency alone can point at the wrong document.
+5. Print one table, most-actionable first:
+
+   | Packet | Claimed by (doc → status) | Git evidence (SHA / PR / worktree) | DRIFT | Next action |
+
+   Raise **DRIFT** for any of: a doc claim with no git evidence; shipped work no
+   doc records; two documents that disagree with each other; or a packet with a
+   worktree or open PR that the docs describe as not started.
+6. Close with: the single next step, every owner gate standing in front of it,
+   any document that needs correcting, and any stale worktree or branch worth
+   retiring.
+7. **Stop.** Do not begin a packet until the owner confirms the table.
+
+## Permissions
+This command needs `gh pr list`, `gh pr checks`, `git fetch` and `git -C …
+status`. If any prompt for approval, that is expected on first run — approve
+them once rather than narrowing the reconciliation.

--- a/.claude/hooks/guard-destructive-command.ps1
+++ b/.claude/hooks/guard-destructive-command.ps1
@@ -1,20 +1,616 @@
-$inputJson = [Console]::In.ReadToEnd() | ConvertFrom-Json
-$command = [string]$inputJson.tool_input.command
+﻿<#
+PreToolUse guard for Bash/PowerShell tool calls.
 
-$blockedPatterns = @(
-    '(?i)\bgit\s+push\b',
-    '(?i)\bgit\s+merge\b',
-    '(?i)\bgit\s+reset\s+--hard\b',
-    '(?i)\bgit\s+clean\s+-[^\s]*f',
-    '(?i)(^|[;&|]\s*)rm\s+-[^\s]*r[^\s]*f',
-    '(?i)\bRemove-Item\b[^\r\n]*\s-Recurse\b'
+Outcomes (Claude Code PreToolUse contract):
+  deny  -> exit 2. The ONLY exit code that blocks. Every other code, including
+           1, is non-blocking, so any internal failure here must also exit 2.
+  ask   -> permissionDecision JSON on stdout, exit 0. Owner confirms. In
+           bypassPermissions, where Claude Code skips prompts, ask-tier
+           operations are denied instead of silently proceeding.
+  allow -> exit 0, silent.
+
+Profiles:
+  agent (default) - charter contract: subagents never push or merge.
+  main            - the owner pushes and merges, so those are allowed; every
+                    filesystem-destructive verb still applies.
+
+THIS FILE MUST STAY PURE ASCII AND KEEP ITS UTF-8 BOM.
+Windows PowerShell 5.1 decodes a BOM-less .ps1 as CP1252. A UTF-8 em dash
+(E2 80 94) then becomes U+201D, which PowerShell accepts as a string delimiter,
+producing a parser error, exit code 1, and a guard that silently fails open.
+tests/test_guard_destructive_command.py pins this.
+
+Contract: confidently classified, or denied. Syntax this guard cannot parse
+(unbalanced quoting, base64 -EncodedCommand, nesting past depth 4) denies.
+
+Substring regexes were tried first and leaked: rm -fr, rm -r -f, leading
+whitespace, sudo rm -rf, git -C <path> clean -fdx, git clean --force -d, and
+git checkout -fq, while blocking the harmless git merge-base. This version
+tokenizes with quote awareness, strips wrapper prefixes and their options,
+resolves the git subcommand past global options, follows delegated execution
+into the command string, and evaluates EVERY position of EVERY segment before
+deciding.
+
+Two deliberate limitations, documented so they are not mistaken for oversights:
+
+  * Script FILES are not gated. `bash run.sh` and `powershell -File x.ps1` run
+    contents this guard cannot read, but so do `python foo.py`, `node x.js` and
+    `npm run x`. Gating only the two shells would break this repo's own
+    scripts/*.ps1 tooling and buy consistency of appearance, not of protection.
+  * Only two shell grammars are modelled, and only partially. This is a speed
+    bump in front of honest mistakes, backed by the deny list in
+    .claude/settings.json. It is not a sandbox and must not be described as one.
+#>
+param(
+    [ValidateSet('agent', 'main')]
+    [string]$GuardProfile = 'agent'
 )
 
-foreach ($pattern in $blockedPatterns) {
-    if ($command -match $pattern) {
-        Write-Error "Blocked destructive command by agent-local guard"
-        exit 2
+$ErrorActionPreference = 'Stop'
+
+# Wrappers that delegate to the real command.
+$prefixes = @('sudo', 'doas', 'command', 'time', 'nice', 'nohup', 'env', 'builtin', 'exec', 'setsid')
+# Wrapper options that consume a following value token.
+$prefixValueFlags = @('-u', '-g', '-p', '-C', '-t', '-r', '-h', '--user', '--group', '--prompt', '--chdir')
+
+# git global options consumed before the subcommand.
+$gitOptsWithValue = @('-C', '-c', '--git-dir', '--work-tree', '--namespace', '--exec-path', '--config-env')
+$gitOptsBare = @('--no-pager', '--paginate', '--bare', '--literal-pathspecs', '--no-replace-objects', '--no-optional-locks')
+
+$rmFamily = @('rm', 'del', 'erase', 'rd', 'rmdir', 'remove-item', 'ri')
+
+# Programs that execute a command string given to them. Their argument has to be
+# scanned too, or `sh -c "rm -rf tmp"` reads as a harmless call to `sh`.
+$posixShells = @('sh', 'bash', 'zsh', 'dash', 'ksh', 'ash')
+$psShells = @('powershell', 'pwsh')
+# `xargs` deliberately absent: it takes a plain command, not a command string,
+# so the every-position scan already reaches the verb in `xargs -I {} rm -rf {}`.
+$shellDelegators = $posixShells + $psShells + @('cmd', 'eval')
+$maxDelegationDepth = 4
+
+# Fields that may carry an executable command, in preference order.
+$commandFields = @('command', 'script', 'code', 'cmd', 'input')
+
+function Split-Segments([string]$text) {
+    # Quote-aware split into segments (on unquoted ; && || | & newline) and
+    # tokens (on unquoted whitespace). Quote characters are removed, so a
+    # quoted executable path containing spaces survives as one token.
+    $segments = New-Object System.Collections.ArrayList
+    $tokens = New-Object System.Collections.ArrayList
+    $buffer = New-Object System.Text.StringBuilder
+    $quote = [char]0
+
+    function Complete-Token {
+        if ($buffer.Length -gt 0) {
+            [void]$tokens.Add($buffer.ToString())
+            [void]$buffer.Clear()
+        }
+    }
+    function Complete-Segment {
+        Complete-Token
+        if ($tokens.Count -gt 0) {
+            [void]$segments.Add(@($tokens.ToArray()))
+            [void]$tokens.Clear()
+        }
+    }
+
+    foreach ($ch in $text.ToCharArray()) {
+        if ($quote -ne [char]0) {
+            if ($ch -eq $quote) { $quote = [char]0 } else { [void]$buffer.Append($ch) }
+            continue
+        }
+        if ($ch -eq '"' -or $ch -eq "'") { $quote = $ch; continue }
+        if ($ch -eq ';' -or $ch -eq '&' -or $ch -eq '|' -or $ch -eq "`n" -or $ch -eq "`r") {
+            Complete-Segment
+            continue
+        }
+        if ([char]::IsWhiteSpace($ch)) { Complete-Token; continue }
+        [void]$buffer.Append($ch)
+    }
+    Complete-Segment
+    return , $segments.ToArray()
+}
+
+function Get-BareName([string]$token) {
+    $name = $token
+    if ($name.Contains('/') -or $name.Contains('\')) {
+        $name = $name.Substring([Math]::Max($name.LastIndexOf('/'), $name.LastIndexOf('\')) + 1)
+    }
+    return ($name -replace '\.(exe|cmd|bat|ps1)$', '').ToLowerInvariant()
+}
+
+function Remove-Wrappers([string[]]$tokens) {
+    $i = 0
+    while ($i -lt $tokens.Count) {
+        $t = $tokens[$i]
+        if ($t -match '^[A-Za-z_][A-Za-z0-9_]*=') { $i++; continue }
+        if ($prefixes -notcontains (Get-BareName $t)) { break }
+        $i++
+        while ($i -lt $tokens.Count -and $tokens[$i] -match '^-') {
+            if ($prefixValueFlags -contains $tokens[$i]) { $i += 2 } else { $i++ }
+        }
+    }
+    if ($i -ge $tokens.Count) { return @() }
+    return @($tokens[$i..($tokens.Count - 1)])
+}
+
+function Test-DryRun([string[]]$tokens) {
+    foreach ($t in $tokens) {
+        if ($t -match '^(--dry-run|--whatif|-WhatIf|-n)$') { return $true }
+    }
+    return $false
+}
+
+function Test-ShortFlag([string]$token, [string]$letter) {
+    # Bundled unix short flag anywhere in the cluster: -f, -fdx, -qf.
+    # Excludes PowerShell-style single-dash words such as -Force or -Recurse.
+    if ($token -cmatch '^-[a-zA-Z]+$' -and $token -cnotmatch '^-[A-Z][a-z]{2,}$') {
+        return $token.Substring(1).Contains($letter)
+    }
+    return $false
+}
+
+function Get-PsParameter([string]$token) {
+    # PowerShell parameters may be abbreviated to any unambiguous prefix and may
+    # carry an explicit switch value: -Rec, -Fo, -Recurse:$true, -Force:$false.
+    if ($token -notmatch '^-([A-Za-z]+)(?::(.*))?$') { return $null }
+    return @{
+        Name     = $matches[1].ToLowerInvariant()
+        HasValue = $token.Contains(':')
+        Value    = $matches[2]
     }
 }
 
-exit 0
+function Test-PsSwitchOn($param) {
+    # Conservative: a switch is ON unless it is explicitly given a false value.
+    # Anything unrecognised (a variable, an expression) is treated as ON.
+    if (-not $param.HasValue) { return $true }
+    $value = ($param.Value -replace '^\$', '').ToLowerInvariant()
+    return -not ($value -eq 'false' -or $value -eq '0')
+}
+
+function Get-RmFlags([string[]]$tokens, [string]$verb) {
+    $recursive = $false
+    $force = $false
+    # cmd.exe deletion commands take slash-flags: rmdir /s /q, del /f /s /q.
+    # Only parsed for those verbs, because `/s` after POSIX `rm` is a path.
+    $slashFlagVerbs = @('del', 'erase', 'rd', 'rmdir')
+    foreach ($t in $tokens) {
+        if ($slashFlagVerbs -contains $verb -and $t -match '^/[a-zA-Z]+$') {
+            $letters = $t.Substring(1).ToLowerInvariant()
+            if ($letters.Contains('s')) { $recursive = $true }
+            if ($letters.Contains('q') -or $letters.Contains('f')) { $force = $true }
+            continue
+        }
+        $psParam = Get-PsParameter $t
+        if ($null -ne $psParam) {
+            $handled = $true
+            if ('recurse'.StartsWith($psParam.Name)) {
+                if (Test-PsSwitchOn $psParam) { $recursive = $true }
+            }
+            elseif ('force'.StartsWith($psParam.Name)) {
+                if (Test-PsSwitchOn $psParam) { $force = $true }
+            }
+            elseif ($psParam.Name.Length -ge 2 -and 'confirm'.StartsWith($psParam.Name)) {
+                # -Confirm:$false suppresses the prompt, which is what -Force does.
+                if (-not (Test-PsSwitchOn $psParam)) { $force = $true }
+            }
+            else { $handled = $false }
+            if ($handled) { continue }
+        }
+        if ($t -match '^--recursive$') { $recursive = $true; continue }
+        if ($t -match '^--force$') { $force = $true; continue }
+        if ($t -match '^--no-preserve-root$') { $force = $true; continue }
+        if ((Test-ShortFlag $t 'r') -or (Test-ShortFlag $t 'R')) { $recursive = $true }
+        if (Test-ShortFlag $t 'f') { $force = $true }
+    }
+    return @{ Recursive = $recursive; Force = $force }
+}
+
+function Get-GitSubcommand([string[]]$tokens) {
+    $i = 1
+    while ($i -lt $tokens.Count) {
+        $t = $tokens[$i]
+        if ($gitOptsWithValue -contains $t) { $i += 2; continue }
+        if ($t -match '^(--git-dir|--work-tree|--namespace|--exec-path|--config-env)=') { $i++; continue }
+        if ($gitOptsBare -contains $t) { $i++; continue }
+        if ($t -match '^-') { $i++; continue }
+        # Two statements: see the note in Get-Delegation about single-element
+        # arrays unrolling to scalars through if-statement output.
+        $rest = @()
+        if ($i + 1 -lt $tokens.Count) { $rest = @($tokens[($i + 1)..($tokens.Count - 1)]) }
+        return @{ Name = $t.ToLowerInvariant(); Rest = $rest }
+    }
+    return $null
+}
+
+function Test-AnyForce([string[]]$tokens) {
+    foreach ($t in $tokens) {
+        if ($t -eq '--force' -or (Test-ShortFlag $t 'f')) { return $true }
+    }
+    return $false
+}
+
+function Get-VerbCandidates([string]$token) {
+    # Both readings of the program name, because they disagree on escapes:
+    # `r\m` is a path whose basename is `m`, but Bash reads the backslash as an
+    # escape and runs `rm`. Anything matching EITHER reading is treated as that
+    # program. `/bin/rm` and `"C:\...\rm.exe"` still resolve through the path
+    # reading.
+    $candidates = New-Object System.Collections.ArrayList
+    [void]$candidates.Add((Get-BareName $token))
+    # Bash ANSI-C quoting: the tokenizer strips the quotes from `$'rm'`, leaving
+    # a leading `$` that the shell never passes to exec.
+    $bare = $token -replace '^\$', ''
+    $unescaped = $bare -replace '\\', ''
+    foreach ($form in @($bare, $unescaped)) {
+        if ($form -ne $token) {
+            [void]$candidates.Add((Get-BareName $form))
+            [void]$candidates.Add($form.ToLowerInvariant())
+        }
+    }
+    return $candidates.ToArray()
+}
+
+function Test-QuotesBalanced([string]$text) {
+    $quote = [char]0
+    foreach ($ch in $text.ToCharArray()) {
+        if ($quote -ne [char]0) {
+            if ($ch -eq $quote) { $quote = [char]0 }
+            continue
+        }
+        if ($ch -eq '"' -or $ch -eq "'") { $quote = $ch }
+    }
+    return ($quote -eq [char]0)
+}
+
+function Get-Delegation([string[]]$tokens) {
+    # Returns how to treat a program that runs another command:
+    #   script -> the nested command string, to be scanned recursively
+    #   deny   -> the nested command cannot be recovered (base64)
+    #   ask    -> an opaque script file is being executed
+    #   $null  -> not a delegator
+    $verbs = Get-VerbCandidates $tokens[0]
+    $shell = $null
+    foreach ($v in $verbs) {
+        if ($shellDelegators -contains $v) { $shell = $v; break }
+    }
+    if ($null -eq $shell) { return $null }
+
+    $printable = $tokens -join ' '
+    # Assigned in two statements on purpose: `$x = if (...) { @($a[1..1]) }`
+    # unrolls a one-element array to a scalar string through the if-statement's
+    # output, after which $x[0] indexes a CHARACTER instead of the token.
+    $rest = @()
+    if ($tokens.Count -gt 1) { $rest = @($tokens[1..($tokens.Count - 1)]) }
+
+    foreach ($t in $rest) {
+        if ($t -match '^-{1,2}(e|enc|encoded|encodedcommand)$') {
+            return @{ Kind = 'deny'; Reason = "base64-encoded shell command cannot be classified: $printable" }
+        }
+    }
+
+    $flagIndex = -1
+    for ($i = 0; $i -lt $rest.Count; $i++) {
+        $t = $rest[$i]
+        # `c` need not be last in the cluster: `bash -cl <script>` is valid.
+        if ($posixShells -contains $shell -and $t -cmatch '^-[a-z]*c[a-z]*$') { $flagIndex = $i; break }
+        if ($psShells -contains $shell -and $t -match '^-c[a-z]*$') { $flagIndex = $i; break }
+        if ($shell -eq 'cmd' -and $t -match '^[/-][ck]$') { $flagIndex = $i; break }
+    }
+
+    if ($shell -eq 'eval') {
+        if ($rest.Count -eq 0) { return $null }
+        return @{ Kind = 'script'; Script = ($rest -join ' ') }
+    }
+    if ($flagIndex -ge 0) {
+        if ($flagIndex + 1 -ge $rest.Count) {
+            return @{ Kind = 'deny'; Reason = "shell invoked with an empty command argument: $printable" }
+        }
+        return @{ Kind = 'script'; Script = (@($rest[($flagIndex + 1)..($rest.Count - 1)]) -join ' ') }
+    }
+
+    # A shell handed a script FILE (`bash run.sh`, `powershell -File x.ps1`) is
+    # deliberately not escalated. The guard cannot read that file either way, and
+    # gating it while `python foo.py`, `node x.js` and `npm run x` stay ungated
+    # buys nothing while breaking this repo's own scripts/*.ps1 tooling.
+    return $null
+}
+
+# xargs options split by how they take a value, because getting this wrong
+# swallows the executable. Case matters: `-I` requires a replace-string, while
+# its deprecated lowercase synonym `-i` takes one only when attached.
+$xargsRequiredShort = @('-I', '-L', '-n', '-P', '-s', '-d', '-a', '-E')
+$xargsOptionalShort = @('-i', '-l', '-e')
+$xargsRequiredLong = @('--max-args', '--max-procs', '--max-chars', '--delimiter',
+    '--arg-file', '--process-slot-var')
+# Optional-value long options bind ONLY as --opt=value. Written alone, the next
+# token is the command, so consuming it would hide `xargs --replace rm -rf`.
+$xargsOptionalLong = @('--replace', '--max-lines', '--eof')
+
+function Get-XargsCommand([string[]]$tokens) {
+    # Everything before the first non-option token belongs to xargs itself; what
+    # follows is the program it will run. This boundary matters: in
+    # `xargs -n1 echo rm -rf` the executable is `echo` and `rm` is data being
+    # printed, so the every-position rule must not be applied to this segment.
+    $i = 1
+    while ($i -lt $tokens.Count) {
+        $t = $tokens[$i]
+        # --opt=value carries its own value.
+        if ($t -match '^--[a-zA-Z-]+=') { $i++; continue }
+        if ($xargsRequiredLong -ccontains $t) { $i += 2; continue }
+        # Optional-value long options bind only with `=`, so written alone they
+        # consume nothing and the next token is the command.
+        if ($xargsOptionalLong -ccontains $t) { $i++; continue }
+        if ($t -match '^--') { $i++; continue }
+        if ($t -match '^-.') {
+            # `-n1` and `-i{}` carry their value attached, whatever the option.
+            if ($t.Length -gt 2) { $i++; continue }
+            $short = $t.Substring(0, 2)
+            # -ccontains: `-I` requires a value, `-i` does not.
+            if ($xargsRequiredShort -ccontains $short) { $i += 2; continue }
+            # Optional-value and plain switches alone consume nothing.
+            $i++
+            continue
+        }
+        break
+    }
+    if ($i -ge $tokens.Count) { return @() }
+    return @($tokens[$i..($tokens.Count - 1)])
+}
+
+function Test-Segment([string[]]$tokens, [string]$printable) {
+    $tokens = @(Remove-Wrappers $tokens)
+    if ($tokens.Count -eq 0) { return $null }
+
+    $verbs = @(Get-VerbCandidates $tokens[0])
+    $verb = $null
+    foreach ($v in $verbs) {
+        if ($rmFamily -contains $v -or $v -eq 'git') { $verb = $v; break }
+    }
+    if ($null -eq $verb) { return $null }
+    $rest = @()
+    if ($tokens.Count -gt 1) { $rest = @($tokens[1..($tokens.Count - 1)]) }
+
+    if ($rmFamily -contains $verb) {
+        if (Test-DryRun $rest) { return $null }
+        $flags = Get-RmFlags $rest $verb
+        $inherentlyRecursive = @('rd', 'rmdir') -contains $verb
+        if ($flags.Recursive -or $inherentlyRecursive) {
+            if ($flags.Force) {
+                return @{ Decision = 'deny'; Reason = "recursive force delete: $printable" }
+            }
+            return @{ Decision = 'ask'; Reason = "recursive delete, confirm the target: $printable" }
+        }
+        return $null
+    }
+
+    if ($verb -ne 'git') { return $null }
+    $sub = Get-GitSubcommand $tokens
+    if ($null -eq $sub) { return $null }
+    $subRest = $sub.Rest
+    if (Test-DryRun $subRest) { return $null }
+
+    switch ($sub.Name) {
+        'reset' {
+            if ($subRest -contains '--hard') {
+                return @{ Decision = 'deny'; Reason = "git reset --hard discards working-tree changes: $printable" }
+            }
+        }
+        'clean' {
+            if (Test-AnyForce $subRest) {
+                return @{ Decision = 'deny'; Reason = "git clean force deletes untracked files: $printable" }
+            }
+        }
+        'rm' {
+            if ($subRest -contains '--cached') {
+                # --cached only edits the index; the working tree is left alone.
+                # The risk is downstream: once untracked, a later clean removes it.
+                return @{ Decision = 'ask'; Reason = "git rm --cached untracks files, exposing them to a later clean: $printable" }
+            }
+            return @{ Decision = 'ask'; Reason = "git rm deletes working-tree files: $printable" }
+        }
+        'push' {
+            foreach ($t in $subRest) {
+                if ($t -eq '--force' -or $t -eq '--delete' -or $t -like '--force-with-lease*' -or (Test-ShortFlag $t 'f') -or (Test-ShortFlag $t 'd')) {
+                    return @{ Decision = 'deny'; Reason = "force or delete push rewrites remote history: $printable" }
+                }
+            }
+            if ($GuardProfile -eq 'agent') {
+                return @{ Decision = 'deny'; Reason = "subagents do not push; hand the branch to the owner" }
+            }
+        }
+        'merge' {
+            if ($GuardProfile -eq 'agent') {
+                return @{ Decision = 'deny'; Reason = "subagents do not merge; hand the branch to the owner" }
+            }
+        }
+        'branch' {
+            $forceDelete = $false
+            foreach ($t in $subRest) {
+                if ($t -cmatch '^-[a-zA-Z]*D[a-zA-Z]*$') { $forceDelete = $true }
+            }
+            if (($subRest -contains '--delete') -and (Test-AnyForce $subRest)) { $forceDelete = $true }
+            if ($forceDelete) {
+                return @{ Decision = 'ask'; Reason = "git branch force-delete drops an unmerged branch: $printable" }
+            }
+        }
+        'worktree' {
+            if ($subRest.Count -ge 1 -and $subRest[0] -eq 'remove') {
+                return @{ Decision = 'ask'; Reason = "git worktree remove discards a worktree: $printable" }
+            }
+        }
+        'checkout' {
+            if (Test-AnyForce $subRest) {
+                return @{ Decision = 'ask'; Reason = "git checkout --force overwrites local modifications: $printable" }
+            }
+        }
+    }
+    return $null
+}
+
+function Get-CandidateCommands($toolInput) {
+    # No comma operator here: `, $empty` returns a one-element array containing
+    # an empty array, which reads as Count 1 at the call site and defeats the
+    # fail-closed check.
+    $found = New-Object System.Collections.ArrayList
+    if ($null -eq $toolInput) { return @() }
+    foreach ($field in $commandFields) {
+        $value = $toolInput.PSObject.Properties[$field]
+        if ($null -ne $value -and $value.Value -is [string] -and -not [string]::IsNullOrWhiteSpace($value.Value)) {
+            [void]$found.Add([string]$value.Value)
+        }
+    }
+    if ($found.Count -eq 0) {
+        # Unknown schema. Scan every string field except free-text metadata so a
+        # renamed command field cannot slip past unexamined.
+        foreach ($property in $toolInput.PSObject.Properties) {
+            if ($property.Name -eq 'description') { continue }
+            if ($property.Value -is [string] -and -not [string]::IsNullOrWhiteSpace($property.Value)) {
+                [void]$found.Add([string]$property.Value)
+            }
+        }
+    }
+    return $found.ToArray()
+}
+
+function Invoke-CommandScan([string]$command, [int]$depth) {
+    if ($depth -gt $maxDelegationDepth) {
+        [void]$script:denials.Add("command nesting exceeds $maxDelegationDepth levels; cannot classify: $command")
+        return
+    }
+
+    # A backslash before a newline is a line continuation: the shell joins the
+    # two lines into one word, so `r\<newline>m -rf tmp` runs `rm`. Join first,
+    # or the newline reads as a segment break and hides the verb.
+    $command = $command -replace '\\\r?\n', ''
+
+    if (-not (Test-QuotesBalanced $command)) {
+        # Quoting the guard cannot close means its tokenization is not
+        # trustworthy at all: a quote may be hiding a separator, as in
+        # `echo "; rm -rf tmp`. Unclassifiable syntax is denied, not guessed at.
+        [void]$script:denials.Add("unbalanced quoting; the command cannot be classified: $command")
+        return
+    }
+
+    foreach ($tokens in (Split-Segments $command)) {
+        if ($tokens.Count -eq 0) { continue }
+        $stripped = @(Remove-Wrappers $tokens)
+        if ($stripped.Count -eq 0) { continue }
+
+        # xargs states its own command boundary, so honour it rather than
+        # scanning positions: only the program it runs is executable, and its
+        # trailing arguments are data.
+        if ((Get-VerbCandidates $stripped[0]) -contains 'xargs') {
+            $inner = @(Get-XargsCommand $stripped)
+            if ($inner.Count -gt 0) {
+                $delegation = Get-Delegation $inner
+                if ($null -ne $delegation) {
+                    switch ($delegation.Kind) {
+                        'deny' { [void]$script:denials.Add($delegation.Reason) }
+                        'ask' { [void]$script:asks.Add($delegation.Reason) }
+                        'script' { Invoke-CommandScan $delegation.Script ($depth + 1) }
+                    }
+                }
+                else {
+                    $result = Test-Segment $inner ($inner -join ' ')
+                    if ($null -ne $result) {
+                        if ($result.Decision -eq 'deny') { [void]$script:denials.Add($result.Reason) }
+                        elseif ($result.Decision -eq 'ask') { [void]$script:asks.Add($result.Reason) }
+                    }
+                }
+            }
+            continue
+        }
+
+        # Evaluate EVERY position, not just the head of the segment. A verb
+        # reaches command position behind control syntax the guard does not
+        # model -- `then rm -rf x`, `if exist x rmdir /s /q x`, `& { Remove-Item
+        # ... }`, `try { ... } catch {}`, `xargs -I {} rm -rf {}`. Enumerating
+        # keywords would be an endless list of two-shell grammar; scanning every
+        # position removes the whole class instead.
+        for ($i = 0; $i -lt $stripped.Count; $i++) {
+            $suffix = @($stripped[$i..($stripped.Count - 1)])
+
+            $delegation = Get-Delegation $suffix
+            if ($null -ne $delegation) {
+                switch ($delegation.Kind) {
+                    'deny' { [void]$script:denials.Add($delegation.Reason) }
+                    'ask' { [void]$script:asks.Add($delegation.Reason) }
+                    'script' { Invoke-CommandScan $delegation.Script ($depth + 1) }
+                }
+                # The rest of this segment is the nested command's own argument.
+                break
+            }
+
+            $result = Test-Segment $suffix ($suffix -join ' ')
+            if ($null -eq $result) { continue }
+            if ($result.Decision -eq 'deny') { [void]$script:denials.Add($result.Reason) }
+            elseif ($result.Decision -eq 'ask') { [void]$script:asks.Add($result.Reason) }
+        }
+    }
+}
+
+# --- entry point -------------------------------------------------------------
+try {
+    $raw = [Console]::In.ReadToEnd()
+    if ([string]::IsNullOrWhiteSpace($raw)) {
+        [Console]::Error.WriteLine("Guard received no hook payload; failing closed.")
+        exit 2
+    }
+    $payload = $raw | ConvertFrom-Json
+    $permissionMode = [string]$payload.permission_mode
+    $toolInput = $payload.tool_input
+    if ($null -eq $toolInput) {
+        [Console]::Error.WriteLine("Guard received no tool_input; failing closed.")
+        exit 2
+    }
+    $commands = @(Get-CandidateCommands $toolInput)
+    if ($commands.Count -eq 0) {
+        [Console]::Error.WriteLine("Guard found no command field in tool_input; failing closed.")
+        exit 2
+    }
+
+    # Evaluate EVERY segment of EVERY candidate before deciding. An early ask
+    # must not mask a later deny: `rm -r a && rm -rf b` is a deny, because
+    # approving the prompt would run both.
+    $script:denials = New-Object System.Collections.ArrayList
+    $script:asks = New-Object System.Collections.ArrayList
+
+    foreach ($command in $commands) {
+        Invoke-CommandScan $command 0
+    }
+
+    $denials = @($script:denials | Select-Object -Unique)
+    $asks = @($script:asks | Select-Object -Unique)
+
+    if ($denials.Count -gt 0) {
+        [Console]::Error.WriteLine("Blocked by $GuardProfile guard: " + ($denials -join ' | '))
+        exit 2
+    }
+    if ($asks.Count -gt 0) {
+        $askReason = ($asks -join ' | ') + " ($GuardProfile guard)"
+        if ([string]::IsNullOrWhiteSpace($permissionMode) -or $permissionMode -eq 'bypassPermissions') {
+            [Console]::Error.WriteLine(
+                "Blocked by $GuardProfile guard: confirmation is required, but permission mode " +
+                "'$permissionMode' cannot enforce an ask prompt. Switch out of bypassPermissions " +
+                "and retry, or run the command manually. $askReason"
+            )
+            exit 2
+        }
+        $decision = @{
+            hookSpecificOutput = @{
+                hookEventName            = 'PreToolUse'
+                permissionDecision       = 'ask'
+                permissionDecisionReason = $askReason
+            }
+        }
+        [Console]::Out.WriteLine(($decision | ConvertTo-Json -Compress -Depth 5))
+        exit 0
+    }
+    exit 0
+}
+catch {
+    [Console]::Error.WriteLine("Guard failed to evaluate the command and is failing closed: $_")
+    exit 2
+}

--- a/.claude/hooks/guard-planning-write.ps1
+++ b/.claude/hooks/guard-planning-write.ps1
@@ -1,4 +1,4 @@
-$inputJson = [Console]::In.ReadToEnd() | ConvertFrom-Json
+﻿$inputJson = [Console]::In.ReadToEnd() | ConvertFrom-Json
 $filePath = [string]$inputJson.tool_input.file_path
 
 if (-not $filePath -or $filePath -notmatch '(?i)(^|[\\/])docs[\\/][^\\/]+[\\/]PLANNING\.md$') {

--- a/.claude/hooks/guard-skill.ps1
+++ b/.claude/hooks/guard-skill.ps1
@@ -1,4 +1,4 @@
-param(
+﻿param(
     [Parameter(Mandatory = $true)]
     [string]$AllowedCsv
 )

--- a/.claude/hooks/guard-test-write.ps1
+++ b/.claude/hooks/guard-test-write.ps1
@@ -1,4 +1,4 @@
-$inputJson = [Console]::In.ReadToEnd() | ConvertFrom-Json
+﻿$inputJson = [Console]::In.ReadToEnd() | ConvertFrom-Json
 $filePath = [string]$inputJson.tool_input.file_path
 
 if (-not $filePath -or $filePath -notmatch '(?i)(^|[\\/])(tests|e2e)[\\/]') {

--- a/.claude/rules/verification.md
+++ b/.claude/rules/verification.md
@@ -1,0 +1,112 @@
+---
+paths:
+  - "static/css/**/*.css"
+  - "scss/**/*.scss"
+  - "scripts/css_audit/**/*.py"
+  - "scripts/css_audit/**/*.mjs"
+  - "e2e/visual.spec.ts"
+  - "e2e/visual-baseline-thumbnails.spec.ts"
+  - "e2e/dark-mode.spec.ts"
+---
+
+# Verification and evidence guide
+
+Rules for any claim of the form "this rule is dead", "this change is
+pixel-neutral", or "this declaration never wins".
+
+## Division of ownership
+**This file owns the durable method** — the invariants below hold for any CSS
+arc and outlive the packet that discovered them.
+
+**`docs/css_phase4_wp4_4/PLANNING.md` owns the arc.** Its §2b method table
+(M1–M12) and §2 standing constraints (G1–G11) bind the WP4.4 packets, carry the
+owner rulings, and record which packet paid for each rule. When that arc closes,
+its arc-specific constraints retire with it; these do not.
+
+Where both describe the same obligation, the plan's wording governs inside the
+arc. Do not copy the M/G table here.
+
+## Validate the oracle before trusting the oracle
+A measurement script is not evidence until it has passed a control:
+1. a **known-live** case it must report live,
+2. a **known-dead** case it must report dead,
+3. a **same-CSS control run** — identical CSS on both sides, which must report
+   zero differing records.
+
+The same-CSS control is a **validity precondition, not evidence of deadness**.
+It tells you the harness is measuring your change rather than noise; it says
+nothing about any particular declaration. A control that reports differences
+invalidates every result from that run. WP4.3i-dead's control produced 52
+differing records and correctly shrank the packet from 24 declarations to 14.
+
+Report raw control output alongside the result. A result without its control is
+not reportable.
+
+**Choose control cases adversarially.** A case table built from the same
+assumption as the implementation will pass and prove nothing — the first version
+of `.claude/hooks/guard-destructive-command.ps1` passed 15 hand-picked cases and
+still missed eight real bypasses, because the cases were derived from the
+patterns rather than from the threat. Enumerate what *should* be caught first,
+independently of how the check works.
+
+## Deadness needs converging evidence, not one sweep
+A sentinel sweep **alone over-reports deadness**. A deletion claim needs the
+sweep **and** a rest-state differential, each capable of falsifying the other,
+with the same-CSS control passing. A sweep reporting that 40 of 97 literals
+never render is a hypothesis, not a finding.
+
+Declarations reachable only through an interaction state (`:hover`, `:focus`,
+`:active`) or a JS-applied class must be proven under that state — and that
+proof is itself unreliable until the control reaches zero, because those states
+animate. Declare interaction-state scope up front or defer it.
+
+Declarations inside `@media` blocks require a capture taken under that block's
+own condition — reduced-motion, print, and each breakpoint.
+
+## Sentinels and transitions
+Suppress transitions before applying, reading **and** removing a sentinel. A
+sentinel written to a transitioned property reads back its pre-sentinel value
+for the whole transition duration, so `getComputedStyle` reports "no effect" on
+an element the sentinel reached perfectly. Inline `!important` does not help —
+the lag is in the computed value, not the cascade. The release is symmetric:
+drop the sentinel while transitions are still suppressed. `header` and `select`
+carry `transition: all 0.3s` and will produce this false negative.
+
+A probe that changes nothing proves nothing: assert per record that the sentinel
+took effect. `var()`-bearing shorthands are invisible to longhand CSSOM queries.
+
+## Visual capture
+- Run the visual pipeline with `PW_VISUAL_SEED=1` (selected in
+  `playwright.config.ts`); without it the seeded DB is absent and the run fails
+  for reasons unrelated to the change.
+- Scope every capture to the element under test. The full-page pixel oracle is
+  unusable on animated-navbar routes.
+- The animated-logo diff is a **band, not a constant**, and it can exceed the
+  configured `maxDiffPixels`, so it presents as a real snapshot failure. Never
+  assert an exact pixel count for it. Read the current threshold and observed
+  range from the active arc's plan rather than from this file — those numbers
+  are baseline state and go stale.
+
+## Reuse the committed harness
+`scripts/css_audit/` holds the reviewed tooling from WP4.4-a — `measure.py`,
+`specificity.py`, `resolution_check.py`, `runtime_probe.mjs`,
+`stylelint_surfaces.mjs`, `emit_baseline.py`. Extend these rather than writing a
+throwaway parser. Specificity in particular must handle `:is()`/`:where()`/
+`:not()`/`:has()`, must not naively comma-split, and must implement `@layer`
+ordering plus the `!important` inversion.
+
+## Windows scripting hazards
+These have each corrupted an analysis run:
+- Normalize CRLF before any line-offset or character-offset math.
+- Avoid bash heredocs; write the script to the scratchpad with `Write` and run
+  the file.
+- Quote every PowerShell path; junctions and worktree paths break unquoted.
+- Never use `nth-child` position or re-serialized CSS text for rule identity —
+  re-serialization is not byte-preserving. Match on selector plus source offset.
+- A comment stripper used for scanning must be length-preserving, or every
+  offset after the first comment is wrong.
+
+## Parallelism
+Only parallelize packets whose file sets are disjoint. CSS packets that touch
+the same bundle run **serially** — state that rather than re-litigating it each
+session.

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -14,9 +14,13 @@
       "Bash(git log *)",
       "Bash(git show *)",
       "Bash(git branch *)",
+      "Bash(git worktree list)",
+      "Bash(git fetch --quiet origin)",
       "Bash(gh repo view *)",
       "Bash(gh issue view *)",
       "Bash(gh pr view *)",
+      "Bash(gh pr list *)",
+      "Bash(gh pr checks *)",
       "Skill(requirements)",
       "Skill(council-plan)",
       "Skill(run-tests)",
@@ -38,6 +42,19 @@
       "Bash(rm -rf *)",
       "Bash(git push --force *)",
       "Bash(git reset --hard *)"
+    ]
+  },
+  "hooks": {
+    "PreToolUse": [
+      {
+        "matcher": "Bash|PowerShell",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "powershell -NoProfile -ExecutionPolicy Bypass -File \"${CLAUDE_PROJECT_DIR}/.claude/hooks/guard-destructive-command.ps1\" -GuardProfile main"
+          }
+        ]
+      }
     ]
   },
   "enableAllProjectMcpServers": true,

--- a/tests/test_guard_destructive_command.py
+++ b/tests/test_guard_destructive_command.py
@@ -1,0 +1,401 @@
+"""Regression table for the PreToolUse destructive-command guard.
+
+Two defect classes drove this file, both of which passed an earlier hand-picked
+check:
+
+1. Substring regexes leaked. `rm -fr`, `rm -r -f`, a leading space,
+   `sudo rm -rf`, `git -C <path> clean -fdx`, `git clean --force -d` and
+   `git checkout -fq` all slipped through, while `git merge-base` was blocked
+   as if it were `git merge`.
+2. The guard ran green under pwsh 7 and was a parser error under Windows
+   PowerShell 5.1, which exits 1 -- a non-blocking code, so the production hook
+   failed open. The cause was one non-ASCII character in a BOM-less .ps1:
+   5.1 decodes such files as CP1252, and the resulting U+201D is a string
+   delimiter to PowerShell.
+
+So every case runs against EVERY PowerShell host on the machine, and the source
+encoding is asserted directly. `.claude/settings.json` and the agent charters
+invoke `powershell`; if that host is present it must be covered.
+
+Outcome vocabulary matches the PreToolUse contract:
+  deny  - exit code 2 (the only blocking exit code)
+  ask   - exit 0 plus permissionDecision=ask on stdout
+  allow - exit 0, no payload
+
+The guard's contract is "confidently classified, or denied". Syntax it cannot
+parse -- unbalanced quoting, base64 `-EncodedCommand`, nesting past depth 4 --
+denies rather than being guessed at.
+
+Two limitations are deliberate, and are limitations rather than oversights:
+
+* **Script files are not gated.** `bash run.sh` and `powershell -File x.ps1`
+  execute contents this guard cannot read. Gating them would break this repo's
+  own `scripts/*.ps1` tooling while `python foo.py`, `node x.js` and
+  `npm run x` remain equally opaque and equally ungated, so it would buy
+  consistency of appearance rather than of protection.
+* **Only two shells are modelled.** An ad-hoc parser cannot cover all of Bash
+  and PowerShell grammar. It is a speed bump backed by the `deny` list in
+  `.claude/settings.json`, not a sandbox, and it should never be described as
+  one.
+"""
+
+from __future__ import annotations
+
+import json
+import shutil
+import subprocess
+from pathlib import Path
+
+import pytest
+
+GUARD = (
+    Path(__file__).resolve().parents[1]
+    / ".claude"
+    / "hooks"
+    / "guard-destructive-command.ps1"
+)
+
+HOSTS = [name for name in ("powershell", "pwsh") if shutil.which(name)]
+
+pytestmark = pytest.mark.skipif(
+    not HOSTS, reason="no PowerShell host available on this platform"
+)
+
+
+def invoke(host: str, payload: str, profile: str) -> subprocess.CompletedProcess:
+    return subprocess.run(
+        [
+            host,
+            "-NoProfile",
+            "-ExecutionPolicy",
+            "Bypass",
+            "-File",
+            str(GUARD),
+            "-GuardProfile",
+            profile,
+        ],
+        input=payload,
+        capture_output=True,
+        text=True,
+    )
+
+
+def outcome(
+    host: str,
+    command: str,
+    profile: str,
+    permission_mode: str = "default",
+) -> str:
+    payload = json.dumps(
+        {
+            "permission_mode": permission_mode,
+            "tool_input": {"command": command},
+        }
+    )
+    proc = invoke(host, payload, profile)
+    if proc.returncode == 2:
+        return "deny"
+    if proc.returncode != 0:
+        raise AssertionError(
+            f"{host} exited {proc.returncode}; every code except 2 is "
+            f"non-blocking, so the guard failed OPEN.\n{proc.stderr}"
+        )
+    if "permissionDecision" in proc.stdout:
+        return json.loads(proc.stdout)["hookSpecificOutput"]["permissionDecision"]
+    return "allow"
+
+
+# (command, profile, expected outcome)
+CASES = [
+    # --- recursive force delete: every spelling that has leaked --------------
+    ("rm -rf tmp", "main", "deny"),
+    ("rm -fr tmp", "main", "deny"),
+    ("rm -r -f tmp", "main", "deny"),
+    ("rm -Rf tmp", "main", "deny"),
+    ("rm -qrf tmp", "main", "deny"),
+    ("  rm -rf tmp", "main", "deny"),
+    ("sudo rm -rf tmp", "main", "deny"),
+    ("sudo -u root rm -rf tmp", "main", "deny"),
+    ("env -i rm -rf tmp", "main", "deny"),
+    ("FOO=bar rm -rf tmp", "main", "deny"),
+    ("cd artifacts && rm -rf tmp", "main", "deny"),
+    ("ls\nrm -rf tmp", "main", "deny"),
+    ("/bin/rm -rf tmp", "main", "deny"),
+    ('"C:\\Program Files\\Git\\usr\\bin\\rm.exe" -rf tmp', "main", "deny"),
+    ("rm --recursive --force tmp", "main", "deny"),
+    ("Remove-Item .\\wt -Recurse -Force", "main", "deny"),
+    ("rm .\\wt -Recurse -Force", "main", "deny"),
+    # PowerShell accepts any unambiguous parameter prefix, and switches may
+    # carry an explicit value. Both are valid syntax, case-insensitively.
+    ("Remove-Item .\\wt -Rec -Fo", "main", "deny"),
+    ("Remove-Item .\\wt -Recurse:$true -Force:$true", "main", "deny"),
+    ("remove-item .\\wt -rec -fo", "main", "deny"),
+    ("Remove-Item .\\wt -R -F", "main", "deny"),
+    ("Remove-Item .\\wt -Recurse -Confirm:$false", "main", "deny"),
+    ('powershell -Command "Remove-Item .\\wt -Rec -Fo"', "main", "deny"),
+    ('pwsh -Command "Remove-Item .\\wt -Recurse:$true -Force:$true"', "main", "deny"),
+    # An explicitly disabled switch is not the recursive form.
+    ("Remove-Item .\\wt -Recurse:$false -Force", "main", "allow"),
+    # --- recursive without force is confirmable ------------------------------
+    ("rm -r tmp", "main", "ask"),
+    ("Remove-Item .\\wt -Recurse", "main", "ask"),
+    ("rmdir build", "main", "ask"),
+    # --- ordinary deletes stay out of the way --------------------------------
+    ("rm artifacts/baseline.txt", "main", "allow"),
+    ("rm -f artifacts/baseline.txt", "main", "allow"),
+    ("npm rm --save-dev foo", "main", "allow"),
+    ("rm -rf --dry-run tmp", "main", "allow"),
+    ("Remove-Item .\\wt -Recurse -WhatIf", "main", "allow"),
+    # --- git global options must not hide the subcommand ---------------------
+    ("git reset --hard origin/main", "main", "deny"),
+    ("git -C ../wt reset --hard", "main", "deny"),
+    ("git --no-pager -C ../wt reset --hard", "main", "deny"),
+    ("git clean -fdx", "main", "deny"),
+    ("git clean -df", "main", "deny"),
+    ("git clean --force -d", "main", "deny"),
+    ("git -C ../wt clean -fdx", "main", "deny"),
+    ("git clean -n", "main", "allow"),
+    ("git clean --dry-run", "main", "allow"),
+    # --- exact subcommand matching -------------------------------------------
+    ("git merge-base main HEAD", "agent", "allow"),
+    ("git merge-base main HEAD", "main", "allow"),
+    ("git merge origin/main", "agent", "deny"),
+    ("git merge --ff-only origin/main", "main", "allow"),
+    # --- push: profile-dependent, force always denied ------------------------
+    ("git push origin HEAD", "main", "allow"),
+    ("git push origin HEAD", "agent", "deny"),
+    ("git push --force origin HEAD", "main", "deny"),
+    ("git push -f origin HEAD", "main", "deny"),
+    ("git push --force-with-lease origin HEAD", "main", "deny"),
+    ("git push --delete origin wt/foo", "main", "deny"),
+    # --- index and branch surgery is confirmable -----------------------------
+    ("git rm -r --cached .idea", "main", "ask"),
+    ("git rm --cached --dry-run x", "main", "allow"),
+    ("git rm src/foo.py", "main", "ask"),
+    ("git branch -D wt/foo", "main", "ask"),
+    ("git branch --delete --force wt/foo", "main", "ask"),
+    ("git branch -d wt/foo", "main", "allow"),
+    ("git worktree remove ../wt", "main", "ask"),
+    # Bare form: exactly one token after the subcommand, which is where a
+    # single-element array unrolls to a scalar string and $rest[0] becomes 'r'.
+    ("git worktree remove", "main", "ask"),
+    ("git worktree list", "main", "allow"),
+    ("git checkout -fq main", "main", "ask"),
+    ("git checkout main", "main", "allow"),
+    # --- aggregation: an early ask must never mask a later deny --------------
+    ("rm -r a && rm -rf b", "main", "deny"),
+    ("git rm file ; git reset --hard HEAD", "main", "deny"),
+    ("git branch -D old && git push --force origin main", "main", "deny"),
+    ("git worktree remove ../wt && git status", "main", "ask"),
+    ("git status && git log --oneline -5", "main", "allow"),
+    # --- delegated execution: the nested command must be scanned too ---------
+    ('sh -c "rm -rf tmp"', "main", "deny"),
+    ("sh -c 'rm -rf tmp'", "main", "deny"),
+    ('bash -c "git reset --hard HEAD"', "main", "deny"),
+    ('bash -lc "rm -rf tmp"', "main", "deny"),
+    ('zsh -c "rm -rf tmp"', "main", "deny"),
+    ('cmd /c "rmdir /s /q tmp"', "main", "deny"),
+    ('cmd /c "del /f /s /q tmp"', "main", "deny"),
+    ('powershell -Command "Remove-Item .\\wt -Recurse -Force"', "main", "deny"),
+    ('pwsh -c "Remove-Item .\\wt -Recurse -Force"', "main", "deny"),
+    ('eval "rm -rf tmp"', "main", "deny"),
+    ("find . -name x | xargs rm -rf", "main", "deny"),
+    ("xargs -n1 rm -rf", "main", "deny"),
+    ('bash -c "sh -c \'rm -rf tmp\'"', "main", "deny"),
+    ('sudo bash -c "rm -rf tmp"', "main", "deny"),
+    # base64 cannot be classified, so it cannot be waved through
+    ("pwsh -EncodedCommand cgBtACAALQByAGYA", "main", "deny"),
+    ("bash -c", "main", "deny"),
+    # --- escaped spellings: Bash reads `r\m` as `rm` -------------------------
+    ("r\\m -rf tmp", "main", "deny"),
+    ("\\rm -rf tmp", "main", "deny"),
+    ('"rm" -rf tmp', "main", "deny"),
+    # --- command position: the verb is not always token 0 --------------------
+    # Each of these is executable syntax that puts a destructive verb behind
+    # control structure the guard does not model. Enumerating shell keywords
+    # would be an endless list across two grammars, so every position in a
+    # segment is evaluated instead.
+    ('bash -cl "rm -rf tmp"', "main", "deny"),
+    ("xargs -I {} rm -rf {}", "main", "deny"),
+    ('powershell -Command "& { Remove-Item .\\wt -Recurse -Force }"', "main", "deny"),
+    ('bash -c "if true; then rm -rf tmp; fi"', "main", "deny"),
+    ('cmd /c "if exist tmp rmdir /s /q tmp"', "main", "deny"),
+    ('pwsh -Command "try { Remove-Item .\\wt -Recurse -Force } catch {}"', "main", "deny"),
+    ("$'rm' -rf tmp", "main", "deny"),
+    # Line continuation: the shell joins these into `rm`, so joining must happen
+    # before the newline is read as a segment break.
+    ("r\\\nm -rf tmp", "main", "deny"),
+    # --- unclassifiable syntax is denied, never guessed at -------------------
+    # Owner ruling: unbalanced or otherwise unclassifiable quoting denies. An
+    # earlier revision rescanned and allowed when the rescan found nothing;
+    # that traded a real guarantee for convenience.
+    ('echo "; rm -rf tmp', "main", "deny"),
+    ("echo '; git reset --hard HEAD", "main", "deny"),
+    ("echo don't", "main", "deny"),
+    # Balanced quoting is still read normally, so ordinary text is unaffected.
+    ("git commit -m \"the owner's flow\"", "main", "allow"),
+    # --- delegation false positives: these must stay usable ------------------
+    ('sh -c "git status"', "main", "allow"),
+    ("bash scripts/run.sh", "main", "allow"),
+    ("powershell -File scripts/run-pytest.ps1", "main", "allow"),
+    ("powershell -NoProfile -ExecutionPolicy Bypass -File scripts/x.ps1", "main", "allow"),
+    ("cmd /c dir", "main", "allow"),
+    ("xargs -n1 echo", "main", "allow"),
+    ("npx playwright test", "main", "allow"),
+    # xargs states its own command boundary: `echo` is the executable here and
+    # `rm -rf` is data being printed. Applying the every-position rule to this
+    # segment would deny a command that deletes nothing.
+    ("xargs -n1 echo rm -rf", "main", "allow"),
+    ("xargs -I {} echo rm -rf {}", "main", "allow"),
+    # ...while the same shapes with rm in command position still deny
+    ("xargs -I {} rm -rf {}", "main", "deny"),
+    ("xargs -n1 rm -rf", "main", "deny"),
+    ("xargs -L 2 rm -rf", "main", "deny"),
+    # Optional-argument options take a value only when attached. Written alone
+    # the NEXT token is the executable, so consuming it hides the command.
+    # Case matters: -I requires a replace-string, its synonym -i does not.
+    ("xargs -i rm -rf", "main", "deny"),
+    ("xargs -l rm -rf", "main", "deny"),
+    ("xargs -e rm -rf", "main", "deny"),
+    ("xargs --replace rm -rf", "main", "deny"),
+    ("xargs --max-lines rm -rf", "main", "deny"),
+    ("xargs --eof rm -rf", "main", "deny"),
+    # The matching executable-boundary controls: same options, echo in command
+    # position, rm as data. If these deny, the parser ate the wrong token.
+    ("xargs -i echo rm -rf", "main", "allow"),
+    ("xargs -l echo rm -rf", "main", "allow"),
+    ("xargs -e echo rm -rf", "main", "allow"),
+    ("xargs --replace echo rm -rf", "main", "allow"),
+    ("xargs --max-lines echo rm -rf", "main", "allow"),
+    ("xargs --eof echo rm -rf", "main", "allow"),
+    # Attached values still bind, and must not leave the executable behind.
+    ("xargs -i{} rm -rf {}", "main", "deny"),
+    ("xargs --max-lines=2 rm -rf", "main", "deny"),
+    ("xargs -i{} echo rm -rf", "main", "allow"),
+    # Quoted literals are data, not commands. Pinned so later hardening cannot
+    # quietly start denying documentation, search and commit messages.
+    ('rg "rm -rf" .', "main", "allow"),
+    ('grep -rn "rm -rf" .', "main", "allow"),
+    ('Write-Output "rm -rf tmp"', "main", "allow"),
+    ('git commit -m "document why rm -rf is denied"', "main", "allow"),
+    ('git commit -m "guard: deny rm -rf and git reset --hard"', "main", "allow"),
+    # Script-file execution stays ungated by design -- see the module docstring.
+    ("bash scripts/new-worktree.sh", "main", "allow"),
+    ("pwsh -File scripts/run-playwright.ps1", "main", "allow"),
+    # Every-position scanning must not fire on ordinary arguments.
+    ("git log --oneline --all -20", "main", "allow"),
+    ("gh pr view 188 --json headRefOid", "main", "allow"),
+    ("npm run build:css -- --watch", "main", "allow"),
+    # --- read-only and build commands are untouched --------------------------
+    ("git status --short", "main", "allow"),
+    ("git log --oneline -20", "main", "allow"),
+    (".venv/Scripts/python.exe -m pytest -q", "main", "allow"),
+    ("npm run build:css", "main", "allow"),
+    ("gh pr list --state all --limit 20", "main", "allow"),
+    ("gh pr checks 188", "main", "allow"),
+]
+
+
+@pytest.mark.parametrize("host", HOSTS)
+@pytest.mark.parametrize(
+    "command,profile,expected",
+    CASES,
+    ids=[f"{p}:{c}" for c, p, _ in CASES],
+)
+def test_guard_outcome(host: str, command: str, profile: str, expected: str) -> None:
+    assert outcome(host, command, profile) == expected
+
+
+# Malformed or unrecognised payloads must fail CLOSED: any exit code other than
+# 2 is non-blocking, so "I could not parse this" has to mean "block".
+MALFORMED = [
+    ("not json", "{not json"),
+    ("empty stdin", ""),
+    ("empty object", "{}"),
+    ("no tool_input", '{"tool_name":"Bash"}'),
+    ("empty tool_input", '{"tool_input":{}}'),
+    ("no command field", '{"tool_input":{"description":"rm -rf tmp"}}'),
+]
+
+
+@pytest.mark.parametrize("host", HOSTS)
+@pytest.mark.parametrize("label,payload", MALFORMED, ids=[m[0] for m in MALFORMED])
+def test_guard_fails_closed(host: str, label: str, payload: str) -> None:
+    assert invoke(host, payload, "main").returncode == 2
+
+
+@pytest.mark.parametrize("host", HOSTS)
+def test_unknown_command_field_is_still_inspected(host: str) -> None:
+    """A renamed command field must not slip past unexamined."""
+    payload = json.dumps(
+        {
+            "permission_mode": "default",
+            "tool_input": {"shellCommand": "rm -rf tmp"},
+        }
+    )
+    assert invoke(host, payload, "main").returncode == 2
+
+
+@pytest.mark.parametrize("host", HOSTS)
+@pytest.mark.parametrize(
+    "command,expected",
+    [
+        ("git worktree remove ../wt", "deny"),
+        ("git rm src/foo.py", "deny"),
+        ("rm -r tmp", "deny"),
+        ("rm -rf tmp", "deny"),
+        ("git status --short", "allow"),
+    ],
+)
+def test_bypass_mode_never_silently_executes_confirmation_tier(
+    host: str,
+    command: str,
+    expected: str,
+) -> None:
+    """bypassPermissions skips prompts, so ask-tier operations must hard-deny."""
+    assert outcome(host, command, "main", "bypassPermissions") == expected
+
+
+@pytest.mark.parametrize("host", HOSTS)
+def test_missing_permission_mode_denies_confirmation_tier(host: str) -> None:
+    """Unknown permission semantics are unsafe for a command requiring approval."""
+    payload = json.dumps({"tool_input": {"command": "git worktree remove ../wt"}})
+    assert invoke(host, payload, "main").returncode == 2
+
+
+HOOK_SCRIPTS = sorted((GUARD.parent).glob("*.ps1"))
+
+
+@pytest.mark.parametrize("script", HOOK_SCRIPTS, ids=lambda p: p.name)
+def test_hook_source_is_ascii_with_bom(script: Path) -> None:
+    """Windows PowerShell 5.1 reads a BOM-less .ps1 as CP1252.
+
+    A single UTF-8 em dash then decodes to U+201D, which PowerShell treats as a
+    string delimiter: the guard becomes a parser error and exits 1. Exit 1 is
+    non-blocking, so the hook fails OPEN while appearing installed. Every hook
+    in this directory is pinned, not just the one that was bitten.
+    """
+    raw = script.read_bytes()
+    assert raw.startswith(b"\xef\xbb\xbf"), f"{script.name} lost its UTF-8 BOM"
+    offenders = [(i, hex(b)) for i, b in enumerate(raw[3:]) if b > 127]
+    assert not offenders, f"non-ASCII bytes in {script.name}: {offenders[:5]}"
+
+
+@pytest.mark.parametrize("host", HOSTS)
+@pytest.mark.parametrize("script", HOOK_SCRIPTS, ids=lambda p: p.name)
+def test_hook_source_parses(host: str, script: Path) -> None:
+    """A hook that cannot be parsed exits non-2 and silently permits the call."""
+    proc = subprocess.run(
+        [
+            host,
+            "-NoProfile",
+            "-Command",
+            f"$errors = $null; "
+            f"$null = [System.Management.Automation.Language.Parser]::ParseFile("
+            f"'{script}', [ref]$null, [ref]$errors); "
+            f"if ($errors.Count) {{ $errors[0].Message; exit 1 }}",
+        ],
+        capture_output=True,
+        text=True,
+    )
+    assert proc.returncode == 0, f"{script.name} fails to parse under {host}: {proc.stdout}{proc.stderr}"


### PR DESCRIPTION
## Summary

Durable safety tooling only. No product code, no status documents, no CSS.

The PreToolUse destructive-command guard was a list of substring regexes wired into three agent charters and nothing else. Two defect classes:

1. **It leaked.** Twenty executable forms reached `allow`, including `rm -fr`, `rm -r -f`, a leading space, `sudo rm -rf`, `git -C <path> clean -fdx`, `sh -c "rm -rf tmp"`, `xargs -I {} rm -rf {}`, `bash -c "if true; then rm -rf tmp; fi"`, `& { Remove-Item -Recurse -Force }`, `$'rm' -rf tmp`, and a backslash-newline continuation. Meanwhile `git merge-base` was blocked as if it were `git merge`.
2. **It failed open under the host that runs it.** One non-ASCII character in a BOM-less `.ps1`: Windows PowerShell 5.1 decodes such files as CP1252, so the byte became `U+201D`, which PowerShell honors as a string delimiter. The result was a parser error, exit code 1 -- and every exit code except 2 is non-blocking, so the guard silently permitted everything while appearing installed. `settings.json` and all three charters invoke `powershell`; the test had selected `pwsh`, the only host that could not observe it.

## What changed

- Quote-aware tokenizer: strips wrapper prefixes and their options, resolves the git subcommand past global options, and evaluates **every position of every segment**, so control syntax (`then rm`, `if exist x rmdir /s /q x`, `try { ... } catch {}`) cannot hide a verb.
- Delegated execution is followed into the command string: POSIX shells with any `-c` cluster, `cmd /c`, `powershell`/`pwsh -Command`, `eval`, to depth 4. Base64 `-EncodedCommand` cannot be recovered, so it denies.
- `xargs` keeps its own command boundary rather than position scanning, with options split by how they bind a value -- `xargs -n1 echo rm -rf` allows because `echo` is the executable and `rm` is data.
- PowerShell parameter abbreviations and switch values parsed case-insensitively (`-Rec -Fo`, `-Recurse:$true`, `-Confirm:$false`), a switch treated as on unless explicitly false.
- Unbalanced quoting, malformed payloads, missing `tool_input` and internal errors all **fail closed**.
- Three-tier outcome with a `-GuardProfile` switch: `agent` preserves the existing charter contract byte-for-byte, `main` permits the owner's push and merge flow. Under `bypassPermissions`, where prompts are skipped, ask-tier operations deny rather than silently proceed.
- Every hook is ASCII with a UTF-8 BOM, both pinned by test, plus a per-host parse check.
- All seven charter hook paths resolve through `${CLAUDE_PROJECT_DIR}`.
- New `/status` command reconciles the three status-claiming documents against git and `gh` instead of trusting any of them.
- New `.claude/rules/verification.md` records the durable CSS evidence method.

## Deliberate limitations

Documented in the guard header and the test module so they are not mistaken for oversights:

- **Script files are not gated.** `bash run.sh` and `powershell -File x.ps1` run contents the guard cannot read -- but so do `python foo.py`, `node x.js` and `npm run x`. Gating only the two shells would break this repo's own `scripts/*.ps1` tooling and buy consistency of appearance, not of protection.
- **Only two shell grammars are modelled, partially.** This is a speed bump in front of honest mistakes, backed by the `deny` list in `.claude/settings.json`. It is not a sandbox and should not be described as one.

## Verification

- **322 guard cases across Windows PowerShell 5.1 and pwsh 7** -- every bypass form found, plus paired allow-controls that fail if the parser consumes the wrong token (`xargs -i echo rm -rf`, `rg "rm -rf" .`, `git commit -m "document why rm -rf is denied"`).
- **Full suite: 2191 passed, 1 skipped.**
- Also fixes a latent PowerShell defect found while testing: assigning an if-statement's output unrolls a one-element array to a scalar string, after which indexing yields a character rather than a token. Three sites did this; `git worktree remove` with no path was the reachable case.

Draft for review. Independent of PR #188.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
