### PR TITLE
docs(status): record WP4.4-f1 complete and name d2 as next

### DIFF
--- a/docs/ACTIVE_DEVELOPMENT.md
+++ b/docs/ACTIVE_DEVELOPMENT.md
@@ -4,10 +4,64 @@ This file is the execution source of truth for autonomous development sessions. 
 
 ## Current Objective
 
-**2026-07-29 (LATEST) — WP4.4-d1 is complete in PR #197 (squash `59e5b10`).
-FIVE of eleven packets are merged:** `a` (#187, `46e340e`), `c` (#188,
+**2026-07-29 (LATEST) — WP4.4-f1 is complete in PR #199 (squash `1127486`).
+SIX of eleven packets are merged:** `a` (#187, `46e340e`), `c` (#188,
 `1b13bfc`), `b` (#192, `3bec677`), `e` (#195, `1346a35`), `d1` (#197,
-`59e5b10`).
+`59e5b10`), `f1` (#199, `1127486`).
+
+**WP4.4-f1** deleted **one rule from `navbar.css`, −6 lines, 0 insertions** —
+`body:not(:has(#navbar)) .navbar`. Unreachable **by construction**, not only by
+census: `navbar.css` is linked from exactly one template (`base.html:22`), that
+template renders `#navbar` unconditionally (`base.html:36`), and every other
+template extends it — `error.html` included. So every document loading the
+stylesheet contains `#navbar` and the guard can never be satisfied. Runtime
+census agreed at **0 matches in 522/522 contexts** (11 routes × 2 themes × 14
+widths covering every breakpoint edge in the file's 11 distinct `@media`
+conditions, plus collapsed/expanded, dropdown open, CDP-forced
+hover/focus/active, reduced-motion, contrast and print).
+
+**The plan projected −150 to −400 lines; the packet delivered −6, and that is
+correct.** A projected line reduction is not an acceptance criterion. Scope was
+not widened to produce a larger diff.
+
+Gates: contracts **16 passed, 16/16 red-path proven** with a **sha256-identical**
+restore; full pytest **2,262 / 1 skipped** (`main` collects 2,247, so +16 is
+exactly the new file); nine required specs **127 passed**; visual **65 / 1
+ledgered red**; owner differential **0 / 64,961**; motion **0 / 306,864**;
+same-CSS control **0 / 17,048** on both sides; sentinels **4,270 / 4,270** took
+effect and reverted on all three runs. Stylelint **2,851 → 2,850 (−1)**, no
+category increased. `!important` **93 → 93**, custom properties **72 → 72**,
+`@layer` blocks **1 → 1**, layered rules **103 → 103** (N2 held).
+Evidence: [`CSS_PHASE4_WP4_4_F1_NAVBAR_EVIDENCE.md`](CSS_PHASE4_WP4_4_F1_NAVBAR_EVIDENCE.md).
+
+**Three `f1` findings that bind later packets:**
+
+1. **The "three live generations" count is established, not assumed** — layered
+   scoped (103 rules), legacy `.navbar` fallback (2), unlayered override tail
+   (89), plus 5 `@keyframes` steps.
+2. **Generation B is NOT dead legacy, and `navbar.css:885` / `:893` lie about
+   it.** The `.navbar` rule is **unlayered** while `#navbar { position: sticky }`
+   is inside `@layer navbar`; for normal declarations the unlayered class
+   selector beats the layered ID selector, so `position: fixed` is what the
+   browser computes. Deleting it would unpin the navbar. Retained and
+   contract-pinned, layer membership included.
+3. **A relaxation that is not provably a superset manufactures deadness.** The
+   first census run nominated 39 rules; **38 were artifacts** (`>` combinators
+   corrupted, substitution inside `:not()` yielding invalid `:not()`,
+   `@keyframes` steps parsed as rules, and a CDP listener attached after
+   `CSS.enable` reporting 0 matched declarations). Each was caught by a control.
+
+**Known-red update:** the animated-logo band is **875/882 ∪ 1,039/1,046**. `f1`
+measured 875 (882 retry), matching `b` and `c`; a same-CSS pixel control with
+`navbar.css` byte-identical to `main` produced the identical count, so it is
+packet-independent.
+
+**Deferred by `f1`, owner-gated, do NOT act:** 155 matched-but-never-winning
+`navbar.css` declarations are **uncertified** (the owner sweep's
+`!important`/layer arbitration was never validated against a known-live
+*overridden* control) and are retained whole; and the six duplicate
+`#navbar > .container-fluid` rules plus near-duplicate `@media` conditions are
+consolidation, which is **`f2`'s exclusively**.
 
 **WP4.4-d1** deleted **14 rule blocks from `a11y.css`, −99 lines, 0
 insertions** — a *superseded generation* of the scale / accessibility UI
@@ -79,17 +133,19 @@ occurrence count. **Do not erode it rule by rule.**
 one packet / worktree / writer / PR at a time:**
 
 ```
-a ✔ → c ✔ → b ✔ → e ✔ → d1 ✔ → f1 → d2 → f2 → g → h → HARD STOP (N4)
+a ✔ → c ✔ → b ✔ → e ✔ → d1 ✔ → f1 ✔ → d2 → f2 → g → h → HARD STOP (N4)
 ```
 
-**`f1` (`navbar.css`, pure deletion only) is next.** This ordering narrows, and
-does not contradict, Plan v2 §4: that section still classifies `d1` and `f1` as
-concurrency-eligible class (a) pure deletion, but the owner has elected serial
-execution, and `f1` is deliberately last among the pure-deletion packets because
-navbar layering, global exposure and the animated-logo oracle make it the
-riskiest. Each packet reconciles these three status documents at its merge
-boundary. The arc hard-stops after `h` per ruling N4; Gate 1 authority does not
-extend to `i`, `j` or `k`.
+**`d2` is next**, and the pure-deletion run is now finished: every packet the
+owner classified as class (a) has shipped. Each packet reconciles these three
+status documents at its merge boundary. The arc hard-stops after `h` per ruling
+N4; Gate 1 authority does not extend to `i`, `j` or `k`.
+
+> **Superseded 2026-07-29 (latest).** This section previously announced WP4.4-d1
+> as LATEST with `f1` next, and described `f1` as "deliberately last among the
+> pure-deletion packets because navbar layering, global exposure and the
+> animated-logo oracle make it the riskiest". That framing was correct and is
+> retained as the `d1`-boundary record; `f1` has since merged in PR #199.
 
 > **Superseded 2026-07-29 (later).** This section previously announced WP4.4-b
 > as LATEST with `e` next. `e` has since merged in PR #195.
@@ -294,30 +350,53 @@ intentional review of the exact golden diff before any behavior change.
 
 ## Next Action
 
-**WP4.4-f1 (`static/css/navbar.css`, pure deletion only) is next**, and it is
-authorized. `a`, `c`, `b`, `e` and `d1` are merged; none may be re-dispatched.
-Execute `f1` in a fresh visual-seeded worktree off current `main`, then continue
-sequentially: `f1` → `d2` → `f2` → `g` → `h`, one writer and one PR per packet.
+**WP4.4-d2 is next.** `a`, `c`, `b`, `e`, `d1` and `f1` are merged; none may be
+re-dispatched. The pure-deletion run is finished — every class (a) packet has
+shipped. Execute `d2` in a fresh visual-seeded worktree off current `main`, then
+continue sequentially: `d2` -> `f2` -> `g` -> `h`, one writer and one PR per
+packet. `d2` and `f2` are re-weighting packets, not deletions, and each still
+needs its own explicit owner go-ahead before any edit.
 
-**`f1` is deliberately last among the pure-deletion packets** because navbar
-layering, global exposure and the animated-logo oracle make it the riskiest.
-Packet `f1` owns exactly `static/css/navbar.css`. Binding constraints:
+**What `f1` established, and what it deliberately left for `f2`:**
 
-- **Generation consolidation and re-weighting are `f2`'s, not `f1`'s.**
+- The **"three live generations" count is confirmed at exactly three** and is no
+  longer an assumption: layered scoped (103 rules), legacy `.navbar` fallback
+  (2), unlayered override tail (89), plus 5 `@keyframes` steps.
+- **Generation B is NOT dead legacy.** `navbar.css:885` and `:893` claim the
+  `.navbar` rule is an overridden fallback that "only applies outside #navbar".
+  It is the live winner for `position`: it is unlayered while
+  `#navbar { position: sticky }` is inside `@layer navbar`, and for normal
+  declarations the unlayered class selector beats the layered ID selector.
+  Correcting those comments is an insertion, so `f1` recorded the defect rather
+  than fixing it.
+- **155 matched-but-never-winning declarations are nominated but UNCERTIFIED**
+  and were retained whole. The owner sweep's `!important`/layer arbitration was
+  never validated against a known-live *overridden* control, so the set is not
+  actionable as it stands. Certifying it requires paying for that control.
+- **Six rules share `#navbar > .container-fluid`** across both layers, and the
+  11 `@media` conditions include near-duplicates (`max-width: 991px` vs
+  `991.98px`). Both are consolidation — `f2`'s exclusively.
+
+**Binding constraints that remain in force for `f2`:**
+
 - **Freeze layer membership (N2).** `navbar.css` holds the arc's only
-  `@layer navbar` block, spanning lines 6–883 at the WP4.4-a baseline —
+  `@layer navbar` block, spanning lines 6-883 at the WP4.4-a baseline —
   **G11: the last `@layer navbar` block may never be deleted.**
 - Preserve the contract-pinned `--nav-gap`, `--nav-padding-y` and
   `--nav-padding-x` declarations (pinned in the shared contract file, which
-  `f1` **runs but never edits**).
+  packets **run but never edit**).
 - Treat layered `!important` declarations as **potentially live winners** —
   A6/G10: for `!important`, layer order inverts, so an explicit layer outranks
   the implicit final unlayered layer regardless of specificity.
 - Exercise collapsed and expanded navigation, dropdowns, keyboard navigation,
   both themes, and all required routes.
 - Reconcile the animated-logo result **only** against its established known-red
