### PR TITLE
docs: record WP4.4-c and reconcile the three status documents

### DIFF
--- a/docs/ACTIVE_DEVELOPMENT.md
+++ b/docs/ACTIVE_DEVELOPMENT.md
@@ -4,7 +4,20 @@ This file is the execution source of truth for autonomous development sessions. 
 
 ## Current Objective
 
-**2026-07-27 (LATEST) — WP4.3j-d-hover-paint is complete in PR #186; then stop.**
+**2026-07-28 (LATEST) — WP4.4-c is complete in PR #188 (squash `1b13bfc`).**
+WP4.4 packets `a` (PR #187, `46e340e`) and `c` are both merged, so the
+`c`-before-`b`/`d1`/`e`/`f1` prerequisite is discharged. Those four packets are
+eligible, file-disjoint (`b` base, `d` a11y, `e` layout, `f` navbar) and
+concurrently authorized by Plan v2 §(a) — **none is started, and each still
+needs explicit owner direction.** The arc hard-stops after `h` per ruling N4.
+
+**Superseded (2026-07-27):** *"WP4.3j-d-hover-paint is complete in PR #186; then
+stop."* That instruction was correct when written and is retained below as the
+Workout Log record. It stopped being the current objective when Gate 1 was
+approved and WP4.4 began executing; this file, `MASTER_HANDOVER.md` and
+`REFACTOR_PLAN.md` had drifted apart, which is what `/status` now reconciles.
+
+**WP4.3j-d-hover-paint (PR #186) — complete, and the Workout Log boundary.**
 The packet removes exactly four cascade-dead declarations from the two retained
 Region G Workout Log hover rules: light/dark `background` and `box-shadow`.
 Both full selector lists and both live filters are byte-identical; the rules are
@@ -179,9 +192,16 @@ intentional review of the exact golden diff before any behavior change.
 
 ## Next Action
 
-After WP4.3j-d PR #186, await owner direction. No further Workout Log packet is
-authorized. Do not begin WP4.4, fatigue, or feature work, and do not reopen the
-root-cleanup track.
+WP4.4-c is merged. `b`, `d1`, `e` and `f1` are eligible and unstarted — await
+owner direction before dispatching any of them, and dispatch at most one writer
+per file. No further Workout Log packet is authorized, and do not begin fatigue
+or feature work or reopen the root-cleanup track.
+
+> **Superseded 2026-07-28.** This section previously read "Do not begin WP4.4",
+> which contradicted merged history from PR #187 and PR #188 as well as the
+> Current Objective above. Because this file declares itself the execution
+> source of truth, an agent obeying it would have refused to continue work that
+> was already built and green.
 
 The sequencing constraint is now **discharged**: a WP4.4 repair of the shared
 `:is()` selector would have **resurrected** regions D–G on this page, which is

--- a/docs/MASTER_HANDOVER.md
+++ b/docs/MASTER_HANDOVER.md
@@ -15,17 +15,40 @@
 >
 > **WP4.4-c** deleted the three cascade-dead `.is-success` paint declarations
 > from `motion.css`, retaining the `success-pulse` animation. `.is-success` is
-> applied only to `#add_exercise_btn`, where `components.css:242` wins all three
-> properties in both themes — that rule carries no theme qualifier.
+> applied only to `#add_exercise_btn`, which never renders those three
+> properties from `motion.css`.
 >
-> **How it wins, precisely.** Both declarations are `!important` and **both are
-> unlayered**: `motion.css` declares no `@layer` at all, and `components.css`
-> opens its only layer (`@layer workout`) at line 3539, well after line 242. The
-> `@layer` important-order inversion therefore never engages here, and
-> **specificity decides** — `#add_exercise_btn.btn` (1,1,0) over `.is-success`
-> (0,1,0). Recorded explicitly because the inversion is the natural thing to
-> reach for in a codebase that uses layers, and it is the wrong explanation for
-> this packet. Per ruling
+> **What actually beats them — the layered `!important` inversion (G10 / A6).**
+> Several rules match this element. The winner is the layered one; every
+> unlayered rule is a fallback that never renders:
+>
+> | Source | Layer | Verdict |
+> |---|---|---|
+> | `motion.css` `.is-success`, specificity `(0,1,0)` | unlayered, `!important` | deleted, proven non-winner |
+> | `components.css:242` `#add_exercise_btn.btn`, specificity `(1,1,0)` | unlayered, `!important` | **runner-up only** — an unlayered fallback that never renders |
+> | `components.css:3154` `.btn.btn-calm-primary`, specificity `(0,2,0)` | unlayered, `!important` | runner-up only, same reason |
+> | `components.css:3540-3548` `#workout[data-page="workout-plan"] .btn.btn-calm-primary` | **inside `@layer workout`**, `!important` | **the actual winner** |
+>
+> **Important-layer ordering is resolved before specificity.** For `!important`
+> declarations layer order is inverted, so the explicit `workout` layer outranks
+> the implicit final unlayered layer — the layered rule wins regardless of the
+> unlayered rules being more specific. Specificity is only the tie-break *within*
+> a layer, which is why `components.css:242` outranks `.is-success` yet still
+> never paints.
+>
+> The computed values settle it: the merged evidence records
+> `background-color: rgb(76, 110, 245)` and `color: rgb(255, 255, 255)` — that is
+> `var(--accent)` `#4c6ef5` and `var(--accent-ink)` from the layered accent rule,
+> **not** line 242's seafoam `#98DFD6` / `#006D77`.
+>
+> **Method note, recorded because it produced a wrong answer.** An audit that
+> greps only for the literal `#add_exercise_btn` finds lines 242/248/254 and
+> misses `.btn.btn-calm-primary` entirely. The element is
+> `class="btn btn-primary btn-calm-primary"`
+> ([`templates/workout_plan.html:247`](../templates/workout_plan.html)) inside
+> `<div id="workout" data-page="workout-plan">` (line 10), so the generic
+> selector matches it. **Resolve ownership against the element's real classes and
+> ancestors, never by ID-literal search.** Per ruling
 > F1 the packet did **not** rely on `visual.spec.ts` — `prepareForScreenshot()`
 > zeroes animation and transition before capture, so it cannot falsify this
 > packet. Ownership was resolved over `CSS.getMatchedStylesForNode` across 11

--- a/docs/MASTER_HANDOVER.md
+++ b/docs/MASTER_HANDOVER.md
@@ -4,9 +4,36 @@
 
 ## Current State
 
-> **2026-07-27 (LATEST) — WP4.4 is EXECUTING. Gate 1 is approved (rulings
-> N1–N10); packet WP4.4-a is COMPLETE in PR #187 (squash `46e340e`). The next
-> packet is WP4.4-c (`motion.css`).**
+> **2026-07-28 (LATEST) — WP4.4 is EXECUTING. Gate 1 is approved (rulings
+> N1–N10). Packet WP4.4-a is COMPLETE in PR #187 (squash `46e340e`) and packet
+> WP4.4-c is COMPLETE in PR #188 (squash `1b13bfc`). The `c`-first prerequisite
+> is discharged; `b`, `d1`, `e` and `f1` are now eligible and none is started.**
+>
+> Those four are file-disjoint — `b` base, `d` a11y, `e` layout, `f` navbar —
+> and Plan v2 §(a) authorizes them concurrently, one writer per file. They still
+> need explicit owner direction before dispatch.
+>
+> **WP4.4-c** deleted the three cascade-dead `.is-success` paint declarations
+> from `motion.css`, retaining the `success-pulse` animation. `.is-success` is
+> applied only to `#add_exercise_btn`, where `components.css:242` wins all three
+> properties in both themes — that rule carries no theme qualifier.
+>
+> **How it wins, precisely.** Both declarations are `!important` and **both are
+> unlayered**: `motion.css` declares no `@layer` at all, and `components.css`
+> opens its only layer (`@layer workout`) at line 3539, well after line 242. The
+> `@layer` important-order inversion therefore never engages here, and
+> **specificity decides** — `#add_exercise_btn.btn` (1,1,0) over `.is-success`
+> (0,1,0). Recorded explicitly because the inversion is the natural thing to
+> reach for in a codebase that uses layers, and it is the wrong explanation for
+> this packet. Per ruling
+> F1 the packet did **not** rely on `visual.spec.ts` — `prepareForScreenshot()`
+> zeroes animation and transition before capture, so it cannot falsify this
+> packet. Ownership was resolved over `CSS.getMatchedStylesForNode` across 11
+> routes × 2 themes under both `prefers-reduced-motion` states, with **0
+> motion-record differences**. It also re-pinned the Packet-a baseline contract
+> to verify the seven surfaces at the baseline's own `sourceCommit`, and added
+> an ancestry assertion so a pin to an unreachable pre-squash commit reds
+> readably instead of dying on a fresh clone.
 >
 > WP4.4-a was read-only — **no production CSS changed**. It delivered the
 > measured baseline every later packet must cite
@@ -54,12 +81,15 @@
 >   and **no packet may classify a declaration affecting those eight elements as
 >   dead using the rest-state harness.**
 >
-> **Next: WP4.4-c (`motion.css`), pure deletion of proven non-winners only.** Its
-> primary proof is the Packet-a motion oracle under both `reduce` and
-> `no-preference` with M6a applied; `visual.spec.ts` is a **backstop only**,
-> because it neutralizes motion before every capture (F1). No Linux deep gate at
-> `c` under N8, and no snapshot updates. **`c` merges before `b`, `d1`, `e` or
-> `f1` begin**, because it changes the oracle environment those packets depend on.
+> **WP4.4-c (`motion.css`) is COMPLETE — PR #188, squash `1b13bfc`.** Superseded
+> 2026-07-28; this paragraph previously read "Next: WP4.4-c" and stated the
+> merge-ordering constraint in the future tense. Its primary proof was the
+> Packet-a motion oracle under both `reduce` and `no-preference` with M6a
+> applied; `visual.spec.ts` was a **backstop only**, because it neutralizes
+> motion before every capture (F1). No Linux deep gate ran at `c` under N8, and
+> no snapshots were updated. The **`c`-before-`b`/`d1`/`e`/`f1` constraint is
+> discharged** — it existed because `c` changes the oracle environment those
+> packets depend on, and `c` has now merged.
 >
 > **2026-07-27 — WP4.3j-d-hover-paint is COMPLETE in PR #186.**
 > Exactly four declarations are gone from the two retained Region G Workout Log
@@ -1017,8 +1047,19 @@
 
 ## Next Safe Step
 
-**Current:** after WP4.3j-d-hover-paint PR #186, stop and await explicit owner
-direction. No further Workout Log cleanup and no WP4.4 work is authorized.
+**Current:** WP4.4 packets `a` and `c` are merged. `b`, `d1`, `e` and `f1` are
+eligible and unstarted; they need explicit owner direction before dispatch.
+Workout Log cleanup beyond WP4.3j-d-hover-paint (PR #186) remains closed and
+owner-gated.
+
+> **Superseded 2026-07-28.** This section previously read "no WP4.4 work is
+> authorized", which contradicted the Current State block above it and
+> contradicted merged history: Gate 1 was approved 2026-07-27 and PR #187 and
+> PR #188 both landed. That contradiction is what `/status`
+> ([`.claude/commands/status.md`](../.claude/commands/status.md)) exists to
+> catch — the same drift previously caused agents to be dispatched at
+> already-shipped WP3.5 and WP4.3g work. Reconcile this file, `ACTIVE_DEVELOPMENT.md`
+> and `REFACTOR_PLAN.md` together, or not at all.
 
 Use [docs/ACTIVE_DEVELOPMENT.md](ACTIVE_DEVELOPMENT.md) as the execution source
 of truth. The older Fatigue Stage-4 and Body Composition material below is

--- a/docs/REFACTOR_PLAN.md
+++ b/docs/REFACTOR_PLAN.md
@@ -1293,10 +1293,19 @@ carries the narrative. **Wait for explicit direction before the next packet.**
 > `i`; `j` and `k` wait until `i` is approved, narrowed, or abandoned.
 >
 > **WP4.4-a is COMPLETE** — PR #187, squash `46e340e`, read-only, no production
-> CSS changed. **The active packet is now WP4.4-c (`motion.css`)**, pure
-> deletion of proven non-winners. `c` is scheduled first among the deletion
-> packets and **must merge before `b`, `d1`, `e` or `f1` begin**, because it
-> changes the oracle environment those packets depend on.
+> CSS changed.
+>
+> **WP4.4-c is COMPLETE** — PR #188, squash `1b13bfc`, merged 2026-07-28. It
+> deleted the three cascade-dead paint declarations from `.is-success` while
+> retaining the `success-pulse` animation, and corrected the Packet-a baseline
+> contract to verify the seven surfaces at the baseline's own `sourceCommit`
+> (plus an ancestry assertion, so a pin to an unreachable pre-squash commit
+> reds instead of dying on a fresh clone).
+>
+> The `c`-before-`b`/`d1`/`e`/`f1` prerequisite is therefore **discharged**.
+> Those four packets are now eligible, and Plan v2 §(a) authorizes them
+> concurrently: each owns exactly one file (`b` base, `d` a11y, `e` layout,
+> `f` navbar), never two writers on one file. None is started.
 >
 > **Method rule M6a is binding on every remaining packet** (Plan v2 §2b):
 > suppress transitions before applying, reading **and** removing a sentinel — a
@@ -1394,11 +1403,14 @@ decisions are silently outstanding; either resolve them or leave them explicitly
 > the detailed work-packet requirements above and wait for explicit owner
 > direction wherever the plan requires it.
 
-Snapshot: **2026-07-27**. **WP4.4-a is complete and merged** (PR #187, squash
+Snapshot: **2026-07-28**. **WP4.4-a is complete and merged** (PR #187, squash
 `46e340e`); it produced evidence and audit tooling, not a production CSS edit.
-The active packet is now **WP4.4-c** (`motion.css`), the first deletion packet.
-The continuous pyright burn-down is a standing track, not an active packet or
-branch. No other implementation packet is in progress.
+**WP4.4-c is complete and merged** (PR #188, squash `1b13bfc`), the arc's first
+production CSS deletion. **No implementation packet is currently active.**
+`b`, `d1`, `e` and `f1` are eligible now that the `c`-first prerequisite is
+discharged, but none is started and each awaits explicit owner direction. The
+continuous pyright burn-down is a standing track, not an active packet or
+branch.
 
 | Area / packet | Owner-review status | What has been done / current boundary | Why it is not started, deferred, or gated |
 |---|---|---|---|
@@ -1418,7 +1430,8 @@ branch. No other implementation packet is in progress.
 | Workout Plan — WP4.3i-jm and WP4.3i-o | **Closed / do not resume** | Both investigations were attempted and deliberately left uncommitted. | Their premises did not justify a safe change. They must not be re-dispatched; the detailed reasons remain in `docs/MASTER_HANDOVER.md`. |
 | Workout Log — cleanup beyond WP4.3j-d-hover-paint | **Not started / owner-gated** | Work is paused at the completed j-d boundary; retained regions and unverified declarations remain protected by the recorded contracts. | Further cleanup needs a newly scoped packet, explicit owner direction, and fresh cascade/visual measurement. A shared-selector change can alter page-local ownership, so prior deadness findings cannot be generalized. |
 | WP4.4-a — shared-surface baseline and cascade harness | **Done** | Merged via PR #187 (squash `46e340e`), read-only, no production CSS changed. Delivered the pinned baseline JSON, the committed harness under `scripts/css_audit/`, nine red-path-proven contracts, and `/fatigue` visual baselines on both platforms under N7. Harness self-checks 22/22; M4 resolution check 9,842 pairs / 0 inversions. | — |
-| WP4.4 — shared bundles, navbar, and `theme-dark.css` (packets `c`–`h`) | **Ongoing — WP4.4-c** | Plan v2 is **Gate-1 approved** (owner, 2026-07-27, rulings N1–N10) in `docs/css_phase4_wp4_4/PLANNING.md`; the prerequisite deletion sequence is discharged and `a` has landed. Remaining order: `c` → (`b`, `d1`, `e`, `f1`) → (`d2`, `f2`) → `g` → `h`. **`c` must merge before `b`/`d1`/`e`/`f1` begin** — it changes the oracle environment they depend on. | Not gated through `h`. The gates still bind: Regions A–C of Workout Log must be re-measured before any shared-selector repair; each packet carries the full visual, dark-mode, navigation, accessibility and summary-page gates; **M6a is binding**; and the ten inherited Linux `desktop` reds plus the eight uncertifiable Welcome elements are ledgered and must not be re-attributed or rebaselined. |
+| WP4.4-c — `motion.css` dead success paint | **Done** | Merged via PR #188 (squash `1b13bfc`, 2026-07-28). Deleted the three cascade-dead `.is-success` paint declarations, retaining `success-pulse`; ownership resolved over `CSS.getMatchedStylesForNode` across 11 routes × 2 themes under both `prefers-reduced-motion` states, 0 motion-record differences. Also re-pinned the Packet-a baseline contract to its own `sourceCommit` and added the ancestry assertion. | — |
+| WP4.4 — shared bundles, navbar, and `theme-dark.css` (packets `b`–`h`) | **Ongoing — `b`/`d1`/`e`/`f1` eligible, none started** | Plan v2 is **Gate-1 approved** (owner, 2026-07-27, rulings N1–N10) in `docs/css_phase4_wp4_4/PLANNING.md`. `a` and `c` have both landed, so the `c`-first prerequisite is **discharged**. Remaining order: (`b`, `d1`, `e`, `f1`) → (`d2`, `f2`) → `g` → `h`. The four eligible packets are file-disjoint — `b` base, `d` a11y, `e` layout, `f` navbar — and Plan v2 §(a) authorizes them concurrently, one writer per file. | Not gated through `h`. The gates still bind: Regions A–C of Workout Log must be re-measured before any shared-selector repair; each packet carries the full visual, dark-mode, navigation, accessibility and summary-page gates; **M6a is binding**; and the ten inherited Linux `desktop` reds plus the eight uncertifiable Welcome elements are ledgered and must not be re-attributed or rebaselined. |
 | WP4.4-i — shared `:is()` selector repair | **Gated — hard stop after `h`** | Nothing started. Ruling N4 requires a separate owner checkpoint immediately before `i`; ruling N9 restricts admissible repair shapes to CSS-local ones in `static/css/components.css`. | Gate 1 authority explicitly does **not** extend to `i`. Before any edit, `i`'s enumerated repair shape and both pre-change inventories (the complete `:is()` family from `g`/`h`, and the G3 regions A–C measurement) must be presented and approved. |
 | WP4.4 — packets `j` and `k` | **Blocked on `i`** | Nothing started. | They follow only after `i` is resolved — approved, narrowed, or abandoned per ruling N3. |
 | Superset dark tint and `layout.css` dead `body.dark-mode` | **Deferred to WP4.4** | The missing live dark override for `--superset-bg-1..4` and the dead selector at `static/css/layout.css:1120` are recorded but unchanged. | Both belong to shared-theme/layout ownership work and must not be changed in an unrelated page packet. |


### PR DESCRIPTION
## Summary

Documentation only. No code, no tests, no CSS.

The repository keeps three documents that each describe current state, and they had drifted apart from each other and from git. While PR #188 was open and green, they said simultaneously:

- "WP4.4 is EXECUTING, next packet is WP4.4-c" -- `MASTER_HANDOVER.md` top
- "no WP4.4 work is authorized" -- `MASTER_HANDOVER.md` bottom, same file
- "Do not begin WP4.4" -- `ACTIVE_DEVELOPMENT.md`, which declares itself the execution source of truth

None of the three recorded PR #188 at all. That is the condition that previously sent agents at already-shipped WP3.5 work and duplicated WP4.3g while an open PR existed.

## What changed

- **WP4.4-c recorded as complete**: PR #188, squash `1b13bfc`, merged 2026-07-28, with its own row in the owner review status table.
- **The plan snapshot moved to 2026-07-28**, and "the active packet is now WP4.4-c" became "no implementation packet is currently active".
- **Both contradictions superseded in place**, not deleted -- each carries the date and the reason, so the correction is auditable rather than looking like the drift never happened.
- **The mechanism behind the `c` deletion is recorded correctly**: the winner is `components.css:3540-3548`, `#workout[data-page="workout-plan"] .btn.btn-calm-primary`, inside `@layer workout` and `!important`. Important-layer ordering resolves before specificity -- the explicit `workout` layer outranks the implicit final unlayered layer -- so it wins even though the unlayered rules are more specific. `components.css:242` and `:3154` are unlayered fallbacks that never render.

### Correction in this PR (commit 2 of 2)

The first commit recorded the wrong mechanism: that line 242 wins, that both declarations are unlayered, that the inversion never engages, and that specificity decides. All four were false, and the merged WP4.4-c evidence already had it right.

Root cause: the audit searched only for the literal `#add_exercise_btn`, which finds lines 242/248/254 and misses `.btn.btn-calm-primary` entirely. The element is `class="btn btn-primary btn-calm-primary"` (`templates/workout_plan.html:247`) inside `<div id="workout" data-page="workout-plan">` (line 10), so the generic selector matches it. The computed values confirm it -- `rgb(76, 110, 245)` / `rgb(255, 255, 255)` are `var(--accent)` and `var(--accent-ink)`, not 242's seafoam `#98DFD6` / `#006D77`.

That method rule is now recorded in the handover: **resolve ownership against the element's real classes and ancestors, never by ID-literal search.** The correction was made forward rather than by force-push, so both the error and its fix stay visible in history.

## On what comes next

`b` is deliberately **not** described as "the next packet". Plan v2 §(a) and the Gate-1 ruling authorize `b`, `d1`, `e` and `f1` concurrently once `c` lands: they are file-disjoint (`b` base, `d` a11y, `e` layout, `f` navbar), one writer per file. Naming a single successor would re-introduce the same class of inaccuracy this PR removes.

All four are eligible, **none is started**, and each still needs explicit owner direction. The arc hard-stops after `h` per ruling N4.

## Verification

- Swept for the phrase classes, not just the three known sentences: `active packet`, `next ... packet`, `must merge`, `before ... begin`, `scheduled first`, `c ... first`. Remaining hits are all dated historical log entries that were accurate when written and are correctly preserved as records.
- All relative links in the three documents resolve against tracked files at HEAD, including the new `/status` reference, which became valid once PR #189 merged.

Draft for review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
