### PR TITLE
docs(status): record WP4.4-e complete and name d1 as next

### DIFF
--- a/docs/ACTIVE_DEVELOPMENT.md
+++ b/docs/ACTIVE_DEVELOPMENT.md
@@ -4,32 +4,54 @@ This file is the execution source of truth for autonomous development sessions. 
 
 ## Current Objective
 
-**2026-07-29 (LATEST) — WP4.4-b is complete in PR #192 (squash `3bec677`).
-Three of eleven packets are merged: `a` (PR #187, `46e340e`), `c` (PR #188,
-`1b13bfc`) and `b` (PR #192, `3bec677`).** `b` deleted four dead `base.css`
-rule blocks (−44 lines): the `.skeleton` block beaten by `motion.css` at equal
-specificity, plus the three unreachable `.loading-spinner` / `.fade-enter` /
-`.fade-enter-active` classes. All 12 `:root` custom properties were retained and
-contract-pinned under M9. Gates: packet contracts **8 passed**, full pytest
-**2,204 passed / 1 skipped**, the five required specs **68 passed**, visual
-**65 passed / 1 ledgered known red**, Stylelint **−2** with no rule increased.
-Evidence: [`CSS_PHASE4_WP4_4_B_BASE_EVIDENCE.md`](CSS_PHASE4_WP4_4_B_BASE_EVIDENCE.md).
+**2026-07-29 (LATEST) — WP4.4-e is complete in PR #195 (squash `1346a35`).
+FOUR of eleven packets are merged:** `a` (#187, `46e340e`), `c` (#188,
+`1b13bfc`), `b` (#192, `3bec677`), `e` (#195, `1346a35`).
 
-**Owner-directed execution order (2026-07-29) — the arc runs SEQUENTIALLY from
-here.** The owner has authorized packets through `h` and directed one packet,
-one worktree, one writer and one PR at a time:
+**WP4.4-e** deleted **34 rule blocks from `layout.css`, −218 lines, 0
+insertions**. The plan carried one candidate into the packet (`body.dark-mode`);
+the audit found **42** fully-unreachable rules. `body.dark-mode` was re-proved,
+not inherited: the rule *is* functional (all seven `--tbl-*` tokens change in
+11/22 contexts when the class is applied) but its selector is never satisfied —
+`<body>` never carries the class, and `darkMode.js:64` sets `data-theme` on the
+root element. It was deleted on **unreachability**, not the ordinary non-winner
+rule, which does not apply to custom properties. The tokens keep their live
+`[data-theme="dark"]` definitions, now contract-pinned.
+
+Evidence: 0 declaration-owner differences / 64,961 records; 0 motion /
+306,864; 2 paint / 340,960, both the ledgered Welcome blur reproduced by the
+before-run's own same-CSS control. Census 0 for all 42 candidates across 11
+routes × 2 themes × 16 widths. Gates: contracts **13 passed, 13/13 red-path
+proven**, full pytest **2,230 / 1 skipped**, seven required specs **89 passed**,
+visual **65 / 1 ledgered red**, Stylelint **2,875 → 2,857 (−18)**, no category
+increased. `!important` 24 → 24 and `@layer` 0 → 0.
+Evidence: [`CSS_PHASE4_WP4_4_E_LAYOUT_EVIDENCE.md`](CSS_PHASE4_WP4_4_E_LAYOUT_EVIDENCE.md).
+
+**Nine rules were deliberately deferred** — the `.tbl-show-*` / `.tbl-hide-*`
+family. Census is 0 and six of nine are oracle-visible, but three declare
+`display: block` (a bare div's initial value), so no control element can
+distinguish them. Splitting the family would leave `@media` overrides targeting
+classes with no base rule, so it is deferred whole and pinned by exact
+occurrence count. **Do not erode it rule by rule.**
+
+**Owner-directed execution order (2026-07-29) — the arc runs SEQUENTIALLY,
+one packet / worktree / writer / PR at a time:**
 
 ```
-e → d1 → f1 → d2 → f2 → g → h → HARD STOP (N4 owner checkpoint before i)
+a ✔ → c ✔ → b ✔ → e ✔ → d1 → f1 → d2 → f2 → g → h → HARD STOP (N4)
 ```
 
-`e` is next. This narrows, and does not contradict, Plan v2 §4: that section
-still classifies `e`, `d1` and `f1` as concurrency-eligible class (a) pure
-deletion, but the owner has elected serial execution, and `f1` is deliberately
-last among the pure-deletion packets because navbar layering, global exposure
-and the animated-logo oracle make it the riskiest. Each packet reconciles these
-three status documents at its merge boundary. The arc hard-stops after `h` per
-ruling N4; Gate 1 authority does not extend to `i`, `j` or `k`.
+**`d1` (`a11y.css`, pure deletion only) is next.** This ordering narrows, and
+does not contradict, Plan v2 §4: that section still classifies `d1` and `f1` as
+concurrency-eligible class (a) pure deletion, but the owner has elected serial
+execution, and `f1` is deliberately last among the pure-deletion packets because
+navbar layering, global exposure and the animated-logo oracle make it the
+riskiest. Each packet reconciles these three status documents at its merge
+boundary. The arc hard-stops after `h` per ruling N4; Gate 1 authority does not
+extend to `i`, `j` or `k`.
+
+> **Superseded 2026-07-29 (later).** This section previously announced WP4.4-b
+> as LATEST with `e` next. `e` has since merged in PR #195.
 
 > **Superseded 2026-07-29.** This section previously read *"WP4.4-c is complete
 > in PR #188 … `b`, `d1`, `e` and `f1` are eligible, none started, each still
@@ -231,20 +253,28 @@ intentional review of the exact golden diff before any behavior change.
 
 ## Next Action
 
-**WP4.4-e (`static/css/layout.css`) is next**, and it is authorized. `a`, `c`
-and `b` are merged; `b` must not be re-dispatched. Execute `e` in a fresh
-visual-seeded worktree off current `main`, as pure deletion only, then continue
-sequentially: `e` → `d1` → `f1` → `d2` → `f2` → `g` → `h`, one writer and one
-PR per packet.
+**WP4.4-d1 (`static/css/a11y.css`, pure deletion only) is next**, and it is
+authorized. `a`, `c`, `b` and `e` are merged; none of them may be re-dispatched.
+Execute `d1` in a fresh visual-seeded worktree off current `main`, then continue
+sequentially: `d1` → `f1` → `d2` → `f2` → `g` → `h`, one writer and one PR per
+packet.
 
-Packet `e` owns exactly `static/css/layout.css`. The dead `body.dark-mode` rule
-recorded at `static/css/layout.css:1120` is a **candidate only** and must be
-re-proved under the current method before deletion — computed-owner evidence
-with all stylesheets loaded, a rest-state before/after differential, a same-CSS
-control, and M6a transition suppression around applying, reading and removing
-every sentinel. `dark-mode.spec.ts` alone is **not** proof of deadness (F4). If
-it proves live, retain it and correct the historical assumption in the packet
-evidence.
+Packet `d1` owns exactly `static/css/a11y.css`. Binding constraints:
+
+- **Re-weighting and `!important` changes are `d2`'s, not `d1`'s.**
+- Preserve the focus-visible, skip-link, keyboard-focus and scale guarantees.
+- Exercise **every** targeted `data-scale` level in both themes.
+- Include print emulation, breakpoint coverage, computed-style checks and
+  keyboard traversal.
+- Preserve the contract-pinned a11y declarations — `a11y.css` is named in the
+  shared contract file, which `d1` **runs but never edits**.
+- M6a and every common packet gate apply.
+
+Method note carried from `e`: a sentinel sweep and a rest-state differential
+cannot falsify an **unreachable** rule, because deleting one changes nothing on
+any rendered page. Pair them with a runtime full-selector census and a synthetic
+injection whose control fails the selector by exactly one compound, and derive
+every probed property from the rule's own declarations rather than guessing.
 
 No further Workout Log packet is authorized, and do not begin fatigue or feature
 work or reopen the root-cleanup track. Do not begin `i`, `j` or `k`.

--- a/docs/MASTER_HANDOVER.md
+++ b/docs/MASTER_HANDOVER.md
@@ -14,28 +14,63 @@
 > WP4.4 packet ordering or next-safe-step below.
 >
 > **2026-07-29 (LATEST) — WP4.4 is EXECUTING. Gate 1 is approved (rulings
-> N1–N10). THREE of eleven packets are merged:**
+> N1–N10). FOUR of eleven packets are merged:**
 >
 > | Packet | PR | Squash | Nature |
 > |---|---|---|---|
 > | **a** shared-surface baseline + cascade harness | #187 | `46e340e` | read-only, no production CSS |
 > | **c** `motion.css` dead success paint | #188 | `1b13bfc` | pure deletion, 3 declarations |
 > | **b** `base.css` four dead rule blocks | #192 | `3bec677` | pure deletion, −44 lines |
+> | **e** `layout.css` 34 unreachable rule blocks | #195 | `1346a35` | pure deletion, −218 lines, 0 insertions |
 >
 > **Owner-directed execution order (2026-07-29) — the arc runs SEQUENTIALLY,
 > one packet, worktree, writer and PR at a time:**
 >
 > ```
-> e → d1 → f1 → d2 → f2 → g → h → HARD STOP (N4 owner checkpoint before i)
+> a ✔ → c ✔ → b ✔ → e ✔ → d1 → f1 → d2 → f2 → g → h → HARD STOP (N4)
 > ```
 >
-> **`e` (`static/css/layout.css`) is next and is authorized.** `b` is DONE and
-> must not be re-dispatched. This ordering narrows rather than contradicts Plan
-> v2 §4: `e`, `d1` and `f1` remain class (a) concurrency-eligible pure deletion
-> there, but the owner has elected serial execution, and `f1` is deliberately
-> last among the pure-deletion packets because navbar layering, global exposure
-> and the animated-logo oracle make it the riskiest. Gate 1 authority does not
-> extend to `i`, `j` or `k`.
+> **`d1` (`static/css/a11y.css`, pure deletion only) is next and is
+> authorized.** `a`, `c`, `b` and `e` are DONE and must not be re-dispatched.
+> This ordering narrows rather than contradicts Plan v2 §4: `d1` and `f1` remain
+> class (a) concurrency-eligible pure deletion there, but the owner has elected
+> serial execution, and `f1` is deliberately last among the pure-deletion
+> packets because navbar layering, global exposure and the animated-logo oracle
+> make it the riskiest. Gate 1 authority does not extend to `i`, `j` or `k`.
+>
+> **WP4.4-e outcome and the method lesson worth carrying.** The plan carried
+> **one** candidate into `e` (`body.dark-mode`); the audit found **42**
+> fully-unreachable rules, including an entire `.tbl-col-chooser` widget the app
+> has never rendered. 34 blocks were deleted; 9 were deferred.
+>
+> `body.dark-mode` was re-proved rather than inherited, and cleared on the right
+> basis: the rule *is* functional (all seven `--tbl-*` tokens change in 11/22
+> contexts) but its selector is *never satisfied*. Deleted on **unreachability**,
+> **not** the ordinary non-winner rule — which does not apply to custom
+> properties, and that block declared only custom properties.
+>
+> **Binding method addition: a rest-state differential cannot falsify an
+> unreachable rule.** If nothing carries the class, deleting the rule changes
+> nothing on any rendered page, so a zero-diff result is *consistent with*
+> deadness but is not proof of it. Pair it with (a) a runtime **full-selector**
+> census taken before any synthetic is injected, and (b) synthetic injection
+> whose control fails the selector by exactly one compound, reading properties
+> **derived from the rule's own declarations**.
+>
+> Four instrumentation defects were caught by controls before anything was
+> deleted, every one pointing the deletion-favourable way: hand-written property
+> lists; a single-viewport probe blind to `@media`-gated rules; a census counting
+> the leaf class (Bootstrap's shared `.row` / `.active`) instead of the full
+> selector; and a control byte-identical to its own test element when the leaf is
+> a bare tag. Full detail in
+> [`CSS_PHASE4_WP4_4_E_LAYOUT_EVIDENCE.md`](CSS_PHASE4_WP4_4_E_LAYOUT_EVIDENCE.md) §3f.
+>
+> Also recorded there: **FontAwesome 5.15.4 independently defines `.sr-only`**
+> (`templates/base.html:16`, CDN-only, no fallback), with a `white-space: nowrap`
+> residual versus the deleted `layout.css` copy.
+>
+> > **Superseded 2026-07-29 (later).** This block previously listed three merged
+> > packets with `e` next. `e` merged in PR #195.
 >
 > **WP4.4-b** deleted the `.skeleton` block beaten by `motion.css` at equal
 > specificity, plus the three unreachable classes `.loading-spinner`,
@@ -1112,23 +1147,39 @@
 
 ## Next Safe Step
 
-**Current (2026-07-29):** WP4.4 packets `a`, `c` and `b` are merged — 3 of 11.
-**WP4.4-e (`static/css/layout.css`) is the next action and is authorized**,
-executed as pure deletion only in a fresh visual-seeded worktree off current
+**Current (2026-07-29, later):** WP4.4 packets `a`, `c`, `b` and `e` are merged
+— **4 of 11**. **WP4.4-d1 (`static/css/a11y.css`, pure deletion only) is the
+next action and is authorized**, in a fresh visual-seeded worktree off current
 `main`. The owner-directed remaining order is sequential:
 
 ```
-e → d1 → f1 → d2 → f2 → g → h → HARD STOP (N4 owner checkpoint before i)
+d1 → f1 → d2 → f2 → g → h → HARD STOP (N4 owner checkpoint before i)
 ```
 
-`b` is DONE (PR #192, squash `3bec677`) and must not be re-dispatched. One
-packet, one worktree, one writer, one PR at a time; reconcile these three status
-documents at each merge boundary. The dead `body.dark-mode` at
-`static/css/layout.css:1120` is a **candidate only** for `e` and must be
-re-proved under computed-owner evidence + rest-state differential + same-CSS
-control + M6a sentinel handling; `dark-mode.spec.ts` alone is not proof (F4).
+`a`, `c`, `b` and `e` are DONE and must not be re-dispatched. One packet, one
+worktree, one writer, one PR at a time; reconcile these three status documents
+at each merge boundary.
+
+**`d1` constraints:** re-weighting and `!important` changes belong to `d2`, not
+`d1`; preserve the focus-visible, skip-link, keyboard-focus and scale
+guarantees; exercise every targeted `data-scale` level in both themes; include
+print emulation, breakpoint coverage, computed-style checks and keyboard
+traversal; preserve the contract-pinned a11y declarations (`a11y.css` is named
+in the shared contract file, which `d1` **runs but never edits**).
+
 Workout Log cleanup beyond WP4.3j-d-hover-paint (PR #186) remains closed and
 owner-gated. Do not begin `i`, `j` or `k`.
+
+**Deferred by `e`, owner-gated, do not act:** the nine-rule
+`.tbl-show-*` / `.tbl-hide-*` breakpoint-helper family in `layout.css`. Census
+is 0 and six of nine are oracle-visible, but three declare `display: block` — a
+bare div's initial value — so no control element can distinguish them. It is
+pinned by exact occurrence count and must be deleted as a **unit** under fresh
+evidence, never eroded rule by rule.
+
+> **Superseded 2026-07-29 (later).** This section previously read "packets `a`,
+> `c` and `b` are merged — 3 of 11 … WP4.4-e is the next action". `e` merged in
+> PR #195 (squash `1346a35`).
 
 > **Superseded 2026-07-29.** This section previously read *"WP4.4 packets `a`
 > and `c` are merged. `b`, `d1`, `e` and `f1` are eligible and unstarted; they

--- a/docs/REFACTOR_PLAN.md
+++ b/docs/REFACTOR_PLAN.md
@@ -1292,7 +1292,7 @@ carries the narrative. **Wait for explicit direction before the next packet.**
 > one packet / worktree / writer / PR at a time:**
 >
 > ```
-> a ✔ → c ✔ → b ✔ → e → d1 → f1 → d2 → f2 → g → h → HARD STOP
+> a ✔ → c ✔ → b ✔ → e ✔ → d1 → f1 → d2 → f2 → g → h → HARD STOP
 > ```
 >
 > **The arc stops after `h`** for the N4 owner checkpoint. Gate 1 authority does
@@ -1319,10 +1319,24 @@ carries the narrative. **Wait for explicit direction before the next packet.**
 > properties retained and contract-pinned under M9. Stylelint **−2**, no rule
 > increased; full pytest **2,204 / 1 skipped**; visual **65 / 1 ledgered red**.
 >
-> The `c`-before-`b`/`d1`/`e`/`f1` prerequisite is **discharged**, and `b` is
-> now **shipped**. **`e` (`layout.css`) is next**; `b` must not be re-dispatched.
-> Each packet still owns exactly one file — `d` a11y, `e` layout, `f` navbar —
-> never two writers on one file.
+> **WP4.4-e is COMPLETE** — PR #195, squash `1346a35`, merged 2026-07-29. Pure
+> deletion of **34 unreachable rule blocks from `layout.css` (−218 lines, 0
+> insertions)**. The plan carried one candidate (`body.dark-mode`); the audit
+> found **42** fully-unreachable rules. `body.dark-mode` was re-proved and
+> deleted on **unreachability**, not the ordinary non-winner rule — it declares
+> only custom properties, whose live definitions in `[data-theme="dark"]` are
+> retained and contract-pinned. 0 declaration-owner differences across 64,961
+> records; Stylelint 2,875 → 2,857 (−18); `!important` 24 → 24; `@layer` 0 → 0.
+>
+> **`e` deferred nine rules** — the `.tbl-show-*` / `.tbl-hide-*` family. Three
+> members declare `display: block`, a bare div's initial value, so no control
+> element can distinguish them. Pinned by exact occurrence count; delete as a
+> unit under fresh evidence or not at all.
+>
+> The `c`-before-`b`/`d1`/`e`/`f1` prerequisite is **discharged**; `b` and `e`
+> are **shipped**. **`d1` (`a11y.css`, pure deletion only) is next**; `a`, `c`,
+> `b` and `e` must not be re-dispatched. Each packet still owns exactly one
+> file — `d` a11y, `f` navbar — never two writers on one file.
 >
 > **Method rule M6a is binding on every remaining packet** (Plan v2 §2b):
 > suppress transitions before applying, reading **and** removing a sentinel — a
@@ -1420,17 +1434,19 @@ decisions are silently outstanding; either resolve them or leave them explicitly
 > the detailed work-packet requirements above and wait for explicit owner
 > direction wherever the plan requires it.
 
-Snapshot: **2026-07-29**. **Three of eleven WP4.4 packets are merged.**
+Snapshot: **2026-07-29 (later)**. **Four of eleven WP4.4 packets are merged.**
 **WP4.4-a** (PR #187, squash `46e340e`) produced evidence and audit tooling, not
 a production CSS edit. **WP4.4-c** (PR #188, squash `1b13bfc`) was the arc's
 first production CSS deletion. **WP4.4-b** (PR #192, squash `3bec677`) deleted
-four dead `base.css` rule blocks. **`b` is DONE and must not be re-dispatched.**
+four dead `base.css` rule blocks. **WP4.4-e** (PR #195, squash `1346a35`)
+deleted 34 unreachable `layout.css` rule blocks, −218 lines. **`a`, `c`, `b` and
+`e` are DONE and must not be re-dispatched.**
 
 The owner directed a **sequential** remaining order on 2026-07-29 — one packet,
 worktree, writer and PR at a time:
-`e` → `d1` → `f1` → `d2` → `f2` → `g` → `h` → **hard stop for the N4 owner
-checkpoint before `i`**. **WP4.4-e (`layout.css`) is the next action.** The
-continuous pyright burn-down is a standing track, not an active packet or
+`d1` → `f1` → `d2` → `f2` → `g` → `h` → **hard stop for the N4 owner checkpoint
+before `i`**. **WP4.4-d1 (`a11y.css`, pure deletion only) is the next action.**
+The continuous pyright burn-down is a standing track, not an active packet or
 branch.
 
 | Area / packet | Owner-review status | What has been done / current boundary | Why it is not started, deferred, or gated |
@@ -1453,9 +1469,11 @@ branch.
 | WP4.4-a — shared-surface baseline and cascade harness | **Done** | Merged via PR #187 (squash `46e340e`), read-only, no production CSS changed. Delivered the pinned baseline JSON, the committed harness under `scripts/css_audit/`, nine red-path-proven contracts, and `/fatigue` visual baselines on both platforms under N7. Harness self-checks 22/22; M4 resolution check 9,842 pairs / 0 inversions. | — |
 | WP4.4-c — `motion.css` dead success paint | **Done** | Merged via PR #188 (squash `1b13bfc`, 2026-07-28). Deleted the three cascade-dead `.is-success` paint declarations, retaining `success-pulse`; ownership resolved over `CSS.getMatchedStylesForNode` across 11 routes × 2 themes under both `prefers-reduced-motion` states, 0 motion-record differences. Also re-pinned the Packet-a baseline contract to its own `sourceCommit` and added the ancestry assertion. | — |
 | WP4.4-b — `base.css` four dead rule blocks | **Done** | Merged via PR #192 (squash `3bec677`, 2026-07-29). Pure deletion, −44 lines: the `.skeleton` block beaten by `motion.css` at equal specificity, plus the three unreachable classes `.loading-spinner`, `.fade-enter`, `.fade-enter-active`. All 12 `:root` custom properties retained and contract-pinned under M9. Packet contracts 8 passed; full pytest 2,204 / 1 skipped; five required specs 68 passed; visual 65 passed / 1 ledgered known red; Stylelint −2, no rule increased. | — |
-| WP4.4 — shared bundles, navbar, and `theme-dark.css` (packets `d`–`h`) | **Ongoing — `e` is next and authorized** | Plan v2 is **Gate-1 approved** (owner, 2026-07-27, rulings N1–N10) in `docs/css_phase4_wp4_4/PLANNING.md`. `a`, `c` and `b` have landed (3 of 11). The owner directed a **sequential** order on 2026-07-29: `e` → `d1` → `f1` → `d2` → `f2` → `g` → `h`, one packet/worktree/writer/PR at a time. Packets remain file-disjoint — `d` a11y, `e` layout, `f` navbar. The serial order narrows Plan v2 §4's concurrent class (a) authorization rather than contradicting it; `f1` is last among the pure-deletion packets as the riskiest. | Not gated through `h`. The gates still bind: Regions A–C of Workout Log must be re-measured before any shared-selector repair; each packet carries the full visual, dark-mode, navigation, accessibility and summary-page gates; **M6a is binding**; and the ten inherited Linux `desktop` reds plus the eight uncertifiable Welcome elements are ledgered and must not be re-attributed or rebaselined. |
+| WP4.4-e — `layout.css` unreachable rule blocks | **Done** | Merged via PR #195 (squash `1346a35`, 2026-07-29). Pure deletion of **34 rule blocks, −218 lines, 0 insertions**: the `.tbl-col-chooser*` widget (10), `.form-container` (9), `.input-frame .row` (6), `.el-clip`/`.col--*` (3), `.tbl--loading` + `::after` + orphaned `@keyframes tbl-spin` (3), `.sr-only`, standalone `.tbl-toolbar`, `body.dark-mode`. Census 0 on the full selector across 11 routes × 2 themes × 16 widths; 0 declaration-owner differences / 64,961 records; contracts 13 passed with 13/13 red-path proven; pytest 2,230 / 1 skipped; seven required specs 89 passed; visual 65 / 1 ledgered red; Stylelint 2,875 → 2,857 (−18); `!important` 24 → 24; `@layer` 0 → 0. | — |
+| WP4.4 — shared bundles, navbar, and `theme-dark.css` (packets `d`–`h`) | **Ongoing — `d1` is next and authorized** | Plan v2 is **Gate-1 approved** (owner, 2026-07-27, rulings N1–N10) in `docs/css_phase4_wp4_4/PLANNING.md`. `a`, `c`, `b` and `e` have landed (4 of 11). The owner directed a **sequential** order on 2026-07-29: `d1` → `f1` → `d2` → `f2` → `g` → `h`, one packet/worktree/writer/PR at a time. Packets remain file-disjoint — `d` a11y, `f` navbar. The serial order narrows Plan v2 §4's concurrent class (a) authorization rather than contradicting it; `f1` is last among the pure-deletion packets as the riskiest. | Not gated through `h`. The gates still bind: Regions A–C of Workout Log must be re-measured before any shared-selector repair; each packet carries the full visual, dark-mode, navigation, accessibility and summary-page gates; **M6a is binding**; and the ten inherited Linux `desktop` reds plus the eight uncertifiable Welcome elements are ledgered and must not be re-attributed or rebaselined. **Method addition from `e`: a rest-state differential cannot falsify an unreachable rule — pair it with a full-selector runtime census and a synthetic injection whose control fails the selector by exactly one compound, reading properties derived from the rule's own declarations.** |
+| `layout.css` `.tbl-show-*` / `.tbl-hide-*` breakpoint helpers | **Deferred by WP4.4-e / gated** | Nine rules. Census 0 and six of nine are visible to the synthetic oracle, but three declare `display: block` — a bare div's initial value — so no control element can distinguish them and their post-deletion flip cannot be demonstrated. Pinned by exact occurrence count in `tests/test_css_wp4_4_layout_contracts.py`. | Splitting the family would leave `@media` overrides targeting classes with no base rule. It must be deleted as a **unit** under fresh evidence, never eroded rule by rule. |
 | WP4.4-i — shared `:is()` selector repair | **Gated — hard stop after `h`** | Nothing started. Ruling N4 requires a separate owner checkpoint immediately before `i`; ruling N9 restricts admissible repair shapes to CSS-local ones in `static/css/components.css`. | Gate 1 authority explicitly does **not** extend to `i`. Before any edit, `i`'s enumerated repair shape and both pre-change inventories (the complete `:is()` family from `g`/`h`, and the G3 regions A–C measurement) must be presented and approved. |
 | WP4.4 — packets `j` and `k` | **Blocked on `i`** | Nothing started. | They follow only after `i` is resolved — approved, narrowed, or abandoned per ruling N3. |
-| Superset dark tint and `layout.css` dead `body.dark-mode` | **`body.dark-mode` now in scope for WP4.4-e as a candidate; superset tint still deferred** | The missing live dark override for `--superset-bg-1..4` remains recorded and unchanged. The selector at `static/css/layout.css:1120` enters WP4.4-e's audit as a **candidate only** — the "dead" label is an inherited assumption, not a current measurement. | The superset tint belongs to `theme-dark.css` ownership (packet `j`), still gated. `layout.css:1120` may be deleted only if re-proved under the current method: computed-owner evidence with all stylesheets loaded, a rest-state before/after differential, a same-CSS control, and M6a transition suppression around sentinel apply/read/remove. `dark-mode.spec.ts` alone is **not** proof of deadness (F4). If it proves live, it is retained and the historical assumption is corrected in the packet evidence. |
+| Superset dark tint and `layout.css` dead `body.dark-mode` | **`body.dark-mode` RESOLVED by WP4.4-e; superset tint still deferred** | `body.dark-mode` was re-proved and **deleted** in PR #195. The rule was *functional* (all seven `--tbl-*` tokens changed in 11/22 contexts when the class was applied) but its selector was *never satisfied*: `<body>` never carries the class and `darkMode.js:64` sets `data-theme` on the root element. Deleted on **unreachability**, explicitly **not** the ordinary non-winner rule, which does not apply to custom properties. The seven tokens keep their live `[data-theme="dark"]` definitions, now contract-pinned. The missing live dark override for `--superset-bg-1..4` remains recorded and unchanged. | The superset tint belongs to `theme-dark.css` ownership (packet `j`), still gated. |
 | Continuous pyright baseline burn-down | **Ongoing — standing track only** | The track remains available for one file or one tightly coupled diagnostic family at a time; no active packet is identified by this snapshot. | It has no single phase-close packet. Each change must remain type-only, reduce the diagnostic multiset, and pass focused plus full pytest gates. |
 | Overall refactor plan | **Partially complete; WP4.4 in execution** | Track A and Phases -1 through 3 are complete; Track B is complete except WPB.4; Phase 4 is complete through the boundaries listed above, and the WP4.4 shared-bundle arc is now executing under Gate-1 authority. | The only authorized work is WP4.4 packets `a` through `h`. WPB.4 and the remaining Workout Plan / Workout Log page cleanup stay paused pending separate owner selection; WP4.4-i needs the N4 checkpoint. |


### PR DESCRIPTION
Merge-boundary reconciliation for [PR #195](https://github.com/avihay1989/Hypertrophy-Toolbox-v3/pull/195) (squash `1346a35`). Updates the three status documents together, as the `/status` rule requires.

- **WP4.4-e marked complete** — 34 unreachable rule blocks deleted from `layout.css`, −218 lines, 0 insertions. **4 of 11 packets merged** (a, c, b, e).
- **`d1` (a11y.css, pure deletion only) is now named as next** in every current-state, next-action, snapshot and status-table location, with its binding constraints recorded: re-weighting and `!important` belong to `d2`; preserve focus-visible / skip-link / keyboard-focus / scale guarantees; exercise every `data-scale` level in both themes; print emulation, breakpoint coverage, computed-style checks, keyboard traversal; `a11y.css` is named in the shared contract file, which `d1` **runs but never edits**.
- **`body.dark-mode` resolved** — re-proved, then deleted on **unreachability**, not the ordinary non-winner rule (which does not apply to custom properties). Its seven `--tbl-*` tokens keep their live `[data-theme="dark"]` definitions, contract-pinned. Status-table row moves from *candidate* to *resolved*.
- **New durable gate row** — the nine-rule `.tbl-show-*`/`.tbl-hide-*` family deferred by `e`. Three members declare `display: block`, a bare div's initial value, so no control element can distinguish them. Pinned by exact occurrence count and recorded as delete-as-a-unit-or-not-at-all, so a later packet cannot erode it.
- **Method addition carried into the remaining packets** — a rest-state differential *cannot* falsify an unreachable rule, since deleting one changes nothing on any rendered page. Pair it with a full-selector runtime census taken before injection, and a synthetic control that fails the selector by exactly one compound, reading properties derived from the rule's own declarations.
- Records that **FontAwesome 5.15.4 independently defines `.sr-only`**, with a `white-space: nowrap` residual versus the deleted `layout.css` copy.

Superseded narrative retained inline with dated markers. No executable ruling in `docs/css_phase4_wp4_4/PLANNING.md` is modified. Docs-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)