### PR TITLE
css(layout): delete 34 unreachable rule blocks (WP4.4-e)

### DIFF
--- a/docs/CSS_PHASE4_WP4_4_E_LAYOUT_EVIDENCE.md
+++ b/docs/CSS_PHASE4_WP4_4_E_LAYOUT_EVIDENCE.md
@@ -1,0 +1,351 @@
+# WP4.4-e — `static/css/layout.css` triage
+
+Packet `e` of the WP4.4 shared-bundle arc. Gate 1 approved 2026-07-27 (rulings
+N1–N10); the owner directed sequential execution on 2026-07-29 with `e` first.
+
+**Result: 34 rule blocks deleted, −218 lines. Nine rules deferred.** Zero
+declaration-owner changes across 64,961 records; zero motion differences; two
+paint differences, both on ledgered-uncertifiable Welcome elements and matched
+exactly by the run's own control.
+
+Base commit: `4cd036b`. Production ownership: `static/css/layout.css` only.
+
+---
+
+## 1. What the packet inherited, and what it actually found
+
+The plan carried **one** candidate into this packet: the dead `body.dark-mode`
+at `layout.css:1120`, deferred here from WP4.3i-h.
+
+The audit found **42** fully-unreachable rules. `body.dark-mode` is one of them,
+and it is the least significant by volume.
+
+| Family | Rules | Disposition |
+|---|---|---|
+| `.tbl-col-chooser*` (trigger, menu, labels, checkbox, `:hover`, `:focus`, `.active`) | 10 | deleted |
+| `.form-container` | 9 | deleted |
+| `.input-frame .row` | 6 | deleted |
+| `.el-clip` / `.col--ellipsis` / `.col--wrap` / `.col--nowrap` | 3 | deleted |
+| `.tbl--loading` + `::after` + `@keyframes tbl-spin` | 3 | deleted |
+| `.sr-only` | 1 | deleted |
+| `.tbl-toolbar` (standalone) | 1 | deleted |
+| `body.dark-mode` | 1 | deleted |
+| `.tbl-show-*` / `.tbl-hide-*` | 9 | **deferred** |
+
+---
+
+## 2. `body.dark-mode` — re-proved, not inherited
+
+The plan's label was an assumption from another packet. It was re-measured here.
+
+**The rule is functional.** Adding `dark-mode` to `<body>` changes all seven
+`--tbl-*` tokens in **11 of 22** route×theme contexts — the light ones. In the
+dark contexts the tokens already hold those values from the live
+`[data-theme="dark"]` block immediately above, so the class changes nothing
+there. That 11/22 split is the positive control: a rule that changed nothing
+when its selector *was* satisfied would mean the oracle could not see it, and no
+deletion claim would be trustworthy.
+
+**The selector is never satisfied.** `<body>` never carries the class
+(`bodyCarriedClassNaturally: false` in all 22 contexts; full-selector census 0).
+`static/js/darkMode.js:64` sets `data-theme` on the root element; nothing
+anywhere calls `classList.add('dark-mode')` or hardcodes it in a template. That
+premise was already contract-locked repo-wide by WP4.3i-h at
+`tests/test_css_cascade_contracts.py:1229` — a file this packet **runs but does
+not edit**.
+
+**The sentinel reverted.** `revertedCleanly: true` in all 22 contexts, with
+transitions suppressed before apply, read *and* remove (M6a).
+
+**Basis for deletion: unreachability, not the ordinary non-winner rule.** The
+block declares only custom properties. The owner's constraint — *do not delete
+custom properties under the ordinary non-winner rule* — is respected: this rule
+is not deleted because something outranks it, but because nothing can ever match
+it. The seven tokens keep their live definition in `[data-theme="dark"]`, now
+pinned by `test_dark_theme_table_tokens_have_a_live_definition`.
+
+`dark-mode.spec.ts` was **not** used as evidence of deadness (F4). It is run as
+a gate only.
+
+---
+
+## 3. Oracles and controls
+
+### 3a. Rest-state differential — the committed harness
+
+`node scripts/css_audit/runtime_probe.mjs`, 11 routes × 2 themes, before and
+after.
+
+| Oracle | Records | Differing |
+|---|---|---|
+| paint | 340,960 | **2** |
+| motion | 153,432 | **0** |
+| motionReduced | 153,432 | **0** |
+| declaration owner (CDP `matchedRules`) | 64,961 | **0** |
+
+### 3b. The 2 paint differences, and why they are not this packet's
+
+Both are the same element in each theme:
+`html/body[1]/main[1]/div[0]/div[0]/section[1]/div[1]/div[0]`, property
+`box-shadow`, differing in the **blur radius at the 4th decimal place**
+(58.7193px vs 58.8779px). That is an animating glow captured at a slightly
+different phase.
+
+Three independent reasons this is not attributable to the deletion:
+
+1. The path appears in the harness's own `uncertifiablePaths` — one of the eight
+   uncertifiable Welcome elements the WP4.0 ledger records. N8 forbids
+   classifying declarations affecting them from this harness, and none were.
+2. The **before**-run's same-CSS control independently reported
+   `uncertifiableDifferingRecords: 1` for `welcome--light` and 1 for
+   `welcome--dark` — 2 total, the same 2, on identical CSS.
+3. `layout.css` never styled that element: the owner differential is 0 across
+   all 64,961 records, so no declaration changed hands anywhere.
+
+**Outside the ledgered blind spot the differential is zero.**
+
+### 3c. Same-CSS control (M5) and sentinels (M6a)
+
+| Check | Before | After |
+|---|---|---|
+| same-CSS control | 22/22 pass, **0** differing / 17,048 elements | 22/22 pass, **0** differing / 17,048 elements |
+| sentinel took effect | **4,270 / 4,270** | **4,270 / 4,270** |
+| screenshot control | 0 differing pixels, sha256 identical | 0 differing pixels, sha256 identical |
+
+### 3d. Bespoke oracle — census + synthetic injection
+
+The rest-state differential **cannot falsify an unreachable rule**: if no
+element carries the class, deleting the rule changes nothing on any rendered
+page, so a zero-diff result is consistent with deadness but is not proof of it.
+The converging evidence is a census plus synthetic injection.
+
+- **Census**, full-selector `querySelectorAll`, taken before any synthetic is
+  injected: **0** for all 42 candidates, across 11 routes × 2 themes × 16
+  viewport widths.
+- **Synthetic**: build an element satisfying the selector plus a control that
+  fails it by exactly one compound, read the rule's **own declared properties**,
+  and require a difference. **39 of 42** rules were visible before deletion.
+- **After deletion**: 37 of the 39 flipped to invisible. The two that did not
+  are proven oracle artifacts — §3e.
+
+Interaction states were **exercised, not inferred**: `:hover` driven by a real
+pointer via `page.hover()`, `:focus` by a real `.focus()` call, both with
+transitions suppressed first.
+
+### 3e. The two rules that did not flip
+
+Neither is a failed deletion; both are control-construction artifacts, and both
+were run down rather than assumed.
+
+**`.tbl-col-chooser-menu input[type="checkbox"]` (`cursor`).** After deletion
+the synthetic still read `cursor: default` against a control reading
+`cursor: text`. The control drops the distinguishing compound — here the
+`type="checkbox"` attribute — so it compared a checkbox against a text input.
+That difference is the UA stylesheet's, not `layout.css`'s.
+
+**`.sr-only`.** After deletion the synthetic still resolved
+`clip: rect(0,0,0,0); height: 1px; margin: -1px; overflow: hidden;
+position: absolute; width: 1px`. **FontAwesome 5.15.4** (`templates/base.html:16`,
+CDN) also defines `.sr-only`. The initial grep covered only local
+`static/css/*.css` and correctly found `layout.css` as the sole *local*
+definition; it did not account for the CDN sheet.
+
+Recorded precisely, because it cuts both ways: `layout.css` loads *after*
+FontAwesome, so its copy **was** the winner for `.sr-only` while it existed —
+but with census 0 it painted nothing. FontAwesome continues to supply the
+utility if anything ever adopts the class. One residual: `layout.css` set
+`white-space: nowrap` and FontAwesome does not, so a future consumer would get
+slightly different behavior. With census 0 and
+`test_deleted_classes_are_still_unreachable` gating future use, that is a
+documented residual, not a regression.
+
+### 3f. Instrumentation defects found before deleting anything
+
+Four, each of which pointed the **deletion-favourable** way. They are recorded
+because the packet's credibility rests on the controls, not on the result.
+
+| Defect | Symptom | Why it mattered |
+|---|---|---|
+| Hand-written property lists | 6 families read "paints in 0/22" | `.tbl-toolbar` declares `position/top/z-index/background-color/padding/border-bottom/box-shadow`; the guessed list read `display/align-items/gap/margin-bottom/flex-wrap`. Would have read as strong deadness evidence. |
+| Single 1440px viewport | media-gated rules invisible | `.tbl-show-lg`/`.tbl-hide-*` simply do not apply at 1440. |
+| Census counted the leaf class | `.input-frame .row` → 96 "live"; `.tbl-col-chooser-menu.active` → 128 | Counted Bootstrap's shared `.row` and `.active`. Fixed to full-selector match, taken before injection so the probe stops counting itself. |
+| Control identical to test element | `.tbl-col-chooser-menu label` read BLIND | Stripping "the last compound's classes" strips nothing when the leaf is a bare tag. Fixed to disable the deepest compound that carries classes. |
+
+A fifth was a genuine oracle limit, not a bug: a modifier rule such as
+`.tbl-col-chooser-menu.active` restores values its base rule suppressed, so
+disabling the whole compound removes the base rule too and the modifier looks
+invisible. The control now drops only the final class for multi-class compounds,
+which recovered that rule to 32/32 (`opacity, pointer-events, visibility`).
+
+---
+
+## 4. What was retained, and why
+
+### 4a. The deferred breakpoint-helper family — 9 rules
+
+`.tbl-show-sm/md/lg` and `.tbl-hide-sm/md/lg`. Census is 0 and six of the nine
+are oracle-visible, so the *unreachability* case is as strong as for the deleted
+families. They are deferred anyway because three members — the `@media`
+overrides at pre-deletion lines 1818, 1828, 1838 — declare `display: block`,
+which is a bare `div`'s initial value. **No control element can distinguish
+them**: that is an inherent limit, not a fixable probe defect, so the
+post-deletion flip cannot be demonstrated for those three.
+
+Deleting only the six observable members would leave `@media` overrides
+targeting classes with no base rule. The family goes as a unit under fresh
+evidence or not at all. Under-delivery was preferred to a claim that cannot be
+fully evidenced.
+
+Pinned by exact occurrence count in `test_retained_rules_are_still_present`, so
+the family cannot be eroded rule by rule.
+
+### 4b. Partially reachable rules — retained whole
+
+Two rules mix a dead branch with a **live** one. Trimming the dead branch out
+would re-weight a live rule; that is not deletion and is out of scope for `e`
+(it is `d2`/`f2`-shaped work).
+
+- `.tbl-controls, .tbl-toolbar { display: none }` in `@media print` —
+  `.tbl-controls` is created at runtime by `static/js/table-responsiveness.js:112`.
+  Retained in full, including its `.tbl-toolbar` branch. Print emulation
+  confirms both branches still resolve to `display: none`.
+- `.input-frame, .action-frame` (9 occurrences) — `.action-frame` is applied
+  throughout `templates/user_profile.html`. Retained in full. Only the
+  `.input-frame .row` **descendant** rules, whose every branch was unreachable,
+  were deleted.
+
+### 4c. Cross-surface note — `.form-container`
+
+`components.css` also defines `.form-container`, and loads after `layout.css`,
+so it won at equal specificity for most widths (layout.css's copies were visible
+at only 4 of 32 width×theme pairs). This packet deleted only `layout.css`'s
+copies; `components.css` is packet `h`'s surface and was not touched. The
+deletion basis is unreachability — census 0 — which holds for both copies
+independently of which would have won.
+
+---
+
+## 5. Method rules and standing constraints
+
+| Rule | How this packet satisfies it |
+|---|---|
+| **M5** same-CSS control | 22/22 pass, 0 differing records, both runs. Reported alongside the result. |
+| **M6/M6a** sentinels | 4,270/4,270 effective both runs; transitions suppressed before apply, read and remove. |
+| **M9** custom properties | No custom property deleted under the non-winner rule. `body.dark-mode`'s seven went on unreachability; their live definitions in `[data-theme="dark"]` are retained and contract-pinned. |
+| **N2** `@layer` freeze | `layout.css` had **0** `@layer` tokens at the WP4.4-a baseline and has 0 now, asserted by `test_layout_css_declares_no_cascade_layer`. No rule crossed a layer boundary. |
+| **N8** ledgered blind spots | The eight uncertifiable Welcome elements were not classified from this harness. The 2 paint diffs are attributed to them, not to this packet. |
+| **F4** | `dark-mode.spec.ts` run as a gate, never used as proof of deadness. |
+| **F16** red path | 13/13 contracts proven to fail under their own violation. |
+| Interaction states | `:hover` and `:focus` exercised with real pointer/focus, not inferred. |
+| `@media` coverage | Every rule probed only at widths its condition admits; 16-width sweep; print emulated. |
+
+---
+
+## 6. Gates
+
+| Gate | Result |
+|---|---|
+| `tests/test_css_wp4_4_layout_contracts.py` | **13 passed** |
+| Red-path proof | **13/13 go red** under their own violation; tree restores to 13 passed |
+| Full `pytest tests/` | **2,230 passed, 1 skipped** (405.20s) |
+| Shared `test_css_cascade_contracts.py` + visual selector contracts | run, **unedited**, green within the full suite |
+| `dark-mode`, `smoke-navigation`, `accessibility`, `volume-progress`, `summary-pages`, `fatigue`, `fatigue-stage4-smokes` | **89 passed** (2.2m) |
+| `visual.spec.ts`, Chromium, 6 variants × 11 routes | **65 passed, 1 failed** — the ledgered known red, below |
+| Stylelint, seven surfaces | **2,875 → 2,857 (−18)**, no rule increased, 0 parse errors |
+| `layout.css` Stylelint | 102 → 84 |
+
+### The one visual failure is the ledgered animated-logo red
+
+`visual.spec.ts:40 › visual baseline: workout-plan › workout-plan desktop dark`.
+
+This is the known red the WP4.4-a baseline records: *"The animated-logo band
+(1,039 / 1,046 px) sits above 800 — it is a real snapshot failure of
+`workout-plan-desktop-dark`, not a diff the option absorbs. Nobody may 'fix' it
+by raising `maxDiffPixels`."* No exact pixel count is asserted here: the diff is
+a **band, not a constant**, and the same run has produced 1,039 then 1,046 on
+retry.
+
+The same 65-passed / 1-failed shape was recorded by WP4.4-b. `layout.css` does
+not style the animated logo, and the owner differential is 0 across all 64,961
+records, so nothing in this packet can have moved it.
+
+`maxDiffPixels` was not touched, and no snapshot was written — see V2 below.
+
+### Stylelint attribution
+
+| Rule | Before | After | Δ |
+|---|---|---|---|
+| `declaration-property-value-disallowed-list` | 1,122 | 1,106 | −16 |
+| `no-descending-specificity` | 245 | 244 | −1 |
+| `no-duplicate-selectors` | 26 | 25 | −1 |
+| `declaration-no-important` | 1,260 | 1,260 | 0 |
+| `selector-max-id` | 116 | 116 | 0 |
+| `selector-max-specificity` | 102 | 102 | 0 |
+| `declaration-block-no-duplicate-properties` | 2 | 2 | 0 |
+| `property-no-unknown` | 2 | 2 | 0 |
+
+---
+
+## 7. Preservation invariants
+
+| Invariant | Verdict |
+|---|---|
+| **V1** no visual difference | Rest-state differential 0 outside the ledgered Welcome blur; screenshot controls byte-identical both runs. |
+| **V2** no rebaseline | `git status` shows **0** changed paths under `e2e/__screenshots__/` and no `e2e/visual-helpers.ts` change. |
+| **V3** no re-weighting | `!important` **24 → 24**; `selector-max-id` +0; `selector-max-specificity` +0. Pure deletion. |
+| **V4** no duplication increase | `no-duplicate-selectors` 26 → 25; `declaration-block-no-duplicate-properties` 2 → 2. |
+| **V5** contribution | −218 lines, −34 rules, −128 declarations. Nine rules deliberately left on the table; scope was **not** widened to chase a projection. |
+| **V6** no conflict | Single writer, single file. |
+
+---
+
+## 8. Surface accounting
+
+| Metric | Before | After | Δ |
+|---|---|---|---|
+| lines | 1,842 | 1,624 | −218 |
+| rules | 268 | 234 | −34 |
+| declarations | 729 | 601 | −128 |
+| `!important` | 24 | 24 | 0 |
+| custom-property declarations | 46 | 39 | −7 |
+| `@layer` tokens | 0 | 0 | 0 |
+| fully-unreachable rules | 42 | 9 | −33 |
+
+---
+
+## 9. Reproducing this
+
+```bash
+# static candidate enumeration -> artifacts/wp4_4/layout_static.json
+python artifacts/wp4_4/layout_static.py
+# derive probe specs (properties + admissible widths) from the parsed CSS
+python artifacts/wp4_4/make_specs.py
+
+# rest-state differential, committed harness
+node scripts/css_audit/runtime_probe.mjs --out artifacts/wp4_4/layout_before
+#   … apply the deletion …
+node scripts/css_audit/runtime_probe.mjs --out artifacts/wp4_4/layout_after
+python artifacts/wp4_4/diff_runs.py artifacts/wp4_4/layout_before artifacts/wp4_4/layout_after
+
+# bespoke census + synthetic oracle, before and after
+node artifacts/wp4_4/layout_probe2.mjs --out artifacts/wp4_4/probe2_before
+
+# red path
+python artifacts/wp4_4/redpath.py
+
+# stylelint, seven surfaces
+node scripts/css_audit/stylelint_surfaces.mjs artifacts/wp4_4/stylelint_after.json
+```
+
+The analysis scripts live under the gitignored `artifacts/` tree;
+`scripts/css_audit/` stays packet-`a`-owned and was not modified (A11).
+
+---
+
+## 10. Out of scope
+
+- `.tbl-show-*` / `.tbl-hide-*` — deferred, §4a.
+- `components.css`'s `.form-container` / `.input-frame` — packet `h`'s surface.
+- Trimming dead branches out of live selector lists — re-weighting, `d2`/`f2`.
+- `theme-dark.css` superset dark tint — packet `j`.
+- The `:is()` shared-selector repair — packet `i`, behind the N4 checkpoint.

