### PR TITLE
docs(status): warn against MSYS path conversion in revision:path checks

### DIFF
--- a/.claude/commands/status.md
+++ b/.claude/commands/status.md
@@ -17,6 +17,11 @@ three as claims to be checked, never as the answer.
   and the active feature's `PLANNING.md`. Never infer it from an evidence doc —
   those record what happened, not what is next.
 - **Read-only.** This command edits nothing, pushes nothing, starts nothing.
+- **Watch the shell on Windows.** Under Git Bash/MSYS, avoid `<revision>:<path>`
+  checks unless path conversion is disabled with `MSYS_NO_PATHCONV=1`; MSYS may
+  rewrite the argument and fabricate a missing-file result. Prefer
+  `git ls-tree -r --name-only <revision> -- <path>`, and independently verify any
+  unexpected absence.
 - **Scope the table.** Do not attempt to re-verify every historical packet;
   `git log -20` cannot substantiate a claim about a packet from three months
   ago. Cover packets that are active, ongoing, owner-gated, or proposed-next,


### PR DESCRIPTION
## What

Adds one rule to `.claude/commands/status.md`:

> On Windows Git Bash/MSYS, avoid `<revision>:<path>` checks unless path conversion is disabled with `MSYS_NO_PATHCONV=1`; MSYS may rewrite the argument and fabricate a missing-file result. Prefer `git ls-tree -r --name-only <revision> -- <path>`, and independently verify any unexpected absence.

## Why

`/status` exists to separate document claims from git ground truth. A `<revision>:<path>` lookup that MSYS silently rewrites returns a false "missing file", which is exactly the kind of fabricated evidence this command is supposed to catch — so the caveat belongs beside the other ground-truth rules.

## Placement

Kept canonical to `/status`. Deliberately **not** duplicated into the CSS-scoped verification rule, so there is one home for it.

## Scope

Documentation only — one file, five added lines. No code, schema, or response-contract change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)