### PR TITLE
docs(status): record WP4.4-d1 complete and name f1 as next

### DIFF
--- a/docs/ACTIVE_DEVELOPMENT.md
+++ b/docs/ACTIVE_DEVELOPMENT.md
@@ -4,9 +4,50 @@ This file is the execution source of truth for autonomous development sessions. 
 
 ## Current Objective
 
-**2026-07-29 (LATEST) — WP4.4-e is complete in PR #195 (squash `1346a35`).
-FOUR of eleven packets are merged:** `a` (#187, `46e340e`), `c` (#188,
-`1b13bfc`), `b` (#192, `3bec677`), `e` (#195, `1346a35`).
+**2026-07-29 (LATEST) — WP4.4-d1 is complete in PR #197 (squash `59e5b10`).
+FIVE of eleven packets are merged:** `a` (#187, `46e340e`), `c` (#188,
+`1b13bfc`), `b` (#192, `3bec677`), `e` (#195, `1346a35`), `d1` (#197,
+`59e5b10`).
+
+**WP4.4-d1** deleted **14 rule blocks from `a11y.css`, −99 lines, 0
+insertions** — a *superseded generation* of the scale / accessibility UI
+(`.scale-control`, `.scale-btn-group`, `.scale-labels`, `.accessibility-menu`,
+`.accessibility-section*`), leaving the live compact generation
+(`.scale-control-compact`, `.scale-btn-compact`, `.scale-indicator`) intact.
+
+Full-selector runtime census was **0 for all 14 candidates across 164
+contexts** (2 themes × 10 widths × 8 `data-scale` levels, plus print and
+reduced-motion). The **oracle validity gate passed first**: the known-live
+compact generation reported census > 0 in **160/160** contexts, so the oracle
+demonstrably sees rules that render. `[data-visual-scale-control]` is a
+registered visual blind spot, so computed-style and declaration-owner evidence
+were load-bearing, not pixels.
+
+Gates: contracts **16 passed, 15/15 red-path proven**; full pytest **2,245 / 1
+skipped**; nine required specs **127 passed**; visual **65 / 1 ledgered red**;
+Stylelint **2,857 → 2,851 (−6)**, no category increased. `!important` **51 →
+51**, custom properties **17 → 17**, `@layer` **0 → 0** — the d1/d2 boundary held
+by construction, since all 14 deleted rules contained zero `!important`.
+Evidence: [`CSS_PHASE4_WP4_4_D1_A11Y_EVIDENCE.md`](CSS_PHASE4_WP4_4_D1_A11Y_EVIDENCE.md).
+
+**Two `d1` findings that bind later packets:**
+
+1. **State the post-deletion flip by source identity, never as "the rule went
+   blind"** — that phrasing cannot be distinguished from "the oracle stopped
+   working". `d1` proved its two residual `.scale-control` matches resolve via
+   CDP `CSS.getMatchedStylesForNode` to the **retained** `@media print` rule at
+   source lines 329–331, and to **zero** rules on `screen`. Separate four
+   things: deleted rule identity, selector text, retained source rule, computed
+   declaration owner.
+2. **Substring assertions masked by duplicate selector text are a recurring
+   defect class**, seen in both `e` and `d1`. Use occurrence-count or
+   source-shape assertions.
+
+**Recorded, not acted on:** `.scale-btn[data-scale]` has runtime census **0** —
+`accessibility.js:144` and `:202` query an empty set, a second dormant JS path.
+Those 11 bare `.scale-btn` rules were **never audited as `d1` candidates**
+(the static pass wrongly treated a JS *query* as proof of reachability) and are
+retained untouched. Deleting them needs its own census and its own packet.
 
 **WP4.4-e** deleted **34 rule blocks from `layout.css`, −218 lines, 0
 insertions**. The plan carried one candidate into the packet (`body.dark-mode`);
@@ -38,10 +79,10 @@ occurrence count. **Do not erode it rule by rule.**
 one packet / worktree / writer / PR at a time:**
 
 ```
-a ✔ → c ✔ → b ✔ → e ✔ → d1 → f1 → d2 → f2 → g → h → HARD STOP (N4)
+a ✔ → c ✔ → b ✔ → e ✔ → d1 ✔ → f1 → d2 → f2 → g → h → HARD STOP (N4)
 ```
 
-**`d1` (`a11y.css`, pure deletion only) is next.** This ordering narrows, and
+**`f1` (`navbar.css`, pure deletion only) is next.** This ordering narrows, and
 does not contradict, Plan v2 §4: that section still classifies `d1` and `f1` as
 concurrency-eligible class (a) pure deletion, but the owner has elected serial
 execution, and `f1` is deliberately last among the pure-deletion packets because
@@ -253,28 +294,50 @@ intentional review of the exact golden diff before any behavior change.
 
 ## Next Action
 
-**WP4.4-d1 (`static/css/a11y.css`, pure deletion only) is next**, and it is
-authorized. `a`, `c`, `b` and `e` are merged; none of them may be re-dispatched.
-Execute `d1` in a fresh visual-seeded worktree off current `main`, then continue
-sequentially: `d1` → `f1` → `d2` → `f2` → `g` → `h`, one writer and one PR per
-packet.
+**WP4.4-f1 (`static/css/navbar.css`, pure deletion only) is next**, and it is
+authorized. `a`, `c`, `b`, `e` and `d1` are merged; none may be re-dispatched.
+Execute `f1` in a fresh visual-seeded worktree off current `main`, then continue
+sequentially: `f1` → `d2` → `f2` → `g` → `h`, one writer and one PR per packet.
 
-Packet `d1` owns exactly `static/css/a11y.css`. Binding constraints:
+**`f1` is deliberately last among the pure-deletion packets** because navbar
+layering, global exposure and the animated-logo oracle make it the riskiest.
+Packet `f1` owns exactly `static/css/navbar.css`. Binding constraints:
 
-- **Re-weighting and `!important` changes are `d2`'s, not `d1`'s.**
-- Preserve the focus-visible, skip-link, keyboard-focus and scale guarantees.
-- Exercise **every** targeted `data-scale` level in both themes.
-- Include print emulation, breakpoint coverage, computed-style checks and
-  keyboard traversal.
-- Preserve the contract-pinned a11y declarations — `a11y.css` is named in the
-  shared contract file, which `d1` **runs but never edits**.
+- **Generation consolidation and re-weighting are `f2`'s, not `f1`'s.**
+- **Freeze layer membership (N2).** `navbar.css` holds the arc's only
+  `@layer navbar` block, spanning lines 6–883 at the WP4.4-a baseline —
+  **G11: the last `@layer navbar` block may never be deleted.**
+- Preserve the contract-pinned `--nav-gap`, `--nav-padding-y` and
+  `--nav-padding-x` declarations (pinned in the shared contract file, which
+  `f1` **runs but never edits**).
+- Treat layered `!important` declarations as **potentially live winners** —
+  A6/G10: for `!important`, layer order inverts, so an explicit layer outranks
+  the implicit final unlayered layer regardless of specificity.
+- Exercise collapsed and expanded navigation, dropdowns, keyboard navigation,
+  both themes, and all required routes.
+- Reconcile the animated-logo result **only** against its established known-red
+  band (1,039 / 1,046 px on `workout-plan-desktop-dark`); it is a band, not a
+  constant. Movement **outside** that band stops the packet.
 - M6a and every common packet gate apply.
 
-Method note carried from `e`: a sentinel sweep and a rest-state differential
-cannot falsify an **unreachable** rule, because deleting one changes nothing on
-any rendered page. Pair them with a runtime full-selector census and a synthetic
-injection whose control fails the selector by exactly one compound, and derive
-every probed property from the rule's own declarations rather than guessing.
+**Method carried from `e` and `d1` — binding:**
+
+- A sentinel sweep and a rest-state differential **cannot falsify an unreachable
+  rule**, because deleting one changes nothing on any rendered page. Pair them
+  with a runtime **full-selector** census (taken *before* injecting synthetics)
+  and a synthetic control that fails the selector by exactly one compound,
+  reading properties **derived from the rule's own declarations**.
+- **Validate the oracle before trusting it.** Measure a known-live control on
+  the same surface first; if the oracle cannot see rules that demonstrably
+  render, none of its findings count.
+- **State the post-deletion flip by source identity**, never as "the rule went
+  blind" — that is indistinguishable from "the oracle stopped working". Where a
+  selector name legitimately survives in a retained rule, attribute the residual
+  by declaration owner (CDP `CSS.getMatchedStylesForNode`) to that rule's source
+  range.
+- **Avoid substring assertions where duplicate selector text can mask a
+  deletion** — a recurring defect class hit in both `e` and `d1`. Use
+  occurrence-count or source-shape assertions.
 
 No further Workout Log packet is authorized, and do not begin fatigue or feature
 work or reopen the root-cleanup track. Do not begin `i`, `j` or `k`.

--- a/docs/MASTER_HANDOVER.md
+++ b/docs/MASTER_HANDOVER.md
@@ -22,16 +22,24 @@
 > | **c** `motion.css` dead success paint | #188 | `1b13bfc` | pure deletion, 3 declarations |
 > | **b** `base.css` four dead rule blocks | #192 | `3bec677` | pure deletion, −44 lines |
 > | **e** `layout.css` 34 unreachable rule blocks | #195 | `1346a35` | pure deletion, −218 lines, 0 insertions |
+> | **d1** `a11y.css` superseded scale/menu generation | #197 | `59e5b10` | pure deletion, −99 lines, 0 insertions |
 >
 > **Owner-directed execution order (2026-07-29) — the arc runs SEQUENTIALLY,
 > one packet, worktree, writer and PR at a time:**
 >
 > ```
-> a ✔ → c ✔ → b ✔ → e ✔ → d1 → f1 → d2 → f2 → g → h → HARD STOP (N4)
+> a ✔ → c ✔ → b ✔ → e ✔ → d1 ✔ → f1 → d2 → f2 → g → h → HARD STOP (N4)
 > ```
 >
-> **`d1` (`static/css/a11y.css`, pure deletion only) is next and is
-> authorized.** `a`, `c`, `b` and `e` are DONE and must not be re-dispatched.
+> **`f1` (`static/css/navbar.css`, pure deletion only) is next and is
+> authorized.** `a`, `c`, `b`, `e` and `d1` are DONE and must not be
+> re-dispatched. `f1` is deliberately **last among the pure-deletion packets**:
+> navbar layering, global exposure and the animated-logo oracle make it the
+> riskiest. It must freeze layer membership (N2), never delete the last
+> `@layer navbar` block (G11), preserve the contract-pinned `--nav-gap` /
+> `--nav-padding-*` declarations, treat layered `!important` as a potentially
+> live winner (A6/G10 — layer order inverts for `!important`), and reconcile the
+> animated logo only against its known-red **band**, not a fixed pixel count.
 > This ordering narrows rather than contradicts Plan v2 §4: `d1` and `f1` remain
 > class (a) concurrency-eligible pure deletion there, but the owner has elected
 > serial execution, and `f1` is deliberately last among the pure-deletion
@@ -1147,25 +1155,57 @@
 
 ## Next Safe Step
 
-**Current (2026-07-29, later):** WP4.4 packets `a`, `c`, `b` and `e` are merged
-— **4 of 11**. **WP4.4-d1 (`static/css/a11y.css`, pure deletion only) is the
-next action and is authorized**, in a fresh visual-seeded worktree off current
-`main`. The owner-directed remaining order is sequential:
+**Current (2026-07-29, latest):** WP4.4 packets `a`, `c`, `b`, `e` and `d1` are
+merged — **5 of 11**. **WP4.4-f1 (`static/css/navbar.css`, pure deletion only)
+is the next action and is authorized**, in a fresh visual-seeded worktree off
+current `main`. The owner-directed remaining order is sequential:
 
 ```
-d1 → f1 → d2 → f2 → g → h → HARD STOP (N4 owner checkpoint before i)
+f1 → d2 → f2 → g → h → HARD STOP (N4 owner checkpoint before i)
 ```
 
-`a`, `c`, `b` and `e` are DONE and must not be re-dispatched. One packet, one
-worktree, one writer, one PR at a time; reconcile these three status documents
-at each merge boundary.
+`a`, `c`, `b`, `e` and `d1` are DONE and must not be re-dispatched. One packet,
+one worktree, one writer, one PR at a time; reconcile these three status
+documents at each merge boundary.
 
-**`d1` constraints:** re-weighting and `!important` changes belong to `d2`, not
-`d1`; preserve the focus-visible, skip-link, keyboard-focus and scale
-guarantees; exercise every targeted `data-scale` level in both themes; include
-print emulation, breakpoint coverage, computed-style checks and keyboard
-traversal; preserve the contract-pinned a11y declarations (`a11y.css` is named
-in the shared contract file, which `d1` **runs but never edits**).
+**`f1` constraints — the riskiest pure-deletion packet:** generation
+consolidation and re-weighting belong to `f2`; **freeze `@layer` membership
+(N2)** and **never delete the last `@layer navbar` block (G11)** — `navbar.css`
+holds the arc's only navbar layer, spanning lines 6–883 at the WP4.4-a baseline;
+preserve the contract-pinned `--nav-gap` / `--nav-padding-y` /
+`--nav-padding-x`; treat layered `!important` declarations as **potentially live
+winners** (A6/G10 — for `!important`, layer order inverts, so an explicit layer
+outranks the implicit final unlayered layer regardless of specificity); exercise
+collapsed and expanded navigation, dropdowns, keyboard navigation, both themes
+and all required routes; reconcile the animated logo **only** against its
+known-red band (1,039 / 1,046 px on `workout-plan-desktop-dark`) — movement
+outside the band stops the packet.
+
+**Method now binding on every remaining packet, paid for by `e` and `d1`:**
+
+1. A rest-state differential **cannot falsify an unreachable rule** — deleting
+   one changes nothing on any rendered page. Pair it with a runtime
+   **full-selector** census taken *before* injecting synthetics, and a synthetic
+   control that fails the selector by exactly one compound, reading properties
+   **derived from the rule's own declarations**.
+2. **Validate the oracle before trusting it** — measure a known-live control on
+   the same surface first. `d1`'s compact generation returned census > 0 in
+   160/160 contexts; without that, none of its candidate findings would count.
+3. **State the post-deletion flip by source identity**, never as "the rule went
+   blind" — that is indistinguishable from "the oracle stopped working". Where a
+   selector name legitimately survives in a retained rule, attribute the residual
+   by declaration owner (CDP `CSS.getMatchedStylesForNode`) to that rule's exact
+   source range.
+4. **Avoid substring assertions where duplicate selector text can mask a
+   deletion** — a defect class hit in **both** `e` and `d1`, so treat it as a
+   property of the technique. Use occurrence-count or source-shape assertions.
+
+**Recorded by `d1`, owner-gated, do not act:** `.scale-btn[data-scale]` has
+runtime census **0** — `accessibility.js:144` and `:202` query an empty set, a
+second dormant JS path beside the accessibility dropdown. The 11 bare
+`.scale-btn` rules in `a11y.css` were **never audited as `d1` candidates**,
+because the static pass wrongly treated a JS *query* as proof of reachability.
+They are retained untouched; deleting them needs its own census and packet.
 
 Workout Log cleanup beyond WP4.3j-d-hover-paint (PR #186) remains closed and
 owner-gated. Do not begin `i`, `j` or `k`.

--- a/docs/REFACTOR_PLAN.md
+++ b/docs/REFACTOR_PLAN.md
@@ -69,7 +69,7 @@ records the WP4.4 authorization granted at Gate 1:**
    there**; **WP4.4 (shared bundles / navbar / `theme-dark.css`) Plan v2 is
    Gate-1 approved (owner, 2026-07-27) and executes from
    [`docs/css_phase4_wp4_4/PLANNING.md`](css_phase4_wp4_4/PLANNING.md)** —
-   authorized order `a` ✔ → `c` ✔ → `b` ✔ → `e` → `d1` → `f1` → `d2` → `f2` →
+   authorized order `a` ✔ → `c` ✔ → `b` ✔ → `e` ✔ → `d1` ✔ → `f1` → `d2` → `f2` →
    `g` → `h`, run **sequentially** per owner direction of 2026-07-29, then a
    **hard stop before `i`** for the N4 owner checkpoint. WP4.3j-a merged
    through
@@ -1292,7 +1292,7 @@ carries the narrative. **Wait for explicit direction before the next packet.**
 > one packet / worktree / writer / PR at a time:**
 >
 > ```
-> a ✔ → c ✔ → b ✔ → e ✔ → d1 → f1 → d2 → f2 → g → h → HARD STOP
+> a ✔ → c ✔ → b ✔ → e ✔ → d1 ✔ → f1 → d2 → f2 → g → h → HARD STOP
 > ```
 >
 > **The arc stops after `h`** for the N4 owner checkpoint. Gate 1 authority does
@@ -1333,10 +1333,18 @@ carries the narrative. **Wait for explicit direction before the next packet.**
 > element can distinguish them. Pinned by exact occurrence count; delete as a
 > unit under fresh evidence or not at all.
 >
-> The `c`-before-`b`/`d1`/`e`/`f1` prerequisite is **discharged**; `b` and `e`
-> are **shipped**. **`d1` (`a11y.css`, pure deletion only) is next**; `a`, `c`,
-> `b` and `e` must not be re-dispatched. Each packet still owns exactly one
-> file — `d` a11y, `f` navbar — never two writers on one file.
+> **WP4.4-d1 is COMPLETE** — PR #197, squash `59e5b10`, merged 2026-07-29.
+> Pure deletion of **14 rule blocks from `a11y.css` (−99 lines, 0 insertions)**:
+> a *superseded generation* of the scale / accessibility UI, leaving the live
+> compact generation intact. Full-selector census 0 for all 14 across 164
+> contexts; oracle validity gate passed first (live generation 160/160).
+> `!important` **51 → 51**, custom properties 17 → 17, `@layer` 0 → 0.
+>
+> The `c`-before-`b`/`d1`/`e`/`f1` prerequisite is **discharged**; `b`, `e` and
+> `d1` are **shipped**. **`f1` (`navbar.css`, pure deletion only) is next** and
+> is deliberately last among the pure-deletion packets — navbar layering, global
+> exposure and the animated-logo oracle make it the riskiest. `a`, `c`, `b`, `e`
+> and `d1` must not be re-dispatched.
 >
 > **Method rule M6a is binding on every remaining packet** (Plan v2 §2b):
 > suppress transitions before applying, reading **and** removing a sentinel — a
@@ -1434,18 +1442,21 @@ decisions are silently outstanding; either resolve them or leave them explicitly
 > the detailed work-packet requirements above and wait for explicit owner
 > direction wherever the plan requires it.
 
-Snapshot: **2026-07-29 (later)**. **Four of eleven WP4.4 packets are merged.**
+Snapshot: **2026-07-29 (latest)**. **Five of eleven WP4.4 packets are merged.**
 **WP4.4-a** (PR #187, squash `46e340e`) produced evidence and audit tooling, not
 a production CSS edit. **WP4.4-c** (PR #188, squash `1b13bfc`) was the arc's
 first production CSS deletion. **WP4.4-b** (PR #192, squash `3bec677`) deleted
 four dead `base.css` rule blocks. **WP4.4-e** (PR #195, squash `1346a35`)
-deleted 34 unreachable `layout.css` rule blocks, −218 lines. **`a`, `c`, `b` and
-`e` are DONE and must not be re-dispatched.**
+deleted 34 unreachable `layout.css` rule blocks, −218 lines. **WP4.4-d1**
+(PR #197, squash `59e5b10`) deleted a superseded scale/menu generation from
+`a11y.css`, −99 lines. **`a`, `c`, `b`, `e` and `d1` are DONE and must not be
+re-dispatched.**
 
 The owner directed a **sequential** remaining order on 2026-07-29 — one packet,
 worktree, writer and PR at a time:
-`d1` → `f1` → `d2` → `f2` → `g` → `h` → **hard stop for the N4 owner checkpoint
-before `i`**. **WP4.4-d1 (`a11y.css`, pure deletion only) is the next action.**
+`f1` → `d2` → `f2` → `g` → `h` → **hard stop for the N4 owner checkpoint
+before `i`**. **WP4.4-f1 (`navbar.css`, pure deletion only) is the next
+action**, and is deliberately last among the pure-deletion packets.
 The continuous pyright burn-down is a standing track, not an active packet or
 branch.
 
@@ -1470,7 +1481,9 @@ branch.
 | WP4.4-c — `motion.css` dead success paint | **Done** | Merged via PR #188 (squash `1b13bfc`, 2026-07-28). Deleted the three cascade-dead `.is-success` paint declarations, retaining `success-pulse`; ownership resolved over `CSS.getMatchedStylesForNode` across 11 routes × 2 themes under both `prefers-reduced-motion` states, 0 motion-record differences. Also re-pinned the Packet-a baseline contract to its own `sourceCommit` and added the ancestry assertion. | — |
 | WP4.4-b — `base.css` four dead rule blocks | **Done** | Merged via PR #192 (squash `3bec677`, 2026-07-29). Pure deletion, −44 lines: the `.skeleton` block beaten by `motion.css` at equal specificity, plus the three unreachable classes `.loading-spinner`, `.fade-enter`, `.fade-enter-active`. All 12 `:root` custom properties retained and contract-pinned under M9. Packet contracts 8 passed; full pytest 2,204 / 1 skipped; five required specs 68 passed; visual 65 passed / 1 ledgered known red; Stylelint −2, no rule increased. | — |
 | WP4.4-e — `layout.css` unreachable rule blocks | **Done** | Merged via PR #195 (squash `1346a35`, 2026-07-29). Pure deletion of **34 rule blocks, −218 lines, 0 insertions**: the `.tbl-col-chooser*` widget (10), `.form-container` (9), `.input-frame .row` (6), `.el-clip`/`.col--*` (3), `.tbl--loading` + `::after` + orphaned `@keyframes tbl-spin` (3), `.sr-only`, standalone `.tbl-toolbar`, `body.dark-mode`. Census 0 on the full selector across 11 routes × 2 themes × 16 widths; 0 declaration-owner differences / 64,961 records; contracts 13 passed with 13/13 red-path proven; pytest 2,230 / 1 skipped; seven required specs 89 passed; visual 65 / 1 ledgered red; Stylelint 2,875 → 2,857 (−18); `!important` 24 → 24; `@layer` 0 → 0. | — |
-| WP4.4 — shared bundles, navbar, and `theme-dark.css` (packets `d`–`h`) | **Ongoing — `d1` is next and authorized** | Plan v2 is **Gate-1 approved** (owner, 2026-07-27, rulings N1–N10) in `docs/css_phase4_wp4_4/PLANNING.md`. `a`, `c`, `b` and `e` have landed (4 of 11). The owner directed a **sequential** order on 2026-07-29: `d1` → `f1` → `d2` → `f2` → `g` → `h`, one packet/worktree/writer/PR at a time. Packets remain file-disjoint — `d` a11y, `f` navbar. The serial order narrows Plan v2 §4's concurrent class (a) authorization rather than contradicting it; `f1` is last among the pure-deletion packets as the riskiest. | Not gated through `h`. The gates still bind: Regions A–C of Workout Log must be re-measured before any shared-selector repair; each packet carries the full visual, dark-mode, navigation, accessibility and summary-page gates; **M6a is binding**; and the ten inherited Linux `desktop` reds plus the eight uncertifiable Welcome elements are ledgered and must not be re-attributed or rebaselined. **Method addition from `e`: a rest-state differential cannot falsify an unreachable rule — pair it with a full-selector runtime census and a synthetic injection whose control fails the selector by exactly one compound, reading properties derived from the rule's own declarations.** |
+| WP4.4-d1 — `a11y.css` superseded scale/menu generation | **Done** | Merged via PR #197 (squash `59e5b10`, 2026-07-29). Pure deletion of **14 rule blocks, −99 lines, 0 insertions**: `.scale-control`, `.scale-control-label`, `.scale-btn-group`, `.scale-labels`, `.scale-label`, `.accessibility-menu`, `.accessibility-section*` and their `@media` overrides. The live compact generation (`.scale-control-compact`, `.scale-btn-compact`, `.scale-indicator`) is retained and contract-pinned. Full-selector census **0 for all 14 across 164 contexts** (2 themes × 10 widths × 8 `data-scale` levels + print + reduced-motion); **oracle validity gate passed first** (live generation census > 0 in 160/160). Residual `.scale-control` matches attributed by CDP to the **retained** `@media print` rule at source lines 329–331; **0** rules on `screen`. Contracts 16 passed with **15/15 red-path proven**; pytest 2,245/1 skipped; nine specs 127 passed; visual 65/1 ledgered red; Stylelint 2,857 → 2,851 (−6). `!important` **51 → 51**, custom properties 17 → 17, `@layer` 0 → 0. | — |
+| WP4.4 — shared bundles, navbar, and `theme-dark.css` (packets `f`–`h`) | **Ongoing — `f1` is next and authorized** | Plan v2 is **Gate-1 approved** (owner, 2026-07-27, rulings N1–N10) in `docs/css_phase4_wp4_4/PLANNING.md`. `a`, `c`, `b`, `e` and `d1` have landed (5 of 11). The owner directed a **sequential** order on 2026-07-29: `f1` → `d2` → `f2` → `g` → `h`, one packet/worktree/writer/PR at a time. The serial order narrows Plan v2 §4's concurrent class (a) authorization rather than contradicting it; **`f1` is last among the pure-deletion packets as the riskiest** — navbar layering, global exposure and the animated-logo oracle. | Not gated through `h`. The gates still bind: Regions A–C of Workout Log must be re-measured before any shared-selector repair; each packet carries the full visual, dark-mode, navigation, accessibility and summary-page gates; **M6a is binding**; the ten inherited Linux `desktop` reds plus the eight uncertifiable Welcome elements are ledgered and must not be re-attributed or rebaselined. **`f1` specifically:** freeze `@layer` membership (N2), **never delete the last `@layer navbar` block (G11)**, preserve contract-pinned `--nav-gap` / `--nav-padding-*`, treat layered `!important` as a potentially live winner (A6/G10 — layer order inverts for `!important`), and reconcile the animated logo only against its known-red **band**. **Method from `e` + `d1`: a rest-state differential cannot falsify an unreachable rule — pair it with a full-selector runtime census taken before injection, a synthetic control failing the selector by exactly one compound with properties derived from the rule's own declarations, a known-live control validating the oracle first, and source-identity attribution (CDP declaration owner) rather than "the rule went blind". Avoid substring assertions where duplicate selector text can mask a deletion — that defect class recurred in both `e` and `d1`.** |
+| `a11y.css` bare `.scale-btn` rules | **Recorded by `d1` / not audited / gated** | 11 exact-token occurrences. Runtime census is **0** — `accessibility.js:144` and `:202` query an empty set, a second dormant JS path beside the accessibility dropdown. `d1`'s static pass wrongly treated that JS *query* as proof of reachability, so these rules were **never audited as candidates** and are retained untouched. | Deleting them requires its own census, its own oracle-validity control and its own packet. A JavaScript query is not evidence of reachability. |
 | `layout.css` `.tbl-show-*` / `.tbl-hide-*` breakpoint helpers | **Deferred by WP4.4-e / gated** | Nine rules. Census 0 and six of nine are visible to the synthetic oracle, but three declare `display: block` — a bare div's initial value — so no control element can distinguish them and their post-deletion flip cannot be demonstrated. Pinned by exact occurrence count in `tests/test_css_wp4_4_layout_contracts.py`. | Splitting the family would leave `@media` overrides targeting classes with no base rule. It must be deleted as a **unit** under fresh evidence, never eroded rule by rule. |
 | WP4.4-i — shared `:is()` selector repair | **Gated — hard stop after `h`** | Nothing started. Ruling N4 requires a separate owner checkpoint immediately before `i`; ruling N9 restricts admissible repair shapes to CSS-local ones in `static/css/components.css`. | Gate 1 authority explicitly does **not** extend to `i`. Before any edit, `i`'s enumerated repair shape and both pre-change inventories (the complete `:is()` family from `g`/`h`, and the G3 regions A–C measurement) must be presented and approved. |
 | WP4.4 — packets `j` and `k` | **Blocked on `i`** | Nothing started. | They follow only after `i` is resolved — approved, narrowed, or abandoned per ruling N3. |


### PR DESCRIPTION
Merge-boundary reconciliation for [PR #197](https://github.com/avihay1989/Hypertrophy-Toolbox-v3/pull/197) (squash `59e5b10`). Updates the three status documents together, as the `/status` rule requires. Docs-only.

- **WP4.4-d1 marked complete** — 14 rule blocks deleted from `a11y.css`, −99 lines, 0 insertions; a superseded generation of the scale/accessibility UI, with the live compact generation retained and contract-pinned. **5 of 11 packets merged** (a, c, b, e, d1).
- **`f1` (navbar.css, pure deletion only) is now named as next** everywhere, with its binding constraints: consolidation/re-weighting belong to `f2`; freeze `@layer` membership (N2); **never delete the last `@layer navbar` block (G11)**; preserve contract-pinned `--nav-gap` / `--nav-padding-*`; treat layered `!important` as a **potentially live winner** (A6/G10 — layer order inverts for `!important`); exercise collapsed/expanded nav, dropdowns, keyboard navigation, both themes, all required routes; reconcile the animated logo only against its known-red **band**, with movement outside it stopping the packet. `f1` is deliberately last among the pure-deletion packets as the riskiest.

## Four method rules now binding, paid for by `e` and `d1`

1. A rest-state differential **cannot falsify an unreachable rule** — deleting one changes nothing on any rendered page. Pair it with a **full-selector** runtime census taken *before* injecting synthetics, and a synthetic control that fails the selector by exactly one compound, reading properties **derived from the rule's own declarations**.
2. **Validate the oracle before trusting it.** `d1`'s known-live compact generation returned census > 0 in **160/160** contexts; without that, none of its candidate findings would count.
3. **State the post-deletion flip by source identity**, never as "the rule went blind" — indistinguishable from "the oracle stopped working". Where a selector name legitimately survives in a retained rule, attribute the residual by declaration owner (CDP `CSS.getMatchedStylesForNode`) to that rule's exact source range.
4. **Avoid substring assertions where duplicate selector text can mask a deletion.** This recurred in **both** `e` and `d1`, so it is a property of the technique rather than bad luck. Use occurrence-count or source-shape assertions.

## New gated row

The **11 bare `.scale-btn` rules** in `a11y.css`. Runtime census is **0** — `accessibility.js:144` and `:202` query an empty set — but they were **never audited as `d1` candidates**, because the static pass wrongly treated a JS *query* as proof of reachability. Retained untouched; deleting them needs its own census and its own packet.

Superseded narrative retained inline with dated markers. No executable ruling in `docs/css_phase4_wp4_4/PLANNING.md` is modified.

🤖 Generated with [Claude Code](https://claude.com/claude-code)