-  band (1,039 / 1,046 px on `workout-plan-desktop-dark`); it is a band, not a
-  constant. Movement **outside** that band stops the packet.
+  band, which is now **875/882 union 1,039/1,046 px** on
+  `workout-plan-desktop-dark`. `f1` measured 875 (882 on retry), matching `b`
+  and `c`, and a same-CSS pixel control with `navbar.css` byte-identical to
+  `main` produced the identical count — so the low half of the band is
+  packet-independent and current. It is a band, not a constant. Movement
+  outside it stops the packet.
 - M6a and every common packet gate apply.
 
 **Method carried from `e` and `d1` — binding:**
@@ -338,6 +417,16 @@ Packet `f1` owns exactly `static/css/navbar.css`. Binding constraints:
 - **Avoid substring assertions where duplicate selector text can mask a
   deletion** — a recurring defect class hit in both `e` and `d1`. Use
   occurrence-count or source-shape assertions.
+- **A selector relaxation that is not provably a superset manufactures
+  deadness.** `f1`'s first census nominated 39 rules and **38 were artifacts**:
+  `>` combinators rewritten, substitution run inside `:not()` producing the
+  invalid `:not()`, `@keyframes` steps parsed as style rules, and a CDP
+  `styleSheetAdded` listener attached *after* `CSS.enable` (reporting 0 matched
+  declarations, which would have made every rule look cascade-dead). Each was
+  caught by a control, never by reading the verdicts. Relax only in the
+  direction that makes a selector easier to match, and only at paren depth 0.
+- **A projected line reduction is not an acceptance criterion.** `f1` shipped −6
+  lines against a −150 to −400 projection and is complete.
 
 No further Workout Log packet is authorized, and do not begin fatigue or feature
 work or reopen the root-cleanup track. Do not begin `i`, `j` or `k`.