--- a/static/css/layout.css
+++ b/static/css/layout.css
@@ -260,9 +260,6 @@ body:not(:has(#navbar)) .navbar,
 /* ============================================================
    MOBILE FIRST - Base (< 576px)
    ============================================================ */
-.form-container {
-    flex-direction: column;
-}
 
 .uniform-dropdown {
     width: 100%;
@@ -283,10 +280,6 @@ body:not(:has(#navbar)) .navbar,
    MEDIUM DEVICES - Tablets Landscape (768px - 991px)
    ============================================================ */
 @media screen and (min-width: 768px) {
-    .form-container {
-        flex-direction: row;
-        flex-wrap: wrap;
-    }
     
     .uniform-dropdown {
         width: auto;
@@ -325,9 +318,6 @@ body:not(:has(#navbar)) .navbar,
         max-width: 480px;
     }
     
-    .form-container {
-        gap: var(--space-md, 0.875rem);
-    }
 }
 
 /* ============================================================
@@ -389,14 +379,7 @@ body:not(:has(#navbar)) .navbar,
         font-size: 0.7rem;
     }
     
-    .form-container {
-        gap: 0.25rem;
-    }
     
-    .input-frame .row {
-        gap: 0.25rem;
-        padding: 0.25rem;
-    }
     
     h1 { font-size: 1.1rem; }
     h2 { font-size: 0.95rem; }
@@ -477,14 +460,7 @@ body:not(:has(#navbar)) .navbar,
         font-size: 0.72rem;
     }
     
-    .form-container {
-        gap: 0.3rem;
-    }
     
-    .input-frame .row {
-        gap: 0.3rem;
-        padding: 0.3rem;
-    }
     
     h1 { font-size: 1.15rem; }
     h2 { font-size: 1rem; }
@@ -565,14 +541,7 @@ body:not(:has(#navbar)) .navbar,
         font-size: 0.75rem;
     }
     
-    .form-container {
-        gap: 0.325rem;
-    }
     
-    .input-frame .row {
-        gap: 0.325rem;
-        padding: 0.325rem;
-    }
     
     h1 { font-size: 1.2rem; }
     h2 { font-size: 1.05rem; }
@@ -653,14 +622,7 @@ body:not(:has(#navbar)) .navbar,
         font-size: 0.78rem;
     }
     
-    .form-container {
-        gap: 0.35rem;
-    }
     
-    .input-frame .row {
-        gap: 0.35rem;
-        padding: 0.35rem;
-    }
     
     h1 { font-size: 1.25rem; }
     h2 { font-size: 1.1rem; }
@@ -741,14 +703,7 @@ body:not(:has(#navbar)) .navbar,
         font-size: 0.8rem;
     }
     
-    .form-container {
-        gap: 0.375rem;
-    }
     
-    .input-frame .row {
-        gap: 0.375rem;
-        padding: 0.375rem;
-    }
     
     h1 { font-size: 1.375rem; }
     h2 { font-size: 1.125rem; }
@@ -903,14 +858,7 @@ body:not(:has(#navbar)) .navbar,
         --bs-gutter-y: 0 !important;
     }
     
-    .form-container {
-        gap: 0.75rem;
-    }
     
-    .input-frame .row {
-        gap: 0.75rem;
-        padding: 0.75rem;
-    }
 }
 
 /* ============================================================
@@ -1116,16 +1064,6 @@ body:not(:has(#navbar)) .navbar,
   --tbl-sticky-shadow-header: 0 2px 4px rgba(0, 0, 0, 0.3);
 }
 
-/* Dark mode class fallback (if data-theme not used) */
-body.dark-mode {
-  --tbl-border-color: #374151;
-  --tbl-header-bg: #1f2937;
-  --tbl-header-color: #f9fafb;
-  --tbl-row-hover-bg: #374151;
-  --tbl-stripe-bg: #1f2937;
-  --tbl-sticky-shadow: 2px 0 4px rgba(0, 0, 0, 0.3);
-  --tbl-sticky-shadow-header: 0 2px 4px rgba(0, 0, 0, 0.3);
-}
 
 /* ============================================================
    TABLE WRAPPER & CONTAINER
@@ -1265,26 +1203,6 @@ body.dark-mode {
   font-variant-numeric: tabular-nums;
 }
 
-/* Ellipsis for long content */
-.el-clip,
-.col--ellipsis {
-  white-space: nowrap;
-  overflow: hidden;
-  text-overflow: ellipsis;
-  max-width: 20ch;
-}
-
-/* Wrap long text */
-.col--wrap {
-  white-space: normal;
-  overflow-wrap: break-word;
-  word-break: break-word;
-}
-
-/* No wrap */
-.col--nowrap {
-  white-space: nowrap;
-}
 
 /* ============================================================
    COLUMN PRIORITY CLASSES
@@ -1505,21 +1423,6 @@ body.dark-mode {
   z-index: 20;
 }
 
-.tbl-col-chooser-trigger {
-  padding: 0.5rem 0.875rem;
-  font-size: 0.875rem;
-  font-weight: 500;
-  border: 1px solid var(--tbl-border-color);
-  border-radius: 0.375rem;
-  background-color: var(--bs-body-bg, #ffffff);
-  color: var(--bs-body-color, #212529);
-  cursor: pointer;
-  transition: all 0.2s ease;
-  white-space: nowrap;
-  display: inline-flex;
-  align-items: center;
-  gap: 0.5rem;
-}
 
 @media (max-width: 768px) {
   .tbl-controls {
@@ -1527,83 +1430,8 @@ body.dark-mode {
   }
 }
 
-.tbl-col-chooser-trigger:hover {
-  background-color: var(--tbl-row-hover-bg);
-  border-color: var(--bs-primary, #0d6efd);
-  box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
-}
-
-.tbl-col-chooser-trigger:focus {
-  outline: 2px solid var(--bs-primary, #0d6efd);
-  outline-offset: 2px;
-}
-
-.tbl-col-chooser {
-  position: relative;
-  display: inline-block;
-  z-index: 20;
-}
-
-.tbl-col-chooser-trigger {
-  position: relative;
-}
-
-.tbl-col-chooser-menu {
-  position: fixed;
-  top: auto;
-  left: auto;
-  max-width: 280px;
-  min-width: 200px;
-  max-height: 400px;
-  overflow-y: auto;
-  background-color: var(--bs-body-bg, #ffffff);
-  border: 1px solid var(--tbl-border-color);
-  border-radius: 0.375rem;
-  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.15);
-  z-index: 100000;
-  visibility: hidden;
-  opacity: 0;
-  pointer-events: none;
-  will-change: transform;
-  padding: 0.5rem;
-  transition: opacity 0.15s ease-out, visibility 0s linear 0.15s;
-}
-
-.tbl-col-chooser-menu.active {
-  visibility: visible;
-  opacity: 1;
-  pointer-events: auto;
-  transition: opacity 0.15s ease-out, visibility 0s linear 0s;
-}
 
 /* Ensure menu doesn't overflow viewport on the right */
-@media (max-width: 640px) {
-  .tbl-col-chooser-menu {
-    position: fixed;
-    top: auto;
-    left: 50%;
-    transform: translateX(-50%);
-    bottom: 20px;
-    max-width: calc(100vw - 2rem);
-  }
-}
-
-.tbl-col-chooser-menu label {
-  display: flex;
-  align-items: center;
-  gap: 0.5rem;
-  padding: 0.375rem 0.5rem;
-  cursor: pointer;
-  font-size: 0.875rem;
-  white-space: nowrap;
-  overflow: hidden;
-  text-overflow: ellipsis;
-}
-
-.tbl-col-chooser-menu input[type="checkbox"] {
-  cursor: pointer;
-}
-
 /* ============================================================
    VIEW MODE TOGGLE (Simple/Advanced) - Glass Style
    ============================================================ */
@@ -1691,15 +1519,6 @@ body.dark-mode {
    STICKY FILTERS/TOOLBAR (if present)
    ============================================================ */
 
-.tbl-toolbar {
-  position: sticky;
-  top: 0;
-  z-index: calc(var(--tbl-z-header) + 1);
-  background-color: var(--bs-body-bg, #ffffff);
-  padding: 0.75rem 1rem;
-  border-bottom: 1px solid var(--tbl-border-color);
-  box-shadow: 0 2px 4px rgba(0, 0, 0, 0.05);
-}
 
 /* ============================================================
    ACCESSIBILITY ENHANCEMENTS
@@ -1714,18 +1533,6 @@ body.dark-mode {
   outline-offset: -2px;
 }
 
-/* Screen reader only content */
-.sr-only {
-  position: absolute;
-  width: 1px;
-  height: 1px;
-  padding: 0;
-  margin: -1px;
-  overflow: hidden;
-  clip: rect(0, 0, 0, 0);
-  white-space: nowrap;
-  border-width: 0;
-}
 
 /* ============================================================
    PRINT STYLES
@@ -1767,31 +1574,6 @@ body.dark-mode {
    LOADING STATE
    ============================================================ */
 
-.tbl--loading {
-  opacity: 0.6;
-  pointer-events: none;
-  position: relative;
-}
-
-.tbl--loading::after {
-  content: '';
-  position: absolute;
-  top: 50%;
-  left: 50%;
-  transform: translate(-50%, -50%);
-  width: 2rem;
-  height: 2rem;
-  border: 3px solid var(--tbl-border-color);
-  border-top-color: var(--bs-primary, #0d6efd);
-  border-radius: 50%;
-  animation: tbl-spin 0.8s linear infinite;
-}
-
-@keyframes tbl-spin {
-  to {
-    transform: translate(-50%, -50%) rotate(360deg);
-  }
-}
 
 /* ============================================================
    RESPONSIVE BREAKPOINT HELPERS

--- a/tests/test_css_wp4_4_layout_contracts.py
+++ b/tests/test_css_wp4_4_layout_contracts.py
@@ -1,0 +1,316 @@
+"""WP4.4-e cascade contracts for `static/css/layout.css`.
+
+These lock the premises the packet's deletions rest on. Each test is written so
+that it fails under its own violation (F16) -- the red-path proofs are recorded
+in docs/CSS_PHASE4_WP4_4_E_LAYOUT_EVIDENCE.md.
+
+This file is packet-owned. It never edits, and must not be confused with, the
+shared `tests/test_css_cascade_contracts.py`, which WP4.4-e runs but does not
+touch (Plan v2 section 4d -- only packet i may amend that file).
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+import pytest
+
+ROOT = Path(__file__).resolve().parents[1]
+LAYOUT = ROOT / "static" / "css" / "layout.css"
+TEMPLATES = ROOT / "templates"
+JS = ROOT / "static" / "js"
+
+
+def _css() -> str:
+    return LAYOUT.read_text(encoding="utf-8")
+
+
+def _strip_comments(css: str) -> str:
+    """Length-preserving, so byte offsets stay valid after stripping."""
+    return re.sub(r"/\*.*?\*/", lambda m: " " * len(m.group(0)), css, flags=re.S)
+
+
+# Classes whose entire rule set WP4.4-e deleted from layout.css. Every one was
+# measured at census 0 across 11 routes x 2 themes x 16 viewport widths, and
+# each deleted rule was demonstrably visible to the synthetic oracle before
+# deletion (so its disappearance is a measurement, not an assumption).
+DELETED_CLASSES = (
+    "form-container",
+    "input-frame",
+    "el-clip",
+    "col--ellipsis",
+    "col--wrap",
+    "col--nowrap",
+    "tbl-col-chooser",
+    "tbl-col-chooser-trigger",
+    "tbl-col-chooser-menu",
+    "tbl-toolbar",
+    "sr-only",
+    "tbl--loading",
+)
+
+# Classes whose every layout.css rule is gone. `tbl-toolbar` and `input-frame`
+# are excluded: both still appear inside selector lists that also name a LIVE
+# class, and those rules were retained whole. Removing just the dead branch
+# would be re-weighting a live rule, which is out of scope for a pure-deletion
+# packet -- see test_partially_reachable_rules_kept_their_dead_branch.
+FULLY_REMOVED_CLASSES = tuple(
+    c for c in DELETED_CLASSES if c not in {"tbl-toolbar", "input-frame"}
+)
+
+# Rules WP4.4-e deliberately did NOT touch, each for a stated reason. Pinning
+# them here is what stops a later packet from treating this packet's silence as
+# permission.
+RETAINED_SNIPPETS = (
+    # The live dark-theme token block. body.dark-mode was deleted as
+    # unreachable; this attribute-selector block is the live definition and
+    # must survive.
+    '[data-theme="dark"]',
+    # The print rule pairs .tbl-toolbar with .tbl-controls, which IS live
+    # (table-responsiveness.js:112 creates it). Partially reachable -> retained
+    # in full, including its .tbl-toolbar branch.
+    ".tbl-controls,",
+)
+
+# The deferred breakpoint-helper family, pinned by exact occurrence count.
+#
+# Substring presence is too weak a gate here: `.tbl-show-sm` appears twice (a
+# top-level rule and an @media override), so asserting "it is still mentioned"
+# stays green when one of the two is deleted. The red-path proof caught exactly
+# that. Counts pin the family member by member.
+#
+# Deferred because three members (the @media overrides) declare `display: block`
+# -- a bare div's initial value -- so no control element can distinguish them
+# and the oracle is inherently blind. Deleting only the six observable members
+# would leave @media overrides targeting classes with no base rule.
+DEFERRED_HELPER_COUNTS = {
+    "tbl-show-sm": 2,
+    "tbl-show-md": 2,
+    "tbl-show-lg": 2,
+    "tbl-hide-sm": 1,
+    "tbl-hide-md": 1,
+    "tbl-hide-lg": 1,
+}
+
+
+def test_deleted_rule_blocks_stay_deleted() -> None:
+    """No rule in layout.css targets a class this packet proved unreachable.
+
+    Red path: restoring any deleted block reintroduces its selector and fails.
+    """
+    css = _strip_comments(_css())
+    offenders = []
+    for cls in FULLY_REMOVED_CLASSES:
+        # A selector use, not a mention inside a var() name or another word.
+        if re.search(rf"\.{re.escape(cls)}(?![\w-])", css):
+            offenders.append(cls)
+    assert offenders == [], (
+        "layout.css again styles classes WP4.4-e deleted as unreachable: "
+        f"{offenders}. If a class became reachable, the deletion must be "
+        "revisited with a fresh census -- do not simply re-add the rule."
+    )
+
+
+def test_partially_reachable_rules_kept_their_dead_branch() -> None:
+    """Rules whose selector list mixes a dead branch with a LIVE one survive whole.
+
+    `.tbl-controls, .tbl-toolbar` -- `.tbl-controls` is created at runtime by
+    static/js/table-responsiveness.js, so the rule paints and stays.
+    `.input-frame, .action-frame` -- `.action-frame` is applied throughout
+    templates/user_profile.html.
+
+    Trimming the dead branch out of either would re-weight a live rule. That is
+    not a deletion and is out of scope for WP4.4-e.
+
+    Red path: deleting the `.tbl-toolbar` branch from the print rule, or the
+    `.input-frame` branch from the frame rules, fails this test.
+    """
+    css = _strip_comments(_css())
+    assert re.search(r"\.tbl-controls\s*,\s*\.tbl-toolbar\s*\{", css), (
+        "the print rule `.tbl-controls, .tbl-toolbar` lost its .tbl-toolbar "
+        "branch; .tbl-controls is live so the rule must be retained whole"
+    )
+    assert re.search(r"\.input-frame\s*,\s*\.action-frame\s*\{", css), (
+        "the `.input-frame, .action-frame` rules lost their .input-frame "
+        "branch; .action-frame is live so the rule must be retained whole"
+    )
+    # And no OTHER layout.css rule may target these two classes alone.
+    for cls, allowed in (("tbl-toolbar", 1), ("input-frame", 9)):
+        found = len(re.findall(rf"\.{re.escape(cls)}(?![\w-])", css))
+        assert found == allowed, (
+            f".{cls} appears {found} times in layout.css, expected {allowed} "
+            "(only inside the retained mixed selector lists)"
+        )
+
+
+def test_deleted_classes_are_still_unreachable() -> None:
+    """Nothing in the app applies the deleted classes.
+
+    This is the premise the deletion rests on, converted into a gate: adding
+    `class="tbl-toolbar"` to a template now fails pytest rather than silently
+    resurrecting a style whose rules are gone.
+
+    Red path: adding `class="sr-only"` to any template fails this test.
+    """
+    corpus = []
+    for base, pattern in ((TEMPLATES, "**/*.html"), (JS, "**/*.js")):
+        for path in base.glob(pattern):
+            corpus.append((path, path.read_text(encoding="utf-8", errors="replace")))
+
+    class_attr = re.compile(r"""class\s*=\s*["']([^"']*)["']""")
+    add_call = re.compile(
+        r"""classList\.(?:add|toggle|replace)\(\s*["']([\w-]+)["']"""
+    )
+
+    offenders: list[str] = []
+    for path, text in corpus:
+        applied: set[str] = set()
+        for match in class_attr.finditer(text):
+            applied.update(match.group(1).split())
+        applied.update(add_call.findall(text))
+        for cls in DELETED_CLASSES:
+            if cls in applied:
+                offenders.append(f"{path.relative_to(ROOT)} applies .{cls}")
+
+    assert offenders == [], (
+        "a deleted layout.css class is now applied by the app: "
+        + "; ".join(offenders)
+    )
+
+
+def test_retained_rules_are_still_present() -> None:
+    """The rules WP4.4-e deliberately kept are still there.
+
+    Red path: deleting the `[data-theme="dark"]` token block, or the print
+    `.tbl-controls, .tbl-toolbar` rule, or the deferred breakpoint helpers,
+    fails this test.
+    """
+    css = _css()
+    missing = [snippet for snippet in RETAINED_SNIPPETS if snippet not in css]
+    assert missing == [], (
+        f"layout.css lost rules WP4.4-e explicitly retained: {missing}"
+    )
+
+    stripped = _strip_comments(css)
+    wrong = {}
+    for cls, expected in DEFERRED_HELPER_COUNTS.items():
+        found = len(re.findall(rf"\.{re.escape(cls)}(?![\w-])", stripped))
+        if found != expected:
+            wrong[cls] = f"{found} (expected {expected})"
+    assert wrong == {}, (
+        "the deferred .tbl-show-*/.tbl-hide-* breakpoint-helper family changed: "
+        f"{wrong}. WP4.4-e deferred this family whole because three of its "
+        "members are invisible to any control element; it must be deleted as a "
+        "unit under fresh evidence, not eroded rule by rule."
+    )
+
+
+def test_dark_theme_table_tokens_have_a_live_definition() -> None:
+    """The seven --tbl-* tokens survive the body.dark-mode deletion.
+
+    body.dark-mode declared exactly these seven custom properties and nothing
+    else. It was deleted because `<body>` never carries the class -- not under
+    the ordinary non-winner rule, which does not apply to custom properties.
+    The live `[data-theme="dark"]` block above it declares the same seven, and
+    that is what must remain.
+
+    Red path: removing any one token from the `[data-theme="dark"]` block fails.
+    """
+    tokens = (
+        "--tbl-border-color",
+        "--tbl-header-bg",
+        "--tbl-header-color",
+        "--tbl-row-hover-bg",
+        "--tbl-stripe-bg",
+        "--tbl-sticky-shadow",
+        "--tbl-sticky-shadow-header",
+    )
+    css = _strip_comments(_css())
+    match = re.search(r'\[data-theme="dark"\]\s*\{(.*?)\}', css, flags=re.S)
+    assert match, 'the [data-theme="dark"] token block is gone from layout.css'
+    block = match.group(1)
+    missing = [t for t in tokens if f"{t}:" not in block]
+    assert missing == [], (
+        f'[data-theme="dark"] no longer defines: {missing}. These are the only '
+        "live definitions since body.dark-mode was deleted."
+    )
+
+
+def test_body_dark_mode_block_stays_deleted() -> None:
+    """`.dark-mode` is not styled by layout.css and is not applied anywhere.
+
+    Red path: restoring the `body.dark-mode` block fails the first assertion;
+    adding `classList.add('dark-mode')` to a JS module fails the second.
+    """
+    assert "dark-mode" not in _strip_comments(_css()), (
+        "layout.css styles .dark-mode again; the live mechanism is the "
+        "data-theme attribute set by static/js/darkMode.js"
+    )
+
+    applies = re.compile(
+        r"""classList\.(?:add|toggle|replace)\(\s*["']dark-mode(?![\w-])"""
+    )
+    hardcoded = re.compile(r"""class\s*=\s*["'][^"']*\bdark-mode(?![\w-])""")
+    for base, pattern in ((TEMPLATES, "**/*.html"), (JS, "**/*.js")):
+        for path in base.glob(pattern):
+            text = path.read_text(encoding="utf-8", errors="replace")
+            assert not applies.search(text), f"{path} applies .dark-mode as a class"
+            assert not hardcoded.search(text), f"{path} hardcodes .dark-mode"
+
+
+def test_layout_css_declares_no_cascade_layer() -> None:
+    """N2 freezes @layer membership arc-wide.
+
+    layout.css had zero `@layer` tokens at the WP4.4-a baseline and must still
+    have zero: this packet may not move a rule across a layer boundary, and the
+    cheapest expression of that for this surface is that no layer exists in it.
+
+    Red path: wrapping any rule in `@layer navbar { ... }` fails.
+    """
+    assert "@layer" not in _strip_comments(_css()), (
+        "layout.css now declares an @layer; N2 freezes layer membership for "
+        "the whole WP4.4 arc"
+    )
+
+
+def test_orphaned_keyframes_went_with_their_only_consumer() -> None:
+    """`@keyframes tbl-spin` had exactly one consumer, `.tbl--loading::after`.
+
+    Deleting the consumer without the keyframes would leave dead animation
+    data; keeping the keyframes reachable would be a false claim.
+
+    Red path: restoring `@keyframes tbl-spin` fails.
+    """
+    css = _strip_comments(_css())
+    assert "tbl-spin" not in css, (
+        "@keyframes tbl-spin (or a reference to it) is back in layout.css, but "
+        "its only consumer .tbl--loading::after was deleted"
+    )
+
+
+@pytest.mark.parametrize(
+    "surface",
+    ["tokens.css", "components.css", "navbar.css", "theme-dark.css", "a11y.css"],
+)
+def test_deleted_classes_are_not_resurrected_by_a_sibling_surface(surface: str) -> None:
+    """A sibling bundle must not start styling a class layout.css stopped
+    styling, which would silently re-create the family this packet removed.
+
+    `.form-container` and `.input-frame` are deliberately excluded:
+    components.css already defines them, and WP4.4-e's deletion was scoped to
+    layout.css's own copies. Their reachability -- census 0 -- is what makes
+    both copies dead, and that premise is gated by
+    test_deleted_classes_are_still_unreachable above.
+
+    Red path: adding `.tbl-toolbar {}` to components.css fails this test.
+    """
+    path = ROOT / "static" / "css" / surface
+    if not path.exists():
+        pytest.skip(f"{surface} not present")
+    css = _strip_comments(path.read_text(encoding="utf-8"))
+    scoped = [c for c in DELETED_CLASSES if c not in {"form-container", "input-frame"}]
+    offenders = [c for c in scoped if re.search(rf"\.{re.escape(c)}(?![\w-])", css)]
+    assert offenders == [], (
+        f"{surface} now styles classes WP4.4-e deleted from layout.css: {offenders}"
+    )


### PR DESCRIPTION
Packet `e` of the WP4.4 shared-bundle arc (Gate 1 approved 2026-07-27, rulings N1–N10; owner-directed sequential execution 2026-07-29). Pure deletion from `static/css/layout.css`: **34 rule blocks, −218 lines, −128 declarations, 0 insertions.**

Evidence: [`docs/CSS_PHASE4_WP4_4_E_LAYOUT_EVIDENCE.md`](docs/CSS_PHASE4_WP4_4_E_LAYOUT_EVIDENCE.md).

## The packet found more than it inherited

The plan carried **one** candidate here — the dead `body.dark-mode` at `layout.css:1120`, deferred from WP4.3i-h. The audit found **42** fully-unreachable rules. 33 plus one orphaned `@keyframes` are deleted; 9 are deferred.

| Family | Rules | Disposition |
|---|---|---|
| `.tbl-col-chooser*` (trigger, menu, label, checkbox, `:hover`, `:focus`, `.active`) | 10 | deleted |
| `.form-container` | 9 | deleted |
| `.input-frame .row` | 6 | deleted |
| `.el-clip` / `.col--ellipsis` / `.col--wrap` / `.col--nowrap` | 3 | deleted |
| `.tbl--loading` + `::after` + `@keyframes tbl-spin` | 3 | deleted |
| `.sr-only`, `.tbl-toolbar` (standalone), `body.dark-mode` | 3 | deleted |
| `.tbl-show-*` / `.tbl-hide-*` | 9 | **deferred** |

## `body.dark-mode` — re-proved, not inherited

The rule **is functional**: adding the class changes all seven `--tbl-*` tokens in 11/22 contexts (the light ones; in dark they already hold those values). Its selector is **never satisfied**: `<body>` never carries the class, and `darkMode.js:64` sets `data-theme` on the root element instead.

Deleted on **unreachability**, not the ordinary non-winner rule — which does not apply to custom properties, and the block declares only custom properties. Their live definitions in `[data-theme="dark"]` are retained and contract-pinned. `dark-mode.spec.ts` was run as a gate, never used as proof of deadness (F4).

## What was deliberately left

- **The 9-rule breakpoint-helper family.** Census 0 and six of nine oracle-visible, so the unreachability case is as strong as for the deleted families. But three members declare `display: block` — a bare `div`'s initial value — so **no control element can distinguish them**; that is an inherent limit, not a fixable probe defect. Splitting the family would leave `@media` overrides targeting classes with no base rule, so it stays whole, pinned by exact occurrence count.
- **Partially-reachable rules, retained whole.** `.tbl-controls, .tbl-toolbar` in `@media print` (`.tbl-controls` is created by `table-responsiveness.js:112`) and the `.input-frame, .action-frame` rules (`.action-frame` is live throughout `user_profile.html`). Trimming a dead branch out of a live selector list is re-weighting, not deletion — out of scope for a pure-deletion packet.

## Evidence

| Oracle | Records | Differing |
|---|---|---|
| declaration owner (CDP `matchedRules`) | 64,961 | **0** |
| motion + motionReduced | 306,864 | **0** |
| paint | 340,960 | **2** |

The 2 paint diffs are the same animating Welcome glow in each theme, differing in the **4th decimal of its blur radius**. The path is in the harness's own `uncertifiablePaths` (one of the eight ledgered Welcome elements, N8), and the **before**-run's same-CSS control independently reported the same 2 records on identical CSS.

| Control | Before | After |
|---|---|---|
| same-CSS (M5) | 22/22 pass, 0 differing / 17,048 elements | 22/22 pass, 0 differing |
| sentinel took effect (M6a) | 4,270 / 4,270 | 4,270 / 4,270 |
| screenshot control | 0 differing pixels | 0 differing pixels |

Census (full-selector `querySelectorAll`, before injection): **0** for all 42 candidates across 11 routes × 2 themes × 16 widths. Synthetic oracle: **39/42 visible before deletion**; `:hover` driven by a real pointer, `:focus` by a real focus call.

**Four instrumentation defects were found and fixed before anything was deleted**, each pointing the deletion-favourable way: hand-written property lists, a single 1440px viewport, a census counting the leaf class (Bootstrap's `.row`/`.active`), and a control identical to its test element for bare-tag leaves. Recorded in §3f — the packet's credibility rests on the controls, not the result.

Two rules did not flip after deletion; both are proven artifacts, not failed deletions: the checkbox `cursor` difference is the UA stylesheet's (the control dropped `type="checkbox"`), and **FontAwesome 5.15.4 also defines `.sr-only`**. The latter is recorded with its residual — `layout.css` set `white-space: nowrap`, FontAwesome does not — as a documented consequence rather than a silent one.

## Gates

| Gate | Result |
|---|---|
| Packet contracts | **13 passed**, **13/13 red-path proven** |
| Full `pytest tests/` | **2,230 passed, 1 skipped** (405s) |
| Shared cascade + visual-selector contracts | run, **unedited**, green |
| `dark-mode`, `smoke-navigation`, `accessibility`, `volume-progress`, `summary-pages`, `fatigue`, `fatigue-stage4-smokes` | **89 passed** |
| `visual.spec.ts` (6 variants × 11 routes) | **65 passed, 1 failed** — the ledgered red |
| Stylelint, seven surfaces | **2,875 → 2,857 (−18)**, no category increased, 0 parse errors |

The one visual failure is `workout-plan desktop dark`, the animated-logo red the packet-a baseline records as a genuine failure above `maxDiffPixels: 800` that must never be "fixed" by raising the tolerance. No exact pixel count is asserted — it is a band (1,039/1,046 on retry). WP4.4-b recorded the same 65/1 shape. `layout.css` does not style the logo and the owner differential is 0.

## Mechanical verification

- `e2e/__screenshots__/` — **0** changed paths
- `e2e/visual-helpers.ts` — unchanged
- `@layer` tokens in `layout.css` — 0 → 0 (**N2**)
- `!important` — 24 → 24 (**V3**, nothing re-weighted)
- `no-duplicate-selectors` 26 → 25, `declaration-block-no-duplicate-properties` 2 → 2 (**V4**)
- No snapshot rebaseline; `maxDiffPixels` untouched
- Diff is three paths only; `scripts/css_audit/` unmodified (A11)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
