### PR TITLE
css(navbar): delete the unreachable legacy fallback rule (WP4.4-f1)

### DIFF
--- a/docs/CSS_PHASE4_WP4_4_F1_NAVBAR_EVIDENCE.md
+++ b/docs/CSS_PHASE4_WP4_4_F1_NAVBAR_EVIDENCE.md
@@ -1,0 +1,443 @@
+# WP4.4-f1 — `static/css/navbar.css` pure deletion
+
+*Phase 4 CSS. Plan: [`docs/css_phase4_wp4_4/PLANNING.md`](css_phase4_wp4_4/PLANNING.md)
+(Gate 1 approved, rulings N1–N10). Base: `wt/wp4-4-f1-navbar` from `main` @
+`c75d155`, worktree seeded `-Seed visual`.*
+
+**One rule deleted. `−6` lines, `0` insertions.** `!important` **93 → 93**,
+custom properties **72 → 72**, `@layer` blocks **1 → 1**, layered/unlayered rule
+split **103/91 → 103/90**. Zero declaration-owner changes across 64,961 records;
+zero motion changes across 306,864.
+
+The packet's yield is deliberately small. The census nominated **39** candidate
+rules on its first run and **38 of those were instrumentation artifacts**;
+§7 records how each was exposed. `f1` deletes only what survived that, and
+scope was not widened to improve the line count (the plan's `−150 to −400`
+projection is explicitly not an acceptance criterion).
+
+---
+
+## 1. What was deleted
+
+```css
+/* Only apply legacy styles if NOT inside #navbar */          ← navbar.css:901
+body:not(:has(#navbar)) .navbar {                             ← :902
+  background-color: #212529;
+  height: 40px;
+}                                                             ← :905
+```
+
+Six source lines (901–906, comment + rule + the separating blank).
+
+### Why it is unreachable — by construction, not only by census
+
+| Step | Evidence |
+|---|---|
+| `navbar.css` is linked from exactly one template | `templates/base.html:22`; no other template references it |
+| that template renders `#navbar` unconditionally | `templates/base.html:36`, first element inside `<body>`, no enclosing `{% if %}` |
+| every other template extends it | the only two non-extending templates are the partials `_fatigue_badge.html` and `_fatigue_muscle_bar.html`, which are included fragments, not documents, and link no stylesheet |
+| `error.html` is not an exception | it extends `base.html:1`, so it too carries `#navbar` |
+
+So **every document that loads this stylesheet contains `#navbar`**, and
+`body:not(:has(#navbar))` is unsatisfiable in all of them. Both premises are
+contract-pinned (`test_navbar_css_is_linked_only_from_base_html`,
+`test_base_html_renders_the_navbar_unconditionally`) precisely because the
+deletion is only safe while they hold.
+
+The runtime census agreed independently: **0 matches in 522/522 contexts.**
+
+---
+
+## 2. The generations — established rule by rule, not inherited
+
+`REFACTOR_PLAN.md:1376` says "triage navbar's three live generations".
+`PLANNING.md:471` marks that count as an assumption this packet must establish.
+Derived from the source (`artifacts/wp4_4/navbar_generations.py`):
+
+| Generation | Rules | Declarations | `!important` | Custom props | Lines |
+|---|---:|---:|---:|---:|---|
+| **A** layered scoped (`@layer navbar`) | 103 | 433 | 8 | 48 | 10–882 |
+| **B** legacy `.navbar` fallback | 2 | 7 | 0 | 0 | 892–905 |
+| **C** unlayered override tail | 89 | 255 | 85 | 24 | 913–1541 |
+| — `@keyframes` steps (not style rules) | 5 | — | — | — | — |
+
+**The count is confirmed at exactly three**, and the boundaries are the ones N2
+freezes: `@layer navbar` spans 6–883 (matching WP4.4-a §3 exactly), and the
+`navbar.css:908` comment's "MUST be outside @layer" tail begins at 913.
+
+### Generation B is *not* dead legacy — and that is the packet's main retention finding
+
+The banner at `:885` calls the whole block "Legacy Support … overridden by the
+scoped styles above", and `:893` says the `.navbar` rule "only applies outside
+#navbar wrapper". **Both comments are wrong**, and a packet that trusted them
+would have deleted a live winner:
+
+- `#navbar` carries the Bootstrap class `navbar`, so `.navbar` matches it.
+- `.navbar` at `:892` is **unlayered**; `#navbar { position: sticky }` at `:90`
+  is **inside `@layer navbar`**. For *normal* declarations the unlayered rule
+  wins **regardless of specificity** — an ID selector loses to a class selector
+  here.
+- Therefore `position: fixed` at `:894` is the value the browser actually
+  computes. This is independently corroborated by WP4.4-a §5 defect 5, which
+  had to clip captures below a **fixed** top bar.
+
+Deleting `.navbar` would have unpinned the navbar. It is retained whole and
+contract-pinned, including its layer membership
+(`test_the_retained_legacy_rule_is_unlayered`).
+
+Only the *second* rule of generation B — the one actually gated on the absence
+of `#navbar` — is unreachable.
+
+---
+
+## 3. Oracle validity gate — run before anything was believed
+
+`.claude/rules/verification.md` requires a known-live case, a known-dead case,
+and a same-CSS control before any result counts.
+
+| Control | Result |
+|---|---|
+| `#navbar` | census > 0 in **522/522** contexts |
+| `.navbar-brand`, `.navbar-toggler`, `.navbar-collapse`, `.navbar-nav` | **522/522** each |
+| `.nav-link` (max 17), `.nav-item` (max 19), `.nav-link-with-icon` (max 11) | **522/522** each |
+| `.dropdown-toggle`, `.dropdown-menu`, `.dropdown-item`, `.navbar-brand-icon` | **522/522** each |
+| known-**dead** `.wp44-f1-known-dead-control` | census > 0 in **0/522** — required |
+
+Twelve known-live controls seen everywhere and a known-dead control seen
+nowhere: the census discriminates in both directions.
+
+---
+
+## 4. Runtime census — 522 contexts
+
+`artifacts/wp4_4/navbar_probe.mjs`. Each rule's selector branches are relaxed to
+a **superset** base (state pseudo-classes, pseudo-elements and runtime-toggled
+classes/attributes removed). Census 0 on the superset proves the real selector
+can never match; census > 0 proves nothing and the rule is **retained**.
+
+| Slice | Contexts |
+|---|---:|
+| 11 rendered routes × 2 themes × 14 widths | 308 |
+| collapsed / expanded-by-click / expanded-by-class / dropdown-by-click / dropdown-by-class, × 2 themes × 3 widths | 30 |
+| CDP-forced `hover`, `focus`, `focus-visible`, `active`, `hover+focus`, `focus-within` on 5 navbar targets × 2 themes × 3 widths | 178 |
+| `prefers-reduced-motion: reduce`, `prefers-contrast: more`, `print`, × 2 themes | 6 |
+| **total** | **522** |
+
+The 14 widths cover every breakpoint edge in the file's **11 distinct `@media`
+conditions** (576, 768, 991, 991.98, 992, 1359.98, 1360, 1500, 1600) — no media
+rule was classified without a capture under its own condition.
+
+**Result: 1 of 100 base selectors never matched anywhere**, and exactly one rule
+has all of its branches in that set:
+
+| Line | Selector | Layer | Census |
+|---:|---|---|---:|
+| 902–905 | `body:not(:has(#navbar)) .navbar` | unlayered | **0 / 522** |
+
+---
+
+## 5. Completeness check from the other side
+
+The relaxation deliberately strips runtime-toggled classes, so a rule gated on a
+class that *nothing* ever applies would be retained rather than nominated.
+`artifacts/wp4_4/navbar_tokens.py` closes that gap: every non-Bootstrap class,
+id and attribute token `navbar.css` selects on was searched across `templates/`,
+`static/js/`, `routes/`, `utils/` and `static/css/`.
+
+**28 tokens probed, 0 unreferenced.** Every JS-applied class the census relaxed
+away is real:
+
+| Token | Applied at |
+|---|---|
+| `.nb-compact` | `static/js/modules/navbar-enhancements.js:28` |
+| `.is-hover-open` | `static/js/modules/navbar-enhancements.js:249` |
+| `.scientific-mode` | `static/js/modules/filter-view-mode.js:594` |
+| `.fa-microscope` | `static/js/modules/filter-view-mode.js:597` |
+
+Validity control for this scan: `nb-compact` 5 hits, `is-hover-open` 3,
+`scientific-mode` 2, `nb-skip-link` 1, `darkModeToggle` 13 — against
+`wp44f1nosuchtoken` 0 and `nb-compactXYZ` 0. It discriminates.
+
+---
+
+## 6. Oracles and controls
+
+### 6a. Rest-state differential — `scripts/css_audit/runtime_probe.mjs`, 22 captures
+
+| Oracle | Records | Differing |
+|---|---:|---:|
+| declaration owner (CDP `matchedRules`) | 64,961 | **0** |
+| motion | 153,432 | **0** |
+| motionReduced | 153,432 | **0** |
+| paint | 340,960 | **2** |
+
+### 6b. The 2 paint records are noise, proven by a same-CSS control
+
+Both are the animating Welcome glow, one per theme, on
+`html/body[1]/main[1]/div[0]/div[0]/section[1]/div[1]/div[0]` — `box-shadow`
+blur differing in the 4th decimal (58.55 → 58.88). That element is one of the
+**8 uncertifiable Welcome elements** registered by WP4.4-a §6.
+
+A **third probe run on identical post-deletion CSS** (`nav_rt_after` vs
+`nav_rt_after2`) reproduces **the same 2 records, on the same path, in the same
+property, with the same magnitude** (58.88 → 58.72). The deletion contributes
+nothing; the drift is the animation.
+
+### 6c. Built-in self-checks — all three runs
+
+| Check | before | after | after2 (control) |
+|---|---|---|---|
+| same-CSS control | 0 differing / **17,048** elements, 22 caps | 0 / 17,048 | 0 / 17,048 |
+| sentinel took effect (M6a) | **4,270 / 4,270** | 4,270 / 4,270 | 4,270 / 4,270 |
+| sentinel reverted (M6a) | **4,270 / 4,270** | 4,270 / 4,270 | 4,270 / 4,270 |
+| screenshot control | **22 / 22** | 22 / 22 | 22 / 22 |
+| uncertifiable elements | 16 | 16 | 16 |
+
+M6a is honoured throughout: transitions are suppressed **before** the sentinel is
+applied, read, and removed, and both effect and reversion are asserted per
+record. A dedicated navbar sentinel sweep over `#navbar`, `.navbar-brand`,
+`.nav-link`, `.navbar-toggler`, `.dropdown-menu`, `.navbar-collapse` reported
+**6/6 took effect and 6/6 reverted in both themes**.
+
+---
+
+## 7. The post-deletion flip, stated by source identity
+
+A zero differential alone is equally consistent with "deleted the right rule"
+and "the probe went blind". The four things kept apart, per the `d1` finding:
+
+1. **deleted rule identity** — the source block at its own source range;
+2. **surviving selector text** — `.navbar` occurs in several retained rules;
+3. **retained source rule** — `.navbar` at `navbar.css:892–899`;
+4. **computed declaration owner** — which rule actually supplies the value.
+
+### 7a. A synthetic element that really satisfies the deleted selector
+
+No real page can satisfy `body:not(:has(#navbar))` — that is the whole basis of
+the deletion — so the probe **removes `#navbar` from the DOM** and inserts a
+`.navbar` element. The **control fails by exactly one compound**: the identical
+element in a document where `#navbar` is still present.
+
+| Theme | Case | `body` matches `:not(:has(#navbar))` | `background-color` | `height` |
+|---|---|---|---|---|
+| light | control (`#navbar` present) | false | `rgba(0,0,0,0)` | `16px` |
+| light | **synthetic, BEFORE** | true | **`rgb(33,37,41)`** = `#212529` | **`40px`** |
+| light | **synthetic, AFTER** | true | `rgba(0,0,0,0)` | `16px` |
+| dark | control (`#navbar` present) | false | `rgba(0,0,0,0)` | `16px` |
+| dark | **synthetic, BEFORE** | true | **`rgb(33,37,41)`** | **`40px`** |
+| dark | **synthetic, AFTER** | true | `rgba(0,0,0,0)` | `16px` |
+
+The control never takes those values, before or after. The synthetic element
+took them before and does not after.
+
+### 7b. Declaration owner by source range (CDP `CSS.getMatchedStylesForNode`)
+
+`navbar.css` author rules owning that synthetic element — universal selectors
+excluded, since `*` resets say nothing about whether a deleted block survived:
+
+| | Rules | Owners |
+|---|---:|---|
+| **BEFORE** | **2** | `.navbar` @ **892–899** → `position: fixed; top: 0; left: 0; right: 0; z-index: 1000;`<br>`body:not(:has(#navbar)) .navbar` @ **902–905** → `background-color: #212529; height: 40px;` |
+| **AFTER** | **1** | `.navbar` @ **892–899** → `position: fixed; top: 0; left: 0; right: 0; z-index: 1000;` |
+
+Identical in both themes.
+
+**The oracle demonstrably did not go blind.** After deletion it still resolves
+the retained rule, at its **unchanged** source range 892–899, with its unchanged
+declarations — and `element.matches('body:not(:has(#navbar)) .navbar')` still
+returns **`true`** in the after run, because selector matching is a DOM
+operation independent of whether any rule uses that selector. The element still
+*satisfies the selector*; no source block *supplies the declarations*. That is
+exactly the distinction a substring contract cannot make.
+
+---
+
+## 8. Instrumentation defects found and corrected
+
+The first census run nominated **39 rules**. **38 were artifacts.** Each was
+caught by a control, not by inspection of the verdicts.
+
+| # | Defect | Symptom | How it was exposed | Fix |
+|---|---|---|---|---|
+| 1 | Relaxation inserted `*` around `>` combinators | `#navbar > .container-fluid` became `#navbar *>* .container-fluid`, matching nothing | `.container-fluid` is at `base.html:38` — a "dead" selector for an element plainly in the DOM | split on combinators at paren depth 0; never rewrite them |
+| 2 | Substitution ran **inside** `:not(...)` | `:not(.active)` became the invalid `:not()`, which throws, scored as census 0 | `#navbar .nav-link:not()` in the verdict list is not a selector anyone wrote | mask functional-pseudo arguments before substituting; `:not(.active)` is already conservative as written |
+| 3 | `@keyframes` steps parsed as style rules | `from`, `to`, `0%`, `55%`, `100%` nominated as dead rules | keyframe stops have no DOM census by definition | exclude any rule under an `@keyframes` at-rule (5 of 199) |
+| 4 | Owner probe attached `CSS.styleSheetAdded` **after** `CSS.enable` | **0** navbar declarations matched — every rule would have looked cascade-dead | a file that certainly matches reporting zero matches is impossible | attach the listener before `enable`, which replays existing sheets |
+
+Defects 1–3 all point the same way: **a relaxation that is not provably a
+superset silently manufactures deadness.** Defect 4 is the `d1` lesson in a new
+place — an oracle reporting a uniform zero must be assumed blind until a
+known-live case proves otherwise, which is why every probe here carries one.
+
+---
+
+## 9. Accessibility and keyboard, both themes
+
+| Theme | Result |
+|---|---|
+| light | **12/12** traversed elements have a computed visible-focus indicator; **12/12** inside `#navbar` |
+| dark | **12/12**; **12/12** inside `#navbar` |
+
+Measured as computed evidence (`outline-style` ≠ `none` and `outline-width` > 0,
+or a non-`none` `box-shadow`), not as a screenshot.
+
+---
+
+## 10. Gates
+
+| Gate | Result |
+|---|---|
+| `tests/test_css_wp4_4_navbar_contracts.py` | **16 passed** |
+| Red-path proof | **16/16** go red under their own violation; tree restores **sha256-identical**; final run 16 passed |
+| Full `pytest tests/` | **2,262 passed, 1 skipped** (396.91s) |
+| Shared `test_css_cascade_contracts.py` + `test_visual_selector_contracts.py` + `test_css_wp4_4_a_baseline_contracts.py` | **43 passed**, run and **unedited** (`git diff` vs `origin/main` empty) |
+| `nav-dropdown` (**required, blocking**), `accessibility`, `dark-mode`, `smoke-navigation`, `summary-pages`, `volume-progress`, `fatigue`, `fatigue-stage4-smokes`, `ui-hardening` | **127 passed** (3.5m) |
+| `visual.spec.ts`, Chromium, full matrix | **65 passed, 1 failed** — the ledgered red, below |
+| Rest-state differential | 0 owner / 0 motion / 0 motionReduced; 2 paint, both ledgered |
+| Same-CSS control (M5) | 0 differing / 17,048 elements, on **both** sides |
+| Stylelint, seven surfaces | **2,851 → 2,850 (−1)**, no rule increased, **0** parse errors |
+| Snapshot / helper integrity | **0** changed paths under `e2e/__screenshots__/`, `e2e/visual-helpers.ts`, `playwright.config.ts`, `scripts/css_audit/` |
+
+Test count reconciles: `main` @ `c75d155` collects **2,247**; this branch
+collects **2,263** = 2,247 + the 16 new contracts.
+
+### The visual failure is the ledgered animated-logo red — and it is in band
+
+`visual.spec.ts:40 › visual baseline: workout-plan › workout-plan desktop dark`
+— **875 pixels, 882 on retry.**
+
+**This reproduces the two most recent recorded observations exactly**, both
+taken before `f1`:
+
+- **WP4.4-c** — "Its current diff is 875 pixels, localized to the navbar GIF",
+  repeated three times.
+- **WP4.4-b** — "failed at **875 pixels** (retry 882) … This run widens the
+  recorded range: 875/882 here against 1,039/1,046 previously", recorded under
+  **M7: the band is not an invariant**.
+
+The ledgered band is therefore **875/882 ∪ 1,039/1,046**, and this run sits on
+the recent half of it.
+
+**A same-CSS pixel control settles authorship.** With `navbar.css` restored
+byte-identical to `main` (`git diff --numstat` = 0), the identical test in the
+identical worktree produced **the identical 875 pixels, 882 on retry**. The
+count is independent of this packet.
+
+875 still exceeds `maxDiffPixels: 800`, so it presents as a real snapshot
+failure, exactly as WP4.4-a §8 says it must. `maxDiffPixels` was **not** touched
+and **no snapshot was written**. **No non-ledger visual difference appeared** in
+any route, theme or viewport. `f1` does not run the Linux deep gate (N8).
+
+### Stylelint attribution
+
+| Rule | Before | After | Δ |
+|---|---:|---:|---:|
+| `declaration-property-value-disallowed-list` | 1,100 | 1,099 | **−1** (the `#212529` literal) |
+| `declaration-no-important` | 1,263 | 1,263 | **0** |
+| `no-descending-specificity` | 244 | 244 | 0 |
+| `no-duplicate-selectors` | 25 | 25 | 0 |
+| `selector-max-id` / `selector-max-specificity` | 116 / 102 | 116 / 102 | **0 / 0** |
+| `navbar.css` alone | 362 | 361 | −1 |
+
+`declaration-no-important` holding at 1,263 — and at **93 within `navbar.css`** —
+is independent confirmation that nothing was re-weighted.
+
+---
+
+## 11. Preservation invariants
+
+| Invariant | Verdict |
+|---|---|
+| **V1** no visual difference | Owner/motion differentials 0; the 2 paint records reproduce on identical CSS; screenshot control 22/22 byte-identical on both sides |
+| **V2** no rebaseline | 0 changed paths under `e2e/__screenshots__/`; no `e2e/visual-helpers.ts` or `playwright.config.ts` change |
+| **V3** no re-weighting | `!important` **93 → 93**; `selector-max-id` +0; `selector-max-specificity` +0 |
+| **V4** no duplication increase | `no-duplicate-selectors` 25 → 25; `declaration-block-no-duplicate-properties` 2 → 2 |
+| **V5** contribution | −6 lines, −1 rule, −2 declarations. Scope was **not** widened to approach the `−150 to −400` projection |
+| **V6** no conflict | Single writer, single production file |
+| **N2** layer membership frozen | `@layer` blocks 1 → 1; layered rules 103 → 103; no rule crossed the boundary |
+| **G11** last layer block preserved | `@layer navbar` is single-sourced at `navbar.css:6` and survives, contract-pinned |
+| **F6** contract-pinned declarations | `--nav-gap: var(--s-3)`, `--nav-padding-y: var(--s-3)`, `--nav-padding-x: 1rem` all present, each with its own red path |
+
+---
+
+## 12. Surface accounting
+
+| Metric | Before | After | Δ |
+|---|---:|---:|---:|
+| lines | 1,542 | 1,536 | **−6** |
+| style rules | 194 | 193 | **−1** |
+| declarations | 695 | 693 | **−2** |
+| layered / unlayered rules | 103 / 91 | 103 / 90 | 0 / −1 |
+| `!important` | 93 | 93 | **0** |
+| custom-property declarations | 72 | 72 | **0** |
+| `@layer` blocks | 1 | 1 | **0** |
+| `@keyframes` steps | 5 | 5 | **0** |
+| Stylelint (`navbar.css`) | 362 | 361 | −1 |
+
+---
+
+## 13. Retained and deferred — binding on `f2`
+
+1. **Generation B's comments are wrong and must not be trusted.** `:885` and
+   `:893` describe the `.navbar` rule as an overridden legacy fallback that
+   "only applies outside #navbar". It is the live winner for `position`.
+   Correcting the comments is an edit `f1` may not make (pure deletion), so the
+   defect is recorded rather than fixed.
+
+2. **A cascade-dead declaration nomination exists and is NOT certified.** A
+   declaration-owner sweep over 150 document states reported 570 `navbar.css`
+   declarations matched, 415 winning somewhere, and **155 matched-but-never-
+   winning**. That set is **not** acted on here: the sweep's winner resolution
+   is hand-rolled and its `!important`/layer arbitration was not independently
+   validated against a known-live *overridden* control. Per the standing rule
+   that an uncertified interaction-state result must remain, all 155 are
+   retained. Certifying them belongs to a packet that can pay for the control.
+
+3. **The 11 distinct `@media` conditions include near-duplicates**
+   (`max-width: 991px` and `max-width: 991.98px`; `min-width: 992px` appears
+   with three different upper bounds). Consolidating them is generation
+   consolidation — **`f2`'s, not `f1`'s**.
+
+4. **Six rules share the selector `#navbar > .container-fluid`** across both
+   layers (`:155`, `:807`, `:964`, `:1050`, `:1131`, `:1249`). This is the
+   clearest consolidation target in the file and is left entirely to `f2`.
+
+---
+
+## 14. Reproducing this
+
+```bash
+python artifacts/wp4_4/navbar_static.py        # parse: 199 rules, 11 media conditions
+python artifacts/wp4_4/navbar_generations.py   # the three generations, rule by rule
+python artifacts/wp4_4/make_navbar_specs.py    # superset relaxation + admissible widths
+python artifacts/wp4_4/navbar_tokens.py        # token reachability, both directions
+
+node artifacts/wp4_4/navbar_probe.mjs  --out artifacts/wp4_4/navbar_census
+node scripts/css_audit/runtime_probe.mjs --out artifacts/wp4_4/nav_rt_before
+node artifacts/wp4_4/navbar_flip.mjs --label BEFORE-deletion --out artifacts/wp4_4/flip_before
+#   … apply the deletion …
+node scripts/css_audit/runtime_probe.mjs --out artifacts/wp4_4/nav_rt_after
+node scripts/css_audit/runtime_probe.mjs --out artifacts/wp4_4/nav_rt_after2   # same-CSS control
+node artifacts/wp4_4/navbar_flip.mjs --label AFTER-deletion --out artifacts/wp4_4/flip_after
+python artifacts/wp4_4/diff_runs.py artifacts/wp4_4/nav_rt_before artifacts/wp4_4/nav_rt_after
+python artifacts/wp4_4/diff_runs.py artifacts/wp4_4/nav_rt_after  artifacts/wp4_4/nav_rt_after2
+
+python artifacts/wp4_4/redpath_f1.py
+node scripts/css_audit/stylelint_surfaces.mjs artifacts/wp4_4/stylelint_after.json
+```
+
+Analysis scripts live under the gitignored `artifacts/` tree.
+`scripts/css_audit/` stays packet-`a`-owned and was not modified (A11).
+
+---
+
+## 15. Out of scope
+
+- **All re-weighting** — `!important` reduction, specificity changes, selector
+  rewrites, trimming live selector lists, `@media` consolidation, and merging the
+  six `#navbar > .container-fluid` rules. That is **`f2`**.
+- **Moving anything across the `@layer navbar` boundary** — frozen arc-wide by
+  N2, and the boundary is load-bearing for generation B.
+- **The 155 uncertified cascade-dead declarations** of §13.2.
+- **Correcting the misleading `:885` / `:893` comments** — an insertion, which a
+  pure-deletion packet may not make.