--- a/docs/MASTER_HANDOVER.md
+++ b/docs/MASTER_HANDOVER.md
@@ -14,7 +14,7 @@
 > WP4.4 packet ordering or next-safe-step below.
 >
 > **2026-07-29 (LATEST) — WP4.4 is EXECUTING. Gate 1 is approved (rulings
-> N1–N10). FOUR of eleven packets are merged:**
+> N1–N10). SIX of eleven packets are merged:**
 >
 > | Packet | PR | Squash | Nature |
 > |---|---|---|---|
@@ -23,28 +23,64 @@
 > | **b** `base.css` four dead rule blocks | #192 | `3bec677` | pure deletion, −44 lines |
 > | **e** `layout.css` 34 unreachable rule blocks | #195 | `1346a35` | pure deletion, −218 lines, 0 insertions |
 > | **d1** `a11y.css` superseded scale/menu generation | #197 | `59e5b10` | pure deletion, −99 lines, 0 insertions |
+> | **f1** `navbar.css` unreachable legacy fallback | #199 | `1127486` | pure deletion, −6 lines, 0 insertions |
 >
 > **Owner-directed execution order (2026-07-29) — the arc runs SEQUENTIALLY,
 > one packet, worktree, writer and PR at a time:**
 >
 > ```
-> a ✔ → c ✔ → b ✔ → e ✔ → d1 ✔ → f1 → d2 → f2 → g → h → HARD STOP (N4)
+> a ✔ → c ✔ → b ✔ → e ✔ → d1 ✔ → f1 ✔ → d2 → f2 → g → h → HARD STOP (N4)
 > ```
 >
-> **`f1` (`static/css/navbar.css`, pure deletion only) is next and is
-> authorized.** `a`, `c`, `b`, `e` and `d1` are DONE and must not be
-> re-dispatched. `f1` is deliberately **last among the pure-deletion packets**:
-> navbar layering, global exposure and the animated-logo oracle make it the
-> riskiest. It must freeze layer membership (N2), never delete the last
-> `@layer navbar` block (G11), preserve the contract-pinned `--nav-gap` /
-> `--nav-padding-*` declarations, treat layered `!important` as a potentially
-> live winner (A6/G10 — layer order inverts for `!important`), and reconcile the
-> animated logo only against its known-red **band**, not a fixed pixel count.
-> This ordering narrows rather than contradicts Plan v2 §4: `d1` and `f1` remain
-> class (a) concurrency-eligible pure deletion there, but the owner has elected
-> serial execution, and `f1` is deliberately last among the pure-deletion
-> packets because navbar layering, global exposure and the animated-logo oracle
-> make it the riskiest. Gate 1 authority does not extend to `i`, `j` or `k`.
+> **`d2` is next.** `a`, `c`, `b`, `e`, `d1` and `f1` are DONE and must not be
+> re-dispatched. Gate 1 authority does not extend to `i`, `j` or `k`.
+>
+> **WP4.4-f1 outcome — a small diff is the correct outcome here.** `f1` deleted
+> exactly **one** rule, `body:not(:has(#navbar)) .navbar` (−6 lines), against a
+> plan projection of −150 to −400. The projection is not an acceptance
+> criterion and scope was not widened to approach it. `navbar.css` is linked
+> only from `base.html:22`, which renders `#navbar` unconditionally, so that
+> selector's guard is unsatisfiable in every document that loads the file;
+> census agreed at 0/522 contexts.
+>
+> **The "three live generations" count is now established, not assumed** —
+> layered scoped (103 rules), legacy `.navbar` fallback (2), unlayered override
+> tail (89), plus 5 `@keyframes` steps.
+>
+> **Binding retention finding: generation B is NOT dead legacy, and the file's
+> own comments lie about it.** `navbar.css:885` and `:893` describe the
+> `.navbar` rule as an overridden legacy fallback that "only applies outside
+> #navbar". It is the live winner: it is **unlayered** while
+> `#navbar { position: sticky }` sits inside `@layer navbar`, so for *normal*
+> declarations the class selector beats the ID selector and `position: fixed` is
+> what the browser computes — corroborated by WP4.4-a §5 defect 5, which had to
+> clip captures below a **fixed** top bar. A packet trusting those comments
+> would unpin the navbar. Retained whole and contract-pinned, layer membership
+> included.
+>
+> **Method addition carried forward: a selector relaxation that is not provably
+> a superset manufactures deadness.** `f1`'s first census run nominated 39
+> rules and **38 were instrumentation artifacts** — `>` combinators corrupted,
+> substitution run inside `:not()` producing the invalid `:not()`, `@keyframes`
+> steps parsed as style rules, and a CDP `styleSheetAdded` listener attached
+> *after* `CSS.enable` (which reported 0 matched declarations and would have
+> made every rule look cascade-dead). Every one was caught by a control, not by
+> reading the verdicts.
+>
+> **The animated-logo known-red band is 875/882 ∪ 1,039/1,046.** `f1` measured
+> **875 px, 882 on retry**, reproducing `b` and `c` exactly. A same-CSS pixel
+> control with `navbar.css` restored byte-identical to `main` produced the
+> identical 875/882, so the count is independent of the packet. Treat it as a
+> band, never a constant, and never "fix" it by raising `maxDiffPixels`.
+>
+> **Two `f1` findings deferred to `f2`, both owner-gated:** (1) **155
+> matched-but-never-winning `navbar.css` declarations** were nominated by a
+> declaration-owner sweep over 150 states but are **NOT certified** — the
+> sweep's `!important`/layer arbitration was never validated against a known-live
+> *overridden* control, so all 155 are retained; (2) six rules share the selector
+> `#navbar > .container-fluid` across both layers, and the 11 `@media` conditions
+> contain near-duplicates (`max-width: 991px` vs `991.98px`). Both are
+> consolidation, which is `f2`'s exclusively.
 >
 > **WP4.4-e outcome and the method lesson worth carrying.** The plan carried
 > **one** candidate into `e` (`body.dark-mode`); the audit found **42**
@@ -1155,31 +1191,40 @@
 
 ## Next Safe Step
 
-**Current (2026-07-29, latest):** WP4.4 packets `a`, `c`, `b`, `e` and `d1` are
-merged — **5 of 11**. **WP4.4-f1 (`static/css/navbar.css`, pure deletion only)
-is the next action and is authorized**, in a fresh visual-seeded worktree off
-current `main`. The owner-directed remaining order is sequential:
+**Current (2026-07-29, latest):** WP4.4 packets `a`, `c`, `b`, `e`, `d1` and
+`f1` are merged — **6 of 11**, and the pure-deletion run is **finished**.
+**WP4.4-d2 is the next action**, in a fresh visual-seeded worktree off current
+`main`. `d2` and `f2` are re-weighting packets, not deletions, and each needs
+its own explicit owner go-ahead before any edit. The owner-directed remaining
+order is sequential:
 
 ```
-f1 → d2 → f2 → g → h → HARD STOP (N4 owner checkpoint before i)
+d2 → f2 → g → h → HARD STOP (N4 owner checkpoint before i)
 ```
 
-`a`, `c`, `b`, `e` and `d1` are DONE and must not be re-dispatched. One packet,
-one worktree, one writer, one PR at a time; reconcile these three status
+`a`, `c`, `b`, `e`, `d1` and `f1` are DONE and must not be re-dispatched. One
+packet, one worktree, one writer, one PR at a time; reconcile these three status
 documents at each merge boundary.
 