--- a/static/css/navbar.css
+++ b/static/css/navbar.css
@@ -898,12 +898,6 @@
   z-index: 1000;
 }
 
-/* Only apply legacy styles if NOT inside #navbar */
-body:not(:has(#navbar)) .navbar {
-  background-color: #212529;
-  height: 40px;
-}
-
 /* ==========================================================================
    Override layer styles - MUST be outside @layer for highest specificity
    Frosted Glass Effect Overrides - Single Layer Only

--- a/tests/test_css_wp4_4_navbar_contracts.py
+++ b/tests/test_css_wp4_4_navbar_contracts.py
@@ -1,0 +1,243 @@
+"""WP4.4-f1 cascade contracts for `static/css/navbar.css`.
+
+These lock the premises the packet's single deletion rests on. Each test fails
+under its own violation (F16); the red-path proofs are recorded in
+docs/CSS_PHASE4_WP4_4_F1_NAVBAR_EVIDENCE.md.
+
+The assertions are deliberately **structural and occurrence-aware** rather than
+substring-based. `.navbar` is the selector text of BOTH the rule f1 deleted
+(`body:not(:has(#navbar)) .navbar`) and the rule f1 retained (`.navbar` at
+navbar.css:892), so `assert ".navbar" in css` cannot tell a successful deletion
+from a restored one. That defect class was found in packet `e` and again in
+packet `d1`; this file avoids it by parsing rules and counting occurrences.
+
+This file is packet-owned. It never edits, and must not be confused with, the
+shared `tests/test_css_cascade_contracts.py`, which WP4.4-f1 runs but does not
+touch (Plan v2 section 4d -- only packet i may amend that file).
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+import pytest
+
+ROOT = Path(__file__).resolve().parents[1]
+NAVBAR = ROOT / "static" / "css" / "navbar.css"
+TEMPLATES = ROOT / "templates"
+
+
+def _css() -> str:
+    return NAVBAR.read_text(encoding="utf-8").replace("\r\n", "\n")
+
+
+def _strip_comments(css: str) -> str:
+    """Length-preserving, so byte offsets stay valid after stripping."""
+    return re.sub(r"/\*.*?\*/", lambda m: " " * len(m.group(0)), css, flags=re.S)
+
+
+def _rules(css: str) -> list[dict]:
+    """Every style rule as (selector, line, declarations), @keyframes excluded.
+
+    Rule identity is selector + source line. Never re-serialized text: that is
+    not byte-preserving and would make the source-shape assertions meaningless.
+    """
+    text = _strip_comments(css)
+    out: list[dict] = []
+    at_stack: list[str] = []
+    i, n, start = 0, len(text), 0
+    while i < n:
+        ch = text[i]
+        if ch == "{":
+            prelude = " ".join(text[start:i].split())
+            if prelude.startswith("@"):
+                at_stack.append(prelude)
+                i += 1
+                start = i
+                continue
+            depth, j = 1, i + 1
+            while j < n and depth:
+                if text[j] == "{":
+                    depth += 1
+                elif text[j] == "}":
+                    depth -= 1
+                j += 1
+            if not any(a.startswith("@keyframes") for a in at_stack):
+                out.append(
+                    {
+                        "selector": prelude,
+                        "line": css[:i].count("\n") + 1 - prelude.count("\n"),
+                        "decls": [
+                            d.strip()
+                            for d in text[i + 1 : j - 1].split(";")
+                            if d.strip() and ":" in d
+                        ],
+                        "layer": next((a for a in at_stack if a.startswith("@layer")), None),
+                    }
+                )
+            i, start = j, j
+            continue
+        if ch == "}":
+            if at_stack:
+                at_stack.pop()
+            i += 1
+            start = i
+            continue
+        i += 1
+    return out
+
+
+# --------------------------------------------------------------------------
+# The deletion
+# --------------------------------------------------------------------------
+
+# The one rule WP4.4-f1 deleted. It was unreachable by construction, not merely
+# by census: navbar.css is linked only from templates/base.html:22, and that
+# template renders <header id="navbar"> unconditionally, so a document that
+# loads this stylesheet always contains #navbar and `body:not(:has(#navbar))`
+# can never be satisfied. The runtime census agreed at 0/522 contexts.
+DELETED_SELECTOR = "body:not(:has(#navbar)) .navbar"
+DELETED_DECLS = ("background-color: #212529", "height: 40px")
+
+
+def test_the_unreachable_legacy_rule_stays_deleted() -> None:
+    """Occurrence count, not substring: `.navbar` survives in a retained rule."""
+    selectors = [r["selector"] for r in _rules(_css())]
+    assert selectors.count(DELETED_SELECTOR) == 0
+
+
+def test_the_deleted_guard_compound_appears_nowhere() -> None:
+    """`:not(:has(#navbar))` was unique to the deleted rule."""
+    assert _strip_comments(_css()).count(":not(:has(#navbar))") == 0
+
+
+def test_no_rule_reintroduces_the_deleted_declarations_under_a_navbar_guard() -> None:
+    """A restore under a renamed selector is still a restore."""
+    for rule in _rules(_css()):
+        if ":has(#navbar)" not in rule["selector"]:
+            continue
+        joined = " ".join(rule["decls"])
+        for decl in DELETED_DECLS:
+            assert decl not in joined, f"{rule['selector']} at line {rule['line']}"
+
+
+# --------------------------------------------------------------------------
+# What must NOT have been deleted
+# --------------------------------------------------------------------------
+
+# The sibling of the deleted rule. `.navbar` is NOT dead legacy: #navbar carries
+# the Bootstrap `navbar` class, and because this rule is UNLAYERED while
+# `#navbar { position: sticky }` sits inside @layer navbar, the unlayered normal
+# declaration wins regardless of specificity. `position: fixed` here is the
+# value the browser actually computes -- which is why WP4.4-a's harness had to
+# clip below a fixed top bar. Deleting it would move the navbar.
+RETAINED_LEGACY_DECLS = (
+    "position: fixed",
+    "top: 0",
+    "left: 0",
+    "right: 0",
+    "z-index: 1000",
+)
+
+
+def test_the_live_legacy_navbar_rule_is_retained_whole() -> None:
+    matches = [r for r in _rules(_css()) if r["selector"] == ".navbar"]
+    assert len(matches) == 1
+    joined = " ".join(matches[0]["decls"])
+    for decl in RETAINED_LEGACY_DECLS:
+        assert decl in joined
+
+
+def test_the_retained_legacy_rule_is_unlayered() -> None:
+    """Its layer membership is what makes it the winner; N2 freezes that."""
+    matches = [r for r in _rules(_css()) if r["selector"] == ".navbar"]
+    assert matches and matches[0]["layer"] is None
+
+
+@pytest.mark.parametrize(
+    "declaration",
+    ["--nav-gap: var(--s-3)", "--nav-padding-y: var(--s-3)", "--nav-padding-x: 1rem"],
+)
+def test_contract_pinned_navbar_tokens_survive(declaration: str) -> None:
+    """Pinned by the shared tests/test_css_cascade_contracts.py:150-152 (F6)."""
+    assert declaration in _strip_comments(_css())
+
+
+def test_the_single_sourced_navbar_layer_block_survives() -> None:
+    """G11: `navbar` is the only file declaring @layer navbar."""
+    assert re.search(r"@layer\s+navbar\s*\{", _strip_comments(_css()))
+
+
+# --------------------------------------------------------------------------
+# Whole-surface invariants -- these are what make the packet pure deletion
+# --------------------------------------------------------------------------
+
+# Measured on the post-deletion file; every one was identical before it.
+IMPORTANT_DECLARATIONS = 93
+CUSTOM_PROPERTY_DECLARATIONS = 72
+LAYER_BLOCKS = 1
+STYLE_RULES = 193
+KEYFRAME_STEPS = 5
+
+
+def test_no_important_was_added_or_removed() -> None:
+    """V3: a pure deletion that changes !important has re-weighted something."""
+    assert len(re.findall(r"!\s*important", _strip_comments(_css()))) == IMPORTANT_DECLARATIONS
+
+
+def test_no_custom_property_declaration_was_deleted() -> None:
+    """Custom properties paint nothing and are non-winners for every property,
+    so the ordinary non-winner rule must never be applied to them."""
+    decls = [d for r in _rules(_css()) for d in r["decls"] if d.lstrip().startswith("--")]
+    assert len(decls) == CUSTOM_PROPERTY_DECLARATIONS
+
+
+def test_layer_membership_is_frozen() -> None:
+    """N2: no rule moved across the boundary, and no layer block was added."""
+    css = _strip_comments(_css())
+    assert len(re.findall(r"@layer\s+[\w-]+\s*\{", css)) == LAYER_BLOCKS
+    rules = _rules(_css())
+    assert sum(1 for r in rules if r["layer"]) == 103
+    assert sum(1 for r in rules if r["layer"] is None) == 90
+
+
+def test_exactly_one_rule_was_removed_from_the_surface() -> None:
+    """The packet's whole production change, stated as a count."""
+    assert len(_rules(_css())) == STYLE_RULES
+
+
+def test_keyframe_steps_are_untouched() -> None:
+    """@keyframes steps are not style rules and have no DOM census; the first
+    version of the f1 audit wrongly nominated five of them as dead."""
+    css = _strip_comments(_css())
+    blocks = re.findall(r"@keyframes\s+[\w-]+\s*\{", css)
+    assert len(blocks) == 2
+    steps = re.findall(r"^\s*(?:from|to|\d+%)\s*\{", css, flags=re.M)
+    assert len(steps) == KEYFRAME_STEPS
+
+
+# --------------------------------------------------------------------------
+# The premise that made the deletion safe
+# --------------------------------------------------------------------------
+
+
+def test_navbar_css_is_linked_only_from_base_html() -> None:
+    linking = [
+        p.name
+        for p in TEMPLATES.rglob("*.html")
+        if "css/navbar.css" in p.read_text(encoding="utf-8")
+    ]
+    assert linking == ["base.html"]
+
+
+def test_base_html_renders_the_navbar_unconditionally() -> None:
+    """The deleted rule's guard `body:not(:has(#navbar))` is unsatisfiable only
+    while this holds: if #navbar ever became conditional, the rule would have
+    been reachable and its deletion would be a behaviour change."""
+    html = (TEMPLATES / "base.html").read_text(encoding="utf-8")
+    body = html[html.index("<body>") : html.index("</body>")]
+    header = re.search(r'<header[^>]*id="navbar"', body)
+    assert header is not None
+    preceding = body[: header.start()]
+    assert "{%" not in preceding.replace("{% block", "")


### PR DESCRIPTION
## What

Deletes **one rule** from `static/css/navbar.css` — **6 lines, 0 insertions**:

```css
body:not(:has(#navbar)) .navbar { background-color: #212529; height: 40px; }
```

Evidence: [`docs/CSS_PHASE4_WP4_4_F1_NAVBAR_EVIDENCE.md`](docs/CSS_PHASE4_WP4_4_F1_NAVBAR_EVIDENCE.md)

## Why it is unreachable — by construction, not only by census

`navbar.css` is linked from exactly one template (`base.html:22`); that template renders `#navbar` unconditionally (`base.html:36`); every other template extends it, `error.html` included. So **every document that loads this stylesheet contains `#navbar`**, and `body:not(:has(#navbar))` can never be satisfied. Both premises are contract-pinned, because the deletion is only safe while they hold.

Runtime census agreed independently: **0 matches in 522/522 contexts** (11 routes × 2 themes × 14 widths covering every breakpoint edge in the file's 11 distinct `@media` conditions, plus collapsed/expanded, dropdown open, CDP-forced hover/focus/active, reduced-motion, contrast and print).

## The generations, established rather than inherited

Confirmed at **exactly three**: layered scoped (103 rules), legacy `.navbar` fallback (2), unlayered override tail (89), plus 5 `@keyframes` steps.

**Main retention finding — generation B is not dead legacy.** Its sibling `.navbar` rule is *unlayered* while `#navbar { position: sticky }` sits inside `@layer navbar`, so for normal declarations the class selector beats the ID selector and `position: fixed` is what the browser actually computes. The file's own comments at `:885` and `:893` claim the opposite; trusting them would have unpinned the navbar. Retained whole and contract-pinned, layer membership included.

## Post-deletion flip, by source identity

A synthetic `.navbar` element in a document with `#navbar` removed took `#212529` / `40px` **before** and does not **after**. The control failing by **exactly one compound** (`#navbar` still present) never took them. CDP owner resolution goes **2 rules → 1**, the survivor being the retained `.navbar` at its **unchanged** source range 892–899. `element.matches(...)` still returns `true` afterwards — the selector still matches; no source block supplies the declarations. The oracle did not go blind.

## Instrumentation

**38 of the first census run's 39 candidates were artifacts.** All four defects — `>` combinator corruption, substitution inside `:not()`, `@keyframes` steps parsed as rules, and a CDP listener attached after `CSS.enable` — plus the control that exposed each, are recorded in §8.

## Gates

| Gate | Result |
|---|---|
| `tests/test_css_wp4_4_navbar_contracts.py` | **16 passed** |
| Red-path proof | **16/16** red under their own violation; tree restores **sha256-identical** |
| Full `pytest tests/` | **2,262 passed, 1 skipped** (396.91s) |
| Shared cascade + visual-selector + a-baseline contracts | **43 passed**, run and **unedited** |
| `nav-dropdown` (required, blocking), `accessibility`, `dark-mode`, `smoke-navigation`, `summary-pages`, `volume-progress`, `fatigue`, `fatigue-stage4-smokes`, `ui-hardening` | **127 passed** |
| `visual.spec.ts` full matrix | **65 passed, 1 ledgered red** |
| Declaration owner / motion / motionReduced | **0 / 64,961**, **0 / 153,432**, **0 / 153,432** |
| Paint | 2 / 340,960 — both the ledgered Welcome blur, reproduced by the same-CSS control |
| Same-CSS control (M5) | **0 differing / 17,048 elements**, both sides |
| Sentinels (M6a) | **4,270 / 4,270** took effect and reverted, all three runs |
| Stylelint, seven surfaces | **2,851 → 2,850**, no category increased, 0 parse errors |

**Known red:** `workout-plan desktop dark` at **875 px (882 on retry)** — reproducing WP4.4-c's and WP4.4-b's recorded observations exactly. A same-CSS pixel control with `navbar.css` restored byte-identical to `main` produced **the identical 875/882**, so the count is independent of this packet. `maxDiffPixels` untouched, no snapshot written.

## Invariants

`!important` **93 → 93** · custom properties **72 → 72** · `@layer` blocks **1 → 1** · layered rules **103 → 103** (N2 frozen) · `@layer navbar` preserved (G11) · `--nav-gap` / `--nav-padding-y` / `--nav-padding-x` preserved (F6), each with its own red path · **0** changed snapshot paths (V2).

## Scope

Three files: `static/css/navbar.css` (0+/6−), the new packet contract, the evidence document. No shared contract, `scripts/css_audit/**`, snapshot, `e2e/visual-helpers.ts`, Playwright config, template, JS or data file touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)