-**`f1` constraints — the riskiest pure-deletion packet:** generation
-consolidation and re-weighting belong to `f2`; **freeze `@layer` membership
-(N2)** and **never delete the last `@layer navbar` block (G11)** — `navbar.css`
-holds the arc's only navbar layer, spanning lines 6–883 at the WP4.4-a baseline;
-preserve the contract-pinned `--nav-gap` / `--nav-padding-y` /
-`--nav-padding-x`; treat layered `!important` declarations as **potentially live
-winners** (A6/G10 — for `!important`, layer order inverts, so an explicit layer
-outranks the implicit final unlayered layer regardless of specificity); exercise
-collapsed and expanded navigation, dropdowns, keyboard navigation, both themes
-and all required routes; reconcile the animated logo **only** against its
-known-red band (1,039 / 1,046 px on `workout-plan-desktop-dark`) — movement
-outside the band stops the packet.
+**Constraints that survive `f1` and bind `f2`:** generation consolidation and
+re-weighting belong to `f2`; **freeze `@layer` membership (N2)** and **never
+delete the last `@layer navbar` block (G11)** — `navbar.css` holds the arc's
+only navbar layer, spanning lines 6–883 at the WP4.4-a baseline; preserve the
+contract-pinned `--nav-gap` / `--nav-padding-y` / `--nav-padding-x`; treat
+layered `!important` declarations as **potentially live winners** (A6/G10 — for
+`!important`, layer order inverts, so an explicit layer outranks the implicit
+final unlayered layer regardless of specificity); exercise collapsed and
+expanded navigation, dropdowns, keyboard navigation, both themes and all
+required routes; reconcile the animated logo **only** against its known-red
+band, now measured as **875/882 ∪ 1,039/1,046 px** on
+`workout-plan-desktop-dark` — `f1` observed 875 (882 retry) and proved it
+packet-independent with a same-CSS pixel control. Movement outside the band
+stops the packet.
+
+> **Superseded 2026-07-29 (latest).** This block previously read *"`a`, `c`,
+> `b`, `e` and `d1` are merged — 5 of 11. WP4.4-f1 … is the next action"* and
+> gave the band as 1,039 / 1,046 only. `f1` merged in PR #199 (`1127486`) and
+> widened the recorded band downward.
 
 **Method now binding on every remaining packet, paid for by `e` and `d1`:**
 

--- a/docs/REFACTOR_PLAN.md
+++ b/docs/REFACTOR_PLAN.md
@@ -69,7 +69,7 @@ records the WP4.4 authorization granted at Gate 1:**
    there**; **WP4.4 (shared bundles / navbar / `theme-dark.css`) Plan v2 is
    Gate-1 approved (owner, 2026-07-27) and executes from
    [`docs/css_phase4_wp4_4/PLANNING.md`](css_phase4_wp4_4/PLANNING.md)** —
-   authorized order `a` ✔ → `c` ✔ → `b` ✔ → `e` ✔ → `d1` ✔ → `f1` → `d2` → `f2` →
+   authorized order `a` ✔ → `c` ✔ → `b` ✔ → `e` ✔ → `d1` ✔ → `f1` ✔ → `d2` → `f2` →
    `g` → `h`, run **sequentially** per owner direction of 2026-07-29, then a
    **hard stop before `i`** for the N4 owner checkpoint. WP4.3j-a merged
    through
@@ -1292,15 +1292,16 @@ carries the narrative. **Wait for explicit direction before the next packet.**
 > one packet / worktree / writer / PR at a time:**
 >
 > ```
-> a ✔ → c ✔ → b ✔ → e ✔ → d1 ✔ → f1 → d2 → f2 → g → h → HARD STOP
+> a ✔ → c ✔ → b ✔ → e ✔ → d1 ✔ → f1 ✔ → d2 → f2 → g → h → HARD STOP
 > ```
 >
 > **The arc stops after `h`** for the N4 owner checkpoint. Gate 1 authority does
 > **not** extend to `i`; `j` and `k` wait until `i` is approved, narrowed, or
-> abandoned. The serial order narrows Plan v2 §4 (which classifies `e`, `d1` and
-> `f1` as concurrency-eligible class (a)) rather than contradicting it; `f1` is
-> deliberately last among the pure-deletion packets because navbar layering,
-> global exposure and the animated-logo oracle make it the riskiest.
+> abandoned. The serial order narrowed Plan v2 §4 (which classifies `e`, `d1`
+> and `f1` as concurrency-eligible class (a)) rather than contradicting it. The
+> pure-deletion run is now **finished**: every class (a) packet has shipped, and
+> `f1` was deliberately last because navbar layering, global exposure and the
+> animated-logo oracle made it the riskiest.
 >
 > **WP4.4-a is COMPLETE** — PR #187, squash `46e340e`, read-only, no production
 > CSS changed.
@@ -1340,11 +1341,34 @@ carries the narrative. **Wait for explicit direction before the next packet.**
 > contexts; oracle validity gate passed first (live generation 160/160).
 > `!important` **51 → 51**, custom properties 17 → 17, `@layer` 0 → 0.
 >
-> The `c`-before-`b`/`d1`/`e`/`f1` prerequisite is **discharged**; `b`, `e` and
-> `d1` are **shipped**. **`f1` (`navbar.css`, pure deletion only) is next** and
-> is deliberately last among the pure-deletion packets — navbar layering, global
-> exposure and the animated-logo oracle make it the riskiest. `a`, `c`, `b`, `e`
-> and `d1` must not be re-dispatched.
+> **WP4.4-f1 is COMPLETE** — PR #199, squash `1127486`, merged 2026-07-29.
+> Pure deletion of **one rule from `navbar.css` (−6 lines, 0 insertions)**:
+> `body:not(:has(#navbar)) .navbar`, unreachable **by construction** —
+> `navbar.css` is linked only from `base.html:22`, which renders `#navbar`
+> unconditionally, so the guard is unsatisfiable in every document that loads
+> the file. Census agreed at 0/522 contexts. `!important` **93 → 93**, custom
+> properties 72 → 72, `@layer` blocks 1 → 1, layered rules 103 → 103.
+>
+> The plan projected −150 to −400 lines; `f1` delivered −6, and that is the
+> correct outcome — a projected line reduction is not an acceptance criterion.
+>
+> **The "three live generations" count this section asserted is now
+> established rather than assumed**, and is confirmed at exactly three: layered
+> scoped (103 rules), legacy `.navbar` fallback (2), unlayered override tail
+> (89), plus 5 `@keyframes` steps. **Generation B is not dead legacy** — its
+> `.navbar` rule is unlayered while `#navbar { position: sticky }` sits inside
+> `@layer navbar`, so the unlayered class selector wins and `position: fixed` is
+> what the browser computes. The file's own comments at `:885` and `:893` say
+> the opposite and must not be trusted.
+>
+> **Deferred to `f2`, uncertified:** 155 matched-but-never-winning `navbar.css`
+> declarations (the owner sweep's `!important`/layer arbitration was never
+> validated against a known-live *overridden* control), the six duplicate
+> `#navbar > .container-fluid` rules, and the near-duplicate `@media`
+> conditions.
+>
+> The `c`-before-`b`/`d1`/`e`/`f1` prerequisite is **discharged**. **`d2` is
+> next.** `a`, `c`, `b`, `e`, `d1` and `f1` must not be re-dispatched.
 >
 > **Method rule M6a is binding on every remaining packet** (Plan v2 §2b):
 > suppress transitions before applying, reading **and** removing a sentinel — a
@@ -1442,21 +1466,23 @@ decisions are silently outstanding; either resolve them or leave them explicitly
 > the detailed work-packet requirements above and wait for explicit owner
 > direction wherever the plan requires it.
 
-Snapshot: **2026-07-29 (latest)**. **Five of eleven WP4.4 packets are merged.**
+Snapshot: **2026-07-29 (latest)**. **Six of eleven WP4.4 packets are merged.**
 **WP4.4-a** (PR #187, squash `46e340e`) produced evidence and audit tooling, not
 a production CSS edit. **WP4.4-c** (PR #188, squash `1b13bfc`) was the arc's
 first production CSS deletion. **WP4.4-b** (PR #192, squash `3bec677`) deleted
 four dead `base.css` rule blocks. **WP4.4-e** (PR #195, squash `1346a35`)
 deleted 34 unreachable `layout.css` rule blocks, −218 lines. **WP4.4-d1**
 (PR #197, squash `59e5b10`) deleted a superseded scale/menu generation from
-`a11y.css`, −99 lines. **`a`, `c`, `b`, `e` and `d1` are DONE and must not be
-re-dispatched.**
+`a11y.css`, −99 lines. **WP4.4-f1** (PR #199, squash `1127486`) deleted the
+unreachable legacy fallback rule from `navbar.css`, −6 lines. **`a`, `c`, `b`,
+`e`, `d1` and `f1` are DONE and must not be re-dispatched.**
 
 The owner directed a **sequential** remaining order on 2026-07-29 — one packet,
 worktree, writer and PR at a time:
-`f1` → `d2` → `f2` → `g` → `h` → **hard stop for the N4 owner checkpoint
-before `i`**. **WP4.4-f1 (`navbar.css`, pure deletion only) is the next
-action**, and is deliberately last among the pure-deletion packets.
+`d2` → `f2` → `g` → `h` → **hard stop for the N4 owner checkpoint
+before `i`**. **WP4.4-d2 is the next action.** The pure-deletion run is
+finished; `d2` and `f2` are re-weighting packets and each needs its own explicit
+owner go-ahead before any edit.
 The continuous pyright burn-down is a standing track, not an active packet or
 branch.
 
@@ -1482,7 +1508,7 @@ branch.
 | WP4.4-b — `base.css` four dead rule blocks | **Done** | Merged via PR #192 (squash `3bec677`, 2026-07-29). Pure deletion, −44 lines: the `.skeleton` block beaten by `motion.css` at equal specificity, plus the three unreachable classes `.loading-spinner`, `.fade-enter`, `.fade-enter-active`. All 12 `:root` custom properties retained and contract-pinned under M9. Packet contracts 8 passed; full pytest 2,204 / 1 skipped; five required specs 68 passed; visual 65 passed / 1 ledgered known red; Stylelint −2, no rule increased. | — |
 | WP4.4-e — `layout.css` unreachable rule blocks | **Done** | Merged via PR #195 (squash `1346a35`, 2026-07-29). Pure deletion of **34 rule blocks, −218 lines, 0 insertions**: the `.tbl-col-chooser*` widget (10), `.form-container` (9), `.input-frame .row` (6), `.el-clip`/`.col--*` (3), `.tbl--loading` + `::after` + orphaned `@keyframes tbl-spin` (3), `.sr-only`, standalone `.tbl-toolbar`, `body.dark-mode`. Census 0 on the full selector across 11 routes × 2 themes × 16 widths; 0 declaration-owner differences / 64,961 records; contracts 13 passed with 13/13 red-path proven; pytest 2,230 / 1 skipped; seven required specs 89 passed; visual 65 / 1 ledgered red; Stylelint 2,875 → 2,857 (−18); `!important` 24 → 24; `@layer` 0 → 0. | — |
 | WP4.4-d1 — `a11y.css` superseded scale/menu generation | **Done** | Merged via PR #197 (squash `59e5b10`, 2026-07-29). Pure deletion of **14 rule blocks, −99 lines, 0 insertions**: `.scale-control`, `.scale-control-label`, `.scale-btn-group`, `.scale-labels`, `.scale-label`, `.accessibility-menu`, `.accessibility-section*` and their `@media` overrides. The live compact generation (`.scale-control-compact`, `.scale-btn-compact`, `.scale-indicator`) is retained and contract-pinned. Full-selector census **0 for all 14 across 164 contexts** (2 themes × 10 widths × 8 `data-scale` levels + print + reduced-motion); **oracle validity gate passed first** (live generation census > 0 in 160/160). Residual `.scale-control` matches attributed by CDP to the **retained** `@media print` rule at source lines 329–331; **0** rules on `screen`. Contracts 16 passed with **15/15 red-path proven**; pytest 2,245/1 skipped; nine specs 127 passed; visual 65/1 ledgered red; Stylelint 2,857 → 2,851 (−6). `!important` **51 → 51**, custom properties 17 → 17, `@layer` 0 → 0. | — |
-| WP4.4 — shared bundles, navbar, and `theme-dark.css` (packets `f`–`h`) | **Ongoing — `f1` is next and authorized** | Plan v2 is **Gate-1 approved** (owner, 2026-07-27, rulings N1–N10) in `docs/css_phase4_wp4_4/PLANNING.md`. `a`, `c`, `b`, `e` and `d1` have landed (5 of 11). The owner directed a **sequential** order on 2026-07-29: `f1` → `d2` → `f2` → `g` → `h`, one packet/worktree/writer/PR at a time. The serial order narrows Plan v2 §4's concurrent class (a) authorization rather than contradicting it; **`f1` is last among the pure-deletion packets as the riskiest** — navbar layering, global exposure and the animated-logo oracle. | Not gated through `h`. The gates still bind: Regions A–C of Workout Log must be re-measured before any shared-selector repair; each packet carries the full visual, dark-mode, navigation, accessibility and summary-page gates; **M6a is binding**; the ten inherited Linux `desktop` reds plus the eight uncertifiable Welcome elements are ledgered and must not be re-attributed or rebaselined. **`f1` specifically:** freeze `@layer` membership (N2), **never delete the last `@layer navbar` block (G11)**, preserve contract-pinned `--nav-gap` / `--nav-padding-*`, treat layered `!important` as a potentially live winner (A6/G10 — layer order inverts for `!important`), and reconcile the animated logo only against its known-red **band**. **Method from `e` + `d1`: a rest-state differential cannot falsify an unreachable rule — pair it with a full-selector runtime census taken before injection, a synthetic control failing the selector by exactly one compound with properties derived from the rule's own declarations, a known-live control validating the oracle first, and source-identity attribution (CDP declaration owner) rather than "the rule went blind". Avoid substring assertions where duplicate selector text can mask a deletion — that defect class recurred in both `e` and `d1`.** |
+| WP4.4 — shared bundles, navbar, and `theme-dark.css` (packets `f`–`h`) | **Ongoing — `d2` is next; the pure-deletion run is finished** | Plan v2 is **Gate-1 approved** (owner, 2026-07-27, rulings N1–N10) in `docs/css_phase4_wp4_4/PLANNING.md`. `a`, `c`, `b`, `e`, `d1` and `f1` have landed (6 of 11). The owner directed a **sequential** order on 2026-07-29: `d2` → `f2` → `g` → `h`, one packet/worktree/writer/PR at a time. The serial order narrowed Plan v2 §4's concurrent class (a) authorization rather than contradicting it; `f1` was last among the pure-deletion packets as the riskiest — navbar layering, global exposure and the animated-logo oracle. **`d2` and `f2` are re-weighting packets, not deletions, and each needs its own explicit owner go-ahead.** | Not gated through `h`. The gates still bind: Regions A–C of Workout Log must be re-measured before any shared-selector repair; each packet carries the full visual, dark-mode, navigation, accessibility and summary-page gates; **M6a is binding**; the ten inherited Linux `desktop` reds plus the eight uncertifiable Welcome elements are ledgered and must not be re-attributed or rebaselined. **`f2` specifically:** freeze `@layer` membership (N2), **never delete the last `@layer navbar` block (G11)**, preserve contract-pinned `--nav-gap` / `--nav-padding-*`, treat layered `!important` as a potentially live winner (A6/G10 — layer order inverts for `!important`), and reconcile the animated logo only against its known-red **band**, measured by `f1` as **875/882 ∪ 1,039/1,046 px** and proved packet-independent by a same-CSS pixel control. **Method from `e` + `d1`: a rest-state differential cannot falsify an unreachable rule — pair it with a full-selector runtime census taken before injection, a synthetic control failing the selector by exactly one compound with properties derived from the rule's own declarations, a known-live control validating the oracle first, and source-identity attribution (CDP declaration owner) rather than "the rule went blind". Avoid substring assertions where duplicate selector text can mask a deletion — that defect class recurred in both `e` and `d1`. From `f1`: a selector relaxation that is not provably a superset manufactures deadness — 38 of its first 39 candidates were instrumentation artifacts, each caught by a control rather than by reading the verdicts.** |
 | `a11y.css` bare `.scale-btn` rules | **Recorded by `d1` / not audited / gated** | 11 exact-token occurrences. Runtime census is **0** — `accessibility.js:144` and `:202` query an empty set, a second dormant JS path beside the accessibility dropdown. `d1`'s static pass wrongly treated that JS *query* as proof of reachability, so these rules were **never audited as candidates** and are retained untouched. | Deleting them requires its own census, its own oracle-validity control and its own packet. A JavaScript query is not evidence of reachability. |
 | `layout.css` `.tbl-show-*` / `.tbl-hide-*` breakpoint helpers | **Deferred by WP4.4-e / gated** | Nine rules. Census 0 and six of nine are visible to the synthetic oracle, but three declare `display: block` — a bare div's initial value — so no control element can distinguish them and their post-deletion flip cannot be demonstrated. Pinned by exact occurrence count in `tests/test_css_wp4_4_layout_contracts.py`. | Splitting the family would leave `@media` overrides targeting classes with no base rule. It must be deleted as a **unit** under fresh evidence, never eroded rule by rule. |
 | WP4.4-i — shared `:is()` selector repair | **Gated — hard stop after `h`** | Nothing started. Ruling N4 requires a separate owner checkpoint immediately before `i`; ruling N9 restricts admissible repair shapes to CSS-local ones in `static/css/components.css`. | Gate 1 authority explicitly does **not** extend to `i`. Before any edit, `i`'s enumerated repair shape and both pre-change inventories (the complete `:is()` family from `g`/`h`, and the G3 regions A–C measurement) must be presented and approved. |


### PR DESCRIPTION
Status-only reconciliation at the **WP4.4-f1** merge boundary (PR #199, squash `1127486`). No production, test or config file is touched.

## What changed

**Six of eleven** WP4.4 packets are merged and the **pure-deletion run is finished**. `d2` is next; `d2` and `f2` are re-weighting packets and each needs its own explicit owner go-ahead before any edit.

## Findings recorded so no later packet re-derives or contradicts them

- **The "three live generations" count is established, not assumed** — confirmed at exactly three: layered scoped (103 rules), legacy `.navbar` fallback (2), unlayered override tail (89), plus 5 `@keyframes` steps.
- **Generation B is NOT dead legacy.** `navbar.css:885` and `:893` describe the `.navbar` rule as an overridden fallback that "only applies outside #navbar". It is the live winner for `position`: unlayered, while `#navbar { position: sticky }` sits inside `@layer navbar`, so the class selector beats the ID selector. A packet trusting those comments would unpin the navbar.
- **The animated-logo known-red band is `875/882 ∪ 1,039/1,046`.** All three documents previously carried only the `1,039/1,046` half — which would have read as a stop condition for any packet measuring the current value. `f1` measured 875 (882 retry), matching `b` and `c`, and proved it packet-independent with a same-CSS pixel control on byte-identical CSS.
- **A selector relaxation that is not provably a superset manufactures deadness** — 38 of `f1`'s first 39 candidates were instrumentation artifacts, each caught by a control rather than by reading the verdicts.
- **A projected line reduction is not an acceptance criterion** — `f1` shipped −6 lines against a −150 to −400 projection and is complete.

## Deferred to `f2`, marked do-not-act

155 matched-but-never-winning `navbar.css` declarations remain **uncertified** (the owner sweep's `!important`/layer arbitration was never validated against a known-live *overridden* control), plus the six duplicate `#navbar > .container-fluid` rules and the near-duplicate `@media` conditions.

Superseded blocks are retained and marked rather than deleted, per the re-dispatch drift class recorded at WP3.5 and WP4.3g.

🤖 Generated with [Claude Code](https://claude.com/claude-